### PR TITLE
Add instance_type option

### DIFF
--- a/app/controllers/districts_controller.rb
+++ b/app/controllers/districts_controller.rb
@@ -22,7 +22,8 @@ class DistrictsController < ApplicationController
 
   def launch_instances
     count = params.require(:count)
-    @district.launch_instances(count: count)
+    instance_type = params[:instance_type] || 't2.micro'
+    @district.launch_instances(count: count, instance_type: instance_type)
     render status: 204, nothing: true
   end
 

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -28,7 +28,7 @@ class District < ActiveRecord::Base
     ).subnets
   end
 
-  def launch_instances(count: 1)
+  def launch_instances(count: 1, instance_type:)
     ec2.run_instances(
       image_id: 'ami-6e920b6e', # amzn-ami-2015.09.a-amazon-ecs-optimized
       min_count: count,
@@ -36,7 +36,7 @@ class District < ActiveRecord::Base
       key_name: 'kkajihiro',
       security_group_ids: [instance_security_group].compact,
       user_data: instance_user_data,
-      instance_type: 't2.micro',
+      instance_type: instance_type,
       subnet_id: subnets("Private").sample.subnet_id,
       iam_instance_profile: {
         name: ecs_instance_role

--- a/spec/models/district_spec.rb
+++ b/spec/models/district_spec.rb
@@ -28,7 +28,7 @@ describe District, :vcr do
   end
 
   describe "#launch_instances" do
-    subject { district.launch_instances(count: 1) }
+    subject { district.launch_instances(count: 1, instance_type: 't2.micro') }
 
     it "launches EC2 instance" do
       is_expected.to_not be_nil

--- a/spec/requests/launch_instances_spec.rb
+++ b/spec/requests/launch_instances_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe "POST /districts/:district/launch_instances", :vcr, type: :request do
+  let(:user) { create :user }
+  let(:auth) { {"X-Barcelona-Token" => user.token} }
+  let(:district) { create :district }
+
+  before do
+    allow_any_instance_of(District).to receive(:subnets) {
+      [double(subnet_id: 'subnet_id')]
+    }
+  end
+
+  it "launches a instance" do
+    params = {
+      count: 1,
+      instance_type: 't2.micro'
+    }
+    post "/districts/#{district.name}/launch_instances", params, auth
+    expect(response.status).to eq 204
+  end
+end


### PR DESCRIPTION
Now you can specify instance_type when you launch a new container instance
