### PR TITLE
Convert env value to string class

### DIFF
--- a/app/models/env_var.rb
+++ b/app/models/env_var.rb
@@ -6,4 +6,9 @@ class EnvVar < ActiveRecord::Base
   validates :key, uniqueness: {scope: :heritage_id}
 
   encrypted_attribute :value, secret_key: ENV['ENCRYPTION_KEY']
+
+  def value_with_to_s
+    value_without_to_s.to_s
+  end
+  alias_method_chain :value, :to_s
 end

--- a/spec/models/env_var_spec.rb
+++ b/spec/models/env_var_spec.rb
@@ -10,5 +10,6 @@ describe EnvVar do
   it "decrypts encrypted value" do
     expect(EnvVar.find(env_var.id).key).to eq "KEY"
     expect(EnvVar.find(env_var.id).value).to eq "VALUE"
+    expect(EnvVar.find(env_var.id).value).to be_a String
   end
 end


### PR DESCRIPTION
Gibberish returns non-string but string-like object. it violates AWS SDK param validation
