### PR TITLE
Don't set before_deploy when creating a heritage

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -12,13 +12,13 @@ class HeritagesController < ApplicationController
 
   def create
     @heritage = BuildHeritage.new(permitted_params, district: @district).execute
-    @heritage.save!
+    @heritage.save_and_deploy!(without_before_deploy: true)
     render json: @heritage
   end
 
   def update
     @heritage = BuildHeritage.new(permitted_params).execute
-    @heritage.save!
+    @heritage.save_and_deploy!(without_before_deploy: false)
     render json: @heritage
   end
 
@@ -34,7 +34,7 @@ class HeritagesController < ApplicationController
       env.value = v
       env.save!
     end
-    @heritage.save!
+    @heritage.save_and_deploy!(without_before_deploy: true)
 
     render json: @heritage
   end
@@ -44,7 +44,7 @@ class HeritagesController < ApplicationController
     env_keys.each do |k|
       @heritage.env_vars.find_by(key: k).destroy!
     end
-    @heritage.save!
+    @heritage.save_and_deploy!(without_before_deploy: true)
 
     render json: @heritage
   end

--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -1,10 +1,10 @@
 class DeployRunnerJob < ActiveJob::Base
   queue_as :default
 
-  def perform(heritage)
+  def perform(heritage, without_before_deploy:)
     heritage.events.create(level: :good, message: "Deploying #{heritage.name}(#{heritage.image_path}) to #{heritage.district.name} district...")
     before_deploy = heritage.before_deploy
-    if before_deploy.present?
+    if before_deploy.present? && !without_before_deploy
       oneoff = heritage.oneoffs.create!(command: before_deploy)
       oneoff.run!(sync: true)
       if oneoff.exit_code != 0

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -11,8 +11,6 @@ class Heritage < ActiveRecord::Base
   accepts_nested_attributes_for :services
   accepts_nested_attributes_for :env_vars
 
-  after_save :update_services
-
   def to_param
     name
   end
@@ -30,8 +28,15 @@ class Heritage < ActiveRecord::Base
     "#{image_name}:#{tag}"
   end
 
-  def update_services
+  def save_and_deploy!(without_before_deploy: false)
+    save!
+    update_services(without_before_deploy)
+  end
+
+  private
+
+  def update_services(without_before_deploy)
     return if image_path.nil?
-    DeployRunnerJob.perform_later self
+    DeployRunnerJob.perform_later self, without_before_deploy: without_before_deploy
   end
 end

--- a/spec/models/heritage_spec.rb
+++ b/spec/models/heritage_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 describe Heritage do
   let(:heritage) { build :heritage }
 
-  describe "create" do
+  describe "#save_and_deploy!" do
     it "enqueues deploy job" do
-      expect(DeployRunnerJob).to receive(:perform_later).with(heritage)
-      heritage.save!
+      expect(DeployRunnerJob).to receive(:perform_later).with(heritage, without_before_deploy: false)
+      heritage.save_and_deploy!
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.before :each do |example|
+  config.before :all do |example|
     Aws.config[:stub_responses] = true
   end
 end

--- a/spec/requests/create_oneoff_spec.rb
+++ b/spec/requests/create_oneoff_spec.rb
@@ -16,7 +16,6 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
       command: "rake db:migrate",
       image_tag: "v100"
     }
-    expect(DeployRunnerJob).to receive(:perform_later)
     post "/heritages/#{heritage.name}/oneoffs", params, auth
     expect(response).to be_success
     oneoff = JSON.load(response.body)["oneoff"]


### PR DESCRIPTION
When creating a heritage, usually a heritage doesn't have appropriate environment variables so if `before_deploy` runs without the env vars it will fail. The most common use case of `before_deploy` is I think `rake db:migrate` and migrations cannot run without DB env vars.
