### PR TITLE
Change logger port to 20514

### DIFF
--- a/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
@@ -25,7 +25,7 @@ module Barcelona
         service = heritage.services.first
         expect(service.name).to eq "main"
         port_mapping = service.port_mappings.first
-        expect(port_mapping.lb_port).to eq 514
+        expect(port_mapping.lb_port).to eq described_class::LOGGER_PORT
         expect(port_mapping.container_port).to eq 514
       end
 


### PR DESCRIPTION
The current subnets' network ACL only allows HTTP, HTTPS and 1024-65535 so the default rsyslog port 514 can't transit over subnets. This PR changes the logger port to 20514. Note that 10000-19999 are reserved by Barcelona and plugins should not use them.
