### PR TITLE
Add NTP plugin

### DIFF
--- a/lib/barcelona/plugins/ntp_plugin.rb
+++ b/lib/barcelona/plugins/ntp_plugin.rb
@@ -1,0 +1,22 @@
+module Barcelona
+  module Plugins
+    class NtpPlugin < Base
+      def on_container_instance_user_data(instance, user_data)
+        return user_data if instance.section.public?
+
+        user_data.boot_commands += [
+          "sed '/^server /s/^/#/' /etc/ntp.conf",
+          hosts.map { |h| "echo server #{h} iburst >> /etc/ntp.conf" },
+          "service ntpd restart"
+        ].flatten
+        user_data
+      end
+
+      private
+
+      def hosts
+        attributes["ntp_hosts"] || []
+      end
+    end
+  end
+end

--- a/spec/lib/barcelona/plugins/ntp_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/ntp_plugin_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+module Barcelona
+  module Plugins
+    describe NtpPlugin do
+      let!(:district) do
+        create :district, plugins_attributes: [
+                 {
+                   name: 'ntp',
+                   plugin_attributes: {ntp_hosts: ["10.0.0.1"]}
+                 }
+               ]
+      end
+
+      it "gets hooked with container_instance_user_data trigger" do
+        section = district.sections[:private]
+        ci = ContainerInstance.new(section, instance_type: 't2.micro')
+        user_data = YAML.load(Base64.decode64(ci.instance_user_data))
+        expect(user_data['bootcmd']).to include "sed '/^server /s/^/#/' /etc/ntp.conf"
+        expect(user_data['bootcmd']).to include "echo server 10.0.0.1 iburst >> /etc/ntp.conf"
+        expect(user_data['bootcmd']).to include "service ntpd restart"
+      end
+
+      it "doesn't apply public instances" do
+        section = district.sections[:public]
+        ci = ContainerInstance.new(section, instance_type: 't2.micro')
+        user_data = YAML.load(Base64.decode64(ci.instance_user_data))
+        expect(user_data['bootcmd']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
There must be better a way to do this but I don't want to dive into deep NTP world...

This plugin enables to modify container instance's `/etc/ntp.conf` so that ntpd communicates with NTP host that is specified in the plugin attribute.

```
bcn request post /districts/staging/plugins '{"name": "ntp", "attributes": {"ntp_hosts": ["10.100.0.111"]}}'
```

an NTP host here is out of Barcelona's scope so we need to launch an EC2 instance for NTP server as a part of CloudFormation
