### PR TITLE
Fix port environment variable type mismatch

### DIFF
--- a/app/models/backend/ecs/service.rb
+++ b/app/models/backend/ecs/service.rb
@@ -52,7 +52,7 @@ module Backend::Ecs
       base[:environment] += service.port_mappings.map do |pm|
         {
           name: "HOST_PORT_#{pm.protocol.upcase}_#{pm.container_port}",
-          value: pm.host_port
+          value: pm.host_port.to_s
         }
       end
 

--- a/spec/models/backend/ecs/adapter_spec.rb
+++ b/spec/models/backend/ecs/adapter_spec.rb
@@ -88,7 +88,7 @@ describe Backend::Ecs::Adapter do
                                      essential: true,
                                      image: 'nginx:1.9.5',
                                      environment: [
-                                       {name: "HOST_PORT_TCP_3000", value: Integer},
+                                       {name: "HOST_PORT_TCP_3000", value: String},
                                      ],
                                      port_mappings: [
                                        {container_port: 3000, protocol: "tcp", host_port: Integer}


### PR DESCRIPTION
The tests didn't catch this bug. I'll update tests to detect invalid AWS request parameters
