### PR TITLE
save district after a plugin is saved

### DIFF
--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -7,6 +7,7 @@ class Plugin < ActiveRecord::Base
   before_validation :name, uniqueness: {scope: :district_id}
   after_create :hook_created
   after_update :hook_updated
+  after_save :save_district
   after_destroy :hook_destroyed
 
   def hook(trigger, origin, arg=nil)
@@ -43,5 +44,10 @@ class Plugin < ActiveRecord::Base
 
   def hook_destroyed
     hook(:destroyed, self)
+  end
+
+  def save_district
+    # trigger district callbacks so that AWS resources are properly updated
+    district.save!
   end
 end


### PR DESCRIPTION
Some plugins(namely proxy plugin) modify AWS resources so district callbacks should be triggered when a plugin is created or updated
