### PR TITLE
Change connection draining timeout to 60 secs

### DIFF
--- a/app/models/backend/ecs/elb.rb
+++ b/app/models/backend/ecs/elb.rb
@@ -58,7 +58,7 @@ module Backend::Ecs
           },
           connection_draining: {
             enabled: true,
-            timeout: 300
+            timeout: 60
           }
         }
       )

--- a/spec/models/backend/ecs/adapter_spec.rb
+++ b/spec/models/backend/ecs/adapter_spec.rb
@@ -145,7 +145,7 @@ describe Backend::Ecs::Adapter do
                                    },
                                    connection_draining: {
                                      enabled: true,
-                                     timeout: 300
+                                     timeout: 60
                                    }
                                  }
                                )


### PR DESCRIPTION
Some types of container establish long-time connection for example rsyslog containers try keeping TCP connection so deploying new version of such kind of docker image waits for connection draining until its timed out. 300 seconds is too long to wait. life is too short, let's kill them after 60 seconds
