### PR TITLE
Add `force_ssl` option

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -76,6 +76,7 @@ class HeritagesController < ApplicationController
         :reverse_proxy_image,
         :public,
         :service_type,
+        :force_ssl,
         {
           port_mappings: [
             :lb_port,

--- a/app/models/backend/ecs/service.rb
+++ b/app/models/backend/ecs/service.rb
@@ -76,6 +76,7 @@ module Backend::Ecs
         {name: "AWS_REGION", value: 'ap-northeast-1'},
         {name: "UPSTREAM_NAME", value: "backend"},
         {name: "UPSTREAM_PORT", value: service.web_container_port.to_s},
+        {name: "FORCE_SSL", value: (!!service.force_ssl).to_s},
         service.hosts.map do |h|
           host_key = h['hostname'].gsub('.', '_').gsub('-', '__').upcase
           [

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,7 +1,7 @@
 class ServiceSerializer < ActiveModel::Serializer
   attributes :name, :public, :command, :cpu, :memory, :endpoint, :status,
              :port_mappings, :running_count, :pending_count, :desired_count,
-             :reverse_proxy_image, :hosts, :service_type
+             :reverse_proxy_image, :hosts, :service_type, :force_ssl
 
   belongs_to :heritage
 

--- a/db/migrate/20151203060634_add_force_ssl_to_services.rb
+++ b/db/migrate/20151203060634_add_force_ssl_to_services.rb
@@ -1,0 +1,5 @@
+class AddForceSslToServices < ActiveRecord::Migration
+  def change
+    add_column :services, :force_ssl, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151203024641) do
+ActiveRecord::Schema.define(version: 20151203060634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 20151203024641) do
     t.string   "reverse_proxy_image"
     t.text     "hosts"
     t.string   "service_type",        default: "default"
+    t.boolean  "force_ssl"
   end
 
   add_index "services", ["heritage_id"], name: "index_services_on_heritage_id", using: :btree

--- a/spec/models/backend/ecs/adapter_spec.rb
+++ b/spec/models/backend/ecs/adapter_spec.rb
@@ -113,7 +113,9 @@ describe Backend::Ecs::Adapter do
                 environment: [
                   {name: "AWS_REGION", value: "ap-northeast-1"},
                   {name: "UPSTREAM_NAME", value: "backend"},
-                  {name: "UPSTREAM_PORT", value: "3000"}
+                  {name: "UPSTREAM_PORT", value: "3000"},
+                  {name: "FORCE_SSL", value: "false"},
+
                 ],
                 port_mappings: [
                   {

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -16,6 +16,7 @@ describe "POST /districts/:district/heritages", type: :request do
           name: "web",
           service_type: "web",
           public: true,
+          force_ssl: true,
           cpu: 128,
           memory: 256,
           reverse_proxy_image: 'org/custom_revpro:v1.2',
@@ -44,6 +45,7 @@ describe "POST /districts/:district/heritages", type: :request do
     expect(heritage["services"][0]["public"]).to eq true
     expect(heritage["services"][0]["cpu"]).to eq 128
     expect(heritage["services"][0]["memory"]).to eq 256
+    expect(heritage["services"][0]["force_ssl"]).to eq true
     expect(heritage["services"][0]["reverse_proxy_image"]).to eq "org/custom_revpro:v1.2"
     expect(heritage["services"][0]["port_mappings"][0]["lb_port"]).to eq 3333
     expect(heritage["services"][0]["port_mappings"][0]["container_port"]).to eq 3333


### PR DESCRIPTION
If `force_ssl` is `true`, a web service redirects http access to https.
this option is ignored if `service_type` is not `web`

```
# ...
    services:
      - name: awesome-app
        service_type: web
        force_ssl: true
        hosts:
          - hostname: www.yourdomain.com
          - ssl_cert_path: s3://your-bucket/path/to/cert
          - ssl_key_path: s3://your-bucket/path/to/key
```
