### PR TITLE
Remain port mapping pair with same port and different protocol

### DIFF
--- a/app/models/port_mapping.rb
+++ b/app/models/port_mapping.rb
@@ -30,7 +30,7 @@ class PortMapping < ActiveRecord::Base
         host_port: pm.special_protocol? ? nil : pm.host_port,
         protocol: pm.host_protocol
       }.compact
-    end.uniq { |pm| pm[:container_port] }
+    end.uniq { |pm| "#{pm[:container_port]}/#{pm[:protocol]}" }
   end
 
   def self.http


### PR DESCRIPTION
@k2nr 

I found my task definition in ECS lacks port mapping for a udp port which exists in [barcelona.yml](https://github.com/degica/bluegreen-consul/blob/master/barcelona.yml#L21).

I didn't test this patch but I think port mapping will be lost if some mapping have same port and different protocol. Something like this update is needed.
