### PR TITLE
Reserve memory

### DIFF
--- a/app/models/district_section.rb
+++ b/app/models/district_section.rb
@@ -124,7 +124,8 @@ class DistrictSection
       "ECS_CLUSTER" => cluster_name,
       "ECS_ENGINE_AUTH_TYPE" => "dockercfg",
       "ECS_ENGINE_AUTH_DATA" => dockercfg.to_json,
-      "ECS_AVAILABLE_LOGGING_DRIVERS" => '["json-file", "syslog", "fluentd"]'
+      "ECS_AVAILABLE_LOGGING_DRIVERS" => '["json-file", "syslog", "fluentd"]',
+      "ECS_RESERVED_MEMORY" => 128
     }
     config = district.hook_plugins(:ecs_config, self, config)
     config.map {|k, v| "#{k}=#{v}"}.join("\n")


### PR DESCRIPTION
The default reserved memory is 0MB. In our use case a container instance runs not only ECS managed containers but also newrelic-agent(in the future), datadog-agent(experimental), and interactive container that is launched by `bcn run`. so we need to ensure that all instances keep some additional free memory space. I'm not sure 128MB is enough or too much amount but I'd like to see use cases with this value
