### PR TITLE
check if proxy_heritage exists on destroy

### DIFF
--- a/lib/barcelona/plugins/proxy_plugin.rb
+++ b/lib/barcelona/plugins/proxy_plugin.rb
@@ -80,7 +80,7 @@ EOS
 
       def on_destroyed(_, _)
         heritage = district.heritages.find_by(name: proxy_heritage_name)
-        heritage.destroy!
+        heritage.destroy! if heritage
       end
 
       def proxy_url


### PR DESCRIPTION
When I tried to destroy a District, this heritage was nil and I could not delete it.

I'm not sure what's the condition of this situation but I confirmed `proxy_heritage` exists before deletion. It was deleted before this hook was called.

Following log has a record of the sequence.

```
09:55:49 web.1    | Started DELETE "/v1/districts/test" for 127.0.0.1 at 2015-12-10 09:55:49 +0900
09:55:49 web.1    | Processing by DistrictsController#destroy as JSON
09:55:49 web.1    |   Parameters: {"id"=>"test", "district"=>{}}
09:55:49 web.1    | Can't verify CSRF token authenticity
09:55:49 web.1    |   User Load (0.7ms)  SELECT  "users".* FROM "users" WHERE "users"."token_hash" = $1 LIMIT 1  [["token_hash", "d6c30ca227ce988abedf58a9ecadd9da23ae3f7e436d40d49d6
7b72024d6ad42"]]
09:55:49 web.1    |   District Load (0.3ms)  SELECT  "districts".* FROM "districts" WHERE "districts"."name" = $1 LIMIT 1  [["name", "test"]]
09:55:49 web.1    |    (0.2ms)  BEGIN
09:55:49 web.1    |   Heritage Load (0.5ms)  SELECT "heritages".* FROM "heritages" WHERE "heritages"."district_id" = $1  [["district_id", 1]]
09:55:49 web.1    |   Service Load (0.5ms)  SELECT "services".* FROM "services" WHERE "services"."heritage_id" = $1  [["heritage_id", 3]]
09:55:49 web.1    |   PortMapping Load (0.4ms)  SELECT "port_mappings".* FROM "port_mappings" WHERE "port_mappings"."service_id" = $1  [["service_id", 3]]
09:55:49 web.1    |   SQL (0.4ms)  DELETE FROM "port_mappings" WHERE "port_mappings"."id" = $1  [["id", 3]]
09:55:49 web.1    |   SQL (0.5ms)  DELETE FROM "services" WHERE "services"."id" = $1  [["id", 3]]
09:56:00 web.1    |   EnvVar Load (0.5ms)  SELECT "env_vars".* FROM "env_vars" WHERE "env_vars"."heritage_id" = $1  [["heritage_id", 3]]
09:56:00 web.1    |   Oneoff Load (0.3ms)  SELECT "oneoffs".* FROM "oneoffs" WHERE "oneoffs"."heritage_id" = $1  [["heritage_id", 3]]
09:56:00 web.1    |   Event Load (0.4ms)  SELECT "events".* FROM "events" WHERE "events"."heritage_id" = $1  [["heritage_id", 3]]
09:56:00 web.1    |   SQL (0.2ms)  DELETE FROM "events" WHERE "events"."id" = $1  [["id", 6]]
09:56:00 web.1    |   SQL (0.3ms)  DELETE FROM "events" WHERE "events"."id" = $1  [["id", 7]]
09:56:00 web.1    |   SQL (0.9ms)  DELETE FROM "heritages" WHERE "heritages"."id" = $1  [["id", 3]]
09:56:00 web.1    |   Service Load (0.2ms)  SELECT "services".* FROM "services" WHERE "services"."heritage_id" = $1  [["heritage_id", 2]]
09:56:00 web.1    |   PortMapping Load (0.2ms)  SELECT "port_mappings".* FROM "port_mappings" WHERE "port_mappings"."service_id" = $1  [["service_id", 2]]
09:56:00 web.1    |   SQL (0.1ms)  DELETE FROM "port_mappings" WHERE "port_mappings"."id" = $1  [["id", 2]]
09:56:00 web.1    |   SQL (0.3ms)  DELETE FROM "services" WHERE "services"."id" = $1  [["id", 2]]
09:56:04 web.1    |   EnvVar Load (0.3ms)  SELECT "env_vars".* FROM "env_vars" WHERE "env_vars"."heritage_id" = $1  [["heritage_id", 2]]
09:56:04 web.1    |   Oneoff Load (0.3ms)  SELECT "oneoffs".* FROM "oneoffs" WHERE "oneoffs"."heritage_id" = $1  [["heritage_id", 2]]
09:56:04 web.1    |   Event Load (0.2ms)  SELECT "events".* FROM "events" WHERE "events"."heritage_id" = $1  [["heritage_id", 2]]
09:56:04 web.1    |   SQL (0.2ms)  DELETE FROM "events" WHERE "events"."id" = $1  [["id", 4]]
09:56:04 web.1    |   SQL (0.1ms)  DELETE FROM "events" WHERE "events"."id" = $1  [["id", 5]]
09:56:04 web.1    |   SQL (0.6ms)  DELETE FROM "heritages" WHERE "heritages"."id" = $1  [["id", 2]]
09:56:04 web.1    |   UsersDistrict Load (0.2ms)  SELECT "users_districts".* FROM "users_districts" WHERE "users_districts"."district_id" = $1  [["district_id", 1]]
09:56:04 web.1    |   ElasticIp Load (1.3ms)  SELECT "elastic_ips".* FROM "elastic_ips" WHERE "elastic_ips"."district_id" = $1  [["district_id", 1]]
09:56:04 web.1    |   Plugin Load (0.2ms)  SELECT "plugins".* FROM "plugins" WHERE "plugins"."district_id" = $1  [["district_id", 1]]
09:56:04 web.1    |   SQL (0.2ms)  DELETE FROM "plugins" WHERE "plugins"."id" = $1  [["id", 1]]
09:56:04 web.1    |   District Load (0.2ms)  SELECT  "districts".* FROM "districts" WHERE "districts"."id" = $1 LIMIT 1  [["id", 1]]
09:56:04 web.1    |   Heritage Load (0.2ms)  SELECT  "heritages".* FROM "heritages" WHERE "heritages"."district_id" = $1 AND "heritages"."name" = $2 LIMIT 1  [["district_id", 1], ["
name", "test-proxy"]]
09:56:04 web.1    |    (0.2ms)  ROLLBACK
```

And after I comment out the line, it succeeded.
