### PR TITLE
Log when deploy job fails

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -17,7 +17,16 @@ class DeployRunnerJob < ActiveJob::Base
 
     heritage.services.each do |service|
       Rails.logger.info "Updating service #{service.service_name} ..."
-      service.apply
+      begin
+        service.apply
+      rescue => e
+        Rails.logger.error "#{e.class}: #{e.message}"
+        Rails.logger.error caller.join("\n")
+        heritage.events.create(
+          level: :error,
+          message: "Deploy failed: Something went wrong with deploying #{service.service_name}"
+        )
+      end
     end
 
     heritage.services.each do |service|

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -6,7 +6,7 @@ class MonitorDeploymentJob < ActiveJob::Base
       service.heritage.events.create!(level: :good, message: "#{service.service_name}(#{service.heritage.image_path}) deployed")
     elsif count > 200
       # deploys not finished after 1000 seconds are marked as timeout
-      service.heritage.events.create!(level: :error, message: "Deploying #{service.service_name}(#{service.heritage.image_path}) timed out")
+      service.heritage.events.create!(level: :error, message: "Deploying #{service.service_name}(#{service.heritage.image_path}) has not finished for a while.")
     else
       MonitorDeploymentJob.set(wait: 5.seconds).perform_later(service, count: count + 1)
     end


### PR DESCRIPTION
A rescued exception is not re-raised so this also fixes https://github.com/degica/barcelona/issues/80
