### PR TITLE
Speed up specs

### DIFF
--- a/spec/factories/districts.rb
+++ b/spec/factories/districts.rb
@@ -11,7 +11,5 @@ FactoryGirl.define do
     ecs_instance_role 'ecsInstanceRole'
     private_hosted_zone_id 'Z2MY4ND3Z2EPA2'
     s3_bucket_name 'degica3-barcelona'
-    aws_access_key_id "AWSACCESSKEYID"
-    aws_secret_access_key "SECRETKEY"
   end
 end

--- a/spec/models/district_spec.rb
+++ b/spec/models/district_spec.rb
@@ -12,6 +12,25 @@ describe District do
     allow(district).to receive_message_chain(:aws, :s3)  { s3_mock }
   end
 
+  describe "#validations" do
+    let(:district) { build :district }
+    before do
+      allow(Rails).to receive_message_chain(:env, :test?) {
+        false
+      }
+    end
+    context "when aws keys are nil" do
+      let(:district) { build :district }
+      it { expect(district).to_not be_valid }
+    end
+    context "when aws keys are present" do
+      let(:district) { build :district,
+                             aws_access_key_id: "AWS_ACCESS_KEY_ID",
+                             aws_secret_access_key: "AWS_SECRET_ACCESS_KEY" }
+      it { expect(district).to be_valid }
+    end
+  end
+
   describe "#subnets" do
     it "returns private subnets" do
       expect(ec2_mock).to receive(:describe_subnets).with(


### PR DESCRIPTION
Fixes https://github.com/degica/barcelona/issues/136

Now tests are 800% faster!

The cause is that encrypting and decrypting AWS keys is really slow and nearly all specs creates district.
So I changed to make the values `nil` in test environment
