### PR TITLE
Remove restarting docker and ecs from cloud-init

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -100,9 +100,7 @@ class ContainerInstance
     end
     user_data.run_commands += [
       "aws s3 cp s3://#{section.s3_bucket_name}/#{section.cluster_name}/ecs.config /etc/ecs/ecs.config",
-      "sed -i 's/^#\\s%wheel\\s*ALL=(ALL)\\s*NOPASSWD:\\sALL$/%wheel\\tALL=(ALL)\\tNOPASSWD:\\tALL/g' /etc/sudoers",
-      "service docker restart",
-      "start ecs"
+      "sed -i 's/^#\\s%wheel\\s*ALL=(ALL)\\s*NOPASSWD:\\sALL$/%wheel\\tALL=(ALL)\\tNOPASSWD:\\tALL/g' /etc/sudoers"
     ]
 
     district.users.each do |user|


### PR DESCRIPTION
Restarting docker daemon failed with the latest AMI. I'm not sure why this happened but the code I removed is no longer needed anymore and hopefully this will fix the issue.
