### PR TITLE
Fix ECS service role trusted relationships

### DIFF
--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -205,12 +205,12 @@ module Barcelona
 
         add_resource("AWS::IAM::Role", "ECSServiceRole") do |j|
           j.AssumeRolePolicyDocument do |j|
-            j.Version "2012-10-17"
+            j.Version "2008-10-17"
             j.Statement [
               {
                 "Effect" => "Allow",
                 "Principal" => {
-                  "Service" => ["ec2.amazonaws.com"]
+                  "Service" => ["ecs.amazonaws.com"]
                 },
                 "Action" => ["sts:AssumeRole"]
               }

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -204,12 +204,12 @@ describe Barcelona::Network::NetworkStack do
         "Type"=>"AWS::IAM::Role",
         "Properties" => {
           "AssumeRolePolicyDocument" => {
-            "Version" => "2012-10-17",
+            "Version" => "2008-10-17",
             "Statement" => [
               {
                 "Effect"=>"Allow",
                 "Principal" => {
-                  "Service" => ["ec2.amazonaws.com"]
+                  "Service" => ["ecs.amazonaws.com"]
                 },
                 "Action" => ["sts:AssumeRole"]
               }


### PR DESCRIPTION
@essa found a bug where a new heritage cannot be created with the latest barcelona. I think that's because ECSServiceRole's trusted relationships is wrong. it should be "ecs"
