### PR TITLE
Do not delete a proxy service when proxy plugin is destroyed

### DIFF
--- a/lib/barcelona/plugins/proxy_plugin.rb
+++ b/lib/barcelona/plugins/proxy_plugin.rb
@@ -78,11 +78,6 @@ EOS
         proxy_heritage.save_and_deploy!
       end
 
-      def on_destroyed(_, _)
-        heritage = district.heritages.find_by(name: proxy_heritage_name)
-        heritage.destroy! if heritage
-      end
-
       def proxy_url
         "http://#{proxy_host}:#{proxy_port}"
       end

--- a/spec/lib/barcelona/plugins/proxy_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/proxy_plugin_spec.rb
@@ -25,11 +25,6 @@ module Barcelona
         expect(port_mapping.container_port).to eq 3128
       end
 
-      it "gets hooked with destroyed trigger" do
-        district.plugins.first.destroy!
-        expect(Heritage.count).to be_zero
-      end
-
       it "gets hooked with heritage_task_definition trigger" do
         heritage = district.heritages.create(name: 'heritage',
                                              image_name: "docker_image",


### PR DESCRIPTION
the zero-downtime migration process should be 
1. delete proxy env vars form instances and task definitions
2. update services
3. then remove proxy service

currently deleting proxy plugin does 1 and 3 at same time I need to separate them
