### PR TITLE
Replace the first container process with a command

### DIFF
--- a/app/values/launch_command.rb
+++ b/app/values/launch_command.rb
@@ -7,7 +7,7 @@ class LaunchCommand
     if @command.blank?
       nil
     else
-      ["sh", "-c", @command]
+      ["sh", "-c", "exec " + @command]
     end
   end
 end

--- a/spec/models/backend/ecs/adapter_spec.rb
+++ b/spec/models/backend/ecs/adapter_spec.rb
@@ -90,7 +90,7 @@ describe Backend::Ecs::Adapter do
                   cpu: 128,
                   memory: 128,
                   essential: true,
-                  command: ["sh", "-c", "rails s"],
+                  command: ["sh", "-c", "exec rails s"],
                   image: service.heritage.image_path,
                   environment: [
                     {name: "HOST_PORT_HTTP_3000", value: port_http.host_port.to_s},

--- a/spec/models/oneoff_spec.rb
+++ b/spec/models/oneoff_spec.rb
@@ -49,7 +49,7 @@ describe Oneoff do
             container_overrides: [
               {
                 name: heritage.name + "-oneoff",
-                command: ["sh", "-c", "rake db:migrate"],
+                command: ["sh", "-c", "exec rake db:migrate"],
                 environment: []
               }
             ]
@@ -89,7 +89,7 @@ describe Oneoff do
               container_overrides: [
                 {
                   name: heritage.name + "-oneoff",
-                  command: ["sh", "-c", "rake db:migrate"],
+                  command: ["sh", "-c", "exec rake db:migrate"],
                   environment: [
                     {name: "OVERRITE_ENV", value: "VALUE"}
                   ]


### PR DESCRIPTION
Previously service command you specify is wrapped with `sh` command for example, if you specify a service command like this

```
command: rails s -p $PORT
```

Barcelona convert it to `["sh", "-c", "rail s -p $PORT"]`. This wrapping is a trick to make it possible to use environment variables inside the command attribute. But this way an invoked process cannot receive signals sent from docker daemon because docker daemon sends a signal to only the first process of a docker container but the above invocation actually forks a child process so the child process cannot  receive a signal.

This PR changes that behavior to replace the first process with the specified command so that the replaced command can receive signals
