### PR TITLE
Allow any type of traffic from VPC to public ELB

### DIFF
--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -127,6 +127,12 @@ module Barcelona
               "FromPort" => 443,
               "ToPort" => 443,
               "CidrIp" => "0.0.0.0/0"
+            },
+            {
+              "IpProtocol" => "-1",
+              "FromPort" => "-1",
+              "ToPort" => "-1",
+              "CidrIp" => options[:cidr_block]
             }
           ]
         end

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -64,7 +64,11 @@ describe Barcelona::Network::NetworkStack do
             {"IpProtocol" => "tcp",
              "FromPort" => 443,
              "ToPort" => 443,
-             "CidrIp" => "0.0.0.0/0"}]}},
+             "CidrIp" => "0.0.0.0/0"},
+            {"IpProtocol" => "-1",
+             "FromPort" => "-1",
+             "ToPort" => "-1",
+             "CidrIp" => "10.0.0.0/16"}]}},
       "PrivateELBSecurityGroup" => {
         "Type" => "AWS::EC2::SecurityGroup",
         "Properties" => {"GroupDescription" => "SG for Private ELB",


### PR DESCRIPTION
There would be a public service which provides normal service on HTTP/HTTPS along with admin control on a special port. For those services all public ELB ports should be accessible from inside VPC.

Right now we don't have such service but making the ports internally open doesn't breach the security
