### PR TITLE
Unencrypt aws_access_key_id

### DIFF
--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -34,7 +34,6 @@ class District < ActiveRecord::Base
 
   serialize :dockercfg, JSON
 
-  encrypted_attribute :aws_access_key_id, secret_key: ENV['ENCRYPTION_KEY']
   encrypted_attribute :aws_secret_access_key, secret_key: ENV['ENCRYPTION_KEY']
 
   accepts_nested_attributes_for :plugins

--- a/app/serializers/district_serializer.rb
+++ b/app/serializers/district_serializer.rb
@@ -3,7 +3,7 @@ class DistrictSerializer < ActiveModel::Serializer
              :instance_security_group, :ecs_service_role, :ecs_instance_profile,
              :private_hosted_zone_id, :s3_bucket_name, :container_instances,
              :stack_status, :nat_type, :cluster_size, :cluster_instance_type,
-             :cluster_backend, :cidr_block, :stack_name, :bastion_key_pair
+             :cluster_backend, :cidr_block, :stack_name, :bastion_key_pair, :aws_access_key_id
 
   has_many :heritages
   has_many :plugins

--- a/db/migrate/20160303080747_add_aws_access_key_id_to_districts.rb
+++ b/db/migrate/20160303080747_add_aws_access_key_id_to_districts.rb
@@ -1,0 +1,5 @@
+class AddAwsAccessKeyIdToDistricts < ActiveRecord::Migration
+  def change
+    add_column :districts, :aws_access_key_id, :string
+  end
+end

--- a/db/migrate/20160303080907_unencrypt_aws_access_key_id.rb
+++ b/db/migrate/20160303080907_unencrypt_aws_access_key_id.rb
@@ -1,0 +1,14 @@
+class UnencryptAwsAccessKeyId < ActiveRecord::Migration
+  def change
+    District.find_each do |district|
+      encrypted = district.encrypted_aws_access_key_id
+      decrypted = EncryptAttribute.decrypt_attribute(
+        encrypted,
+        ENV['ENCRYPTION_KEY'],
+        {}
+      )
+      district.aws_access_key_id = decrypted
+      district.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160202021528) do
+ActiveRecord::Schema.define(version: 20160303080907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20160202021528) do
     t.string   "cluster_backend"
     t.integer  "cluster_size"
     t.string   "cluster_instance_type"
+    t.string   "aws_access_key_id"
   end
 
   create_table "env_vars", force: :cascade do |t|


### PR DESCRIPTION
access key id is not secret. if it's encrypted a user would forget which access key is currently used
