### PR TITLE
Fix datadog-plugin

### DIFF
--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -17,7 +17,7 @@ module Barcelona
          "-h", "`hostname`",
          "-v", "/var/run/docker.sock:/var/run/docker.sock",
          "-v", "/proc/:/host/proc/:ro",
-         "-v", "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro",
+         "-v", "/cgroup/:/host/sys/fs/cgroup:ro",
          "-e", "API_KEY=#{api_key}",
          tags,
          "datadog/docker-dd-agent:latest"
@@ -25,7 +25,7 @@ module Barcelona
       end
 
       def tags
-        "-e TAGS=\"barcelona,district:#{district.name}\""
+        "-e TAGS=\"barcelona,barcelona-dd-agent,district:#{district.name}\""
       end
 
       def api_key

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -18,7 +18,7 @@ module Barcelona
         it "gets hooked with container_instance_user_data trigger" do
           ci = ContainerInstance.new(district)
           user_data = YAML.load(Base64.decode64(ci.user_data.build))
-          expect(user_data["runcmd"].last).to eq "docker run -d --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY=abcdef -e TAGS=\"barcelona,district:#{district.name}\" datadog/docker-dd-agent:latest"
+          expect(user_data["runcmd"].last).to eq "docker run -d --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e API_KEY=abcdef -e TAGS=\"barcelona,barcelona-dd-agent,district:#{district.name}\" datadog/docker-dd-agent:latest"
         end
       end
     end


### PR DESCRIPTION
In Amazon linux, cgroup files are stored in `/cgroup`.
