### PR TITLE
Forbid changing image name via trigger API

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -31,6 +31,10 @@ class HeritagesController < ApplicationController
 
   def trigger
     @heritage = Heritage.find_by!(name: params[:heritage_id])
+    if params[:image_name].present? && @heritage.image_name != params[:image_name]
+      raise ExceptionHandler::Forbidden
+    end
+
     params[:id] = params.delete :heritage_id
     if Rack::Utils.secure_compare(params[:token], @heritage.token)
       update


### PR DESCRIPTION
trigger API is called with a trigger token which is usually stored in travis (or somewhere not considered as secure)

The possible attack would be that a hacker steal a heritage token and deploy a new version with a different docker image which could be a serious attack.

the only purpose of the trigger token is to deploy a new version of application from CI so we don't need to allow changing docker image name
