### PR TITLE
Create swap in runcmd

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -50,8 +50,8 @@ class ContainerInstance
 
   def user_data
     user_data = UserData.new
-    user_data.boot_commands += [
-      "echo exclude=ecs-init >> /etc/yum.conf",
+    user_data.run_commands += [
+      "set -e",
       "MEMSIZE=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`",
       "if [ $MEMSIZE -lt 2097152 ]; then",
       "  SIZE=$((MEMSIZE * 2))k",
@@ -62,10 +62,7 @@ class ContainerInstance
       "else",
       "  SIZE=4194304k",
       "fi",
-      "fallocate -l $SIZE /swap.img && mkswap /swap.img && chmod 600 /swap.img && swapon /swap.img"
-    ]
-    user_data.run_commands += [
-      "set -e",
+      "fallocate -l $SIZE /swap.img && mkswap /swap.img && chmod 600 /swap.img && swapon /swap.img",
       "AWS_REGION=ap-northeast-1",
       "aws s3 cp s3://#{district.s3_bucket_name}/#{district.name}/ecs.config /etc/ecs/ecs.config",
       "sed -i 's/^#\\s%wheel\\s*ALL=(ALL)\\s*NOPASSWD:\\sALL$/%wheel\\tALL=(ALL)\\tNOPASSWD:\\tALL/g' /etc/sudoers",


### PR DESCRIPTION
Fixes #198 

The barcelona's cloud-init creates a swap file `/swap.img` in `bootcmd` process and with `m4.large` instance type, the swap size is 8GB.

I investigated the boot log file and found that Amazon linux extends root file system size to the specified size (80GB in our case) from the default 8GB **after bootcmd**.  After all, the m4.large instance tried to create a 8GB swap but the file system size at that time is 8GB so it failed to create a swap.

To solve the issue above I moved the swap creation to runcmd which runs after that resizing.

Also, I removed excluding `ecs-init` from yum update which is unneeded currently
