### PR TITLE
Tweak oneoff container resource limit

### DIFF
--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -94,8 +94,8 @@ class Oneoff < ActiveRecord::Base
 
   def task_definition
     heritage.base_task_definition(container_name).merge(
-      cpu: 256,
-      memory: 256,
+      cpu: 128,
+      memory: 512,
       image: image_path
     )
   end

--- a/spec/models/oneoff_spec.rb
+++ b/spec/models/oneoff_spec.rb
@@ -33,8 +33,8 @@ describe Oneoff do
           container_definitions: [
             {
               name: heritage.name + "-oneoff",
-              cpu: 256,
-              memory: 256,
+              cpu: 128,
+              memory: 512,
               essential: true,
               image: "#{heritage.image_path}",
               environment: []
@@ -73,8 +73,8 @@ describe Oneoff do
             container_definitions: [
               {
                 name: heritage.name + "-oneoff",
-                cpu: 256,
-                memory: 256,
+                cpu: 128,
+                memory: 512,
                 essential: true,
                 image: "#{heritage.image_name}:v100",
                 environment: []


### PR DESCRIPTION
`cpu` and `memory` in ECS are interpreted differently: `cpu` is a lower limit where a container can use more CPU resource if available, whereas `memory` is an upper limit where a container cannot consume over that value.
For a bigger application the current `256` memory might not be enough and results OOM error. On the other hand basically a oneoff task do not require much CPU resource

Ideally this should be configurable so that an application developer can choose the appropriate resource limit but for now I think these defaults works for most applications
