### PR TITLE
Don't apply stack automatically when saved

### DIFF
--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -5,8 +5,8 @@ class District < ActiveRecord::Base
   before_create :assign_default_users
   after_create :create_s3_bucket
   after_create :create_ecs_cluster
+  after_create :create_or_update_network_stack
   after_save :update_ecs_config
-  after_save :create_or_update_network_stack
   after_destroy :delete_ecs_cluster
 
   has_many :heritages, inverse_of: :district, dependent: :destroy


### PR DESCRIPTION
Previously applying CF configuration was triggered automatically whenever district model is saved.
That behavior is too eager because sometimes we need to update 2 or more resources which triggers CF update respectively. what is bad is some resource update, especially autoscaling group (launch configuration) update take 10 to 20 minutes to finish.

With this PR changes, district update no longer triggers CF update, instead Barcelona provides a dedicated API `apply_stack`
