### PR TITLE
Use dev version of reverse proxy

### DIFF
--- a/barcelona.yml
+++ b/barcelona.yml
@@ -11,6 +11,7 @@ environments:
         cpu: 128
         memory: 256
         command: puma -C config/puma.rb
+        reverse_proxy_image: quay.io/degica/barcelona-reverse-proxy:dev
         force_ssl: true
         hosts:
           - hostname: barcelona.degica.com


### PR DESCRIPTION
https://github.com/degica/barcelona-reverse-proxy has now 2 branches: master as a stable version and dev as a latest version.

In order for barcelona to test the latest reverse proxy features, this PR changes barcelona to use dev reverse proxy.
One more advantage of this PR is that we cante `reverse_proxy_image` option in `barcelona.yml` which has not been used until now
