### PR TITLE
Update AMI

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -10,7 +10,7 @@ module Barcelona
                      "ContainerInstanceLaunchConfiguration") do |j|
 
           j.IamInstanceProfile ref("ECSInstanceProfile")
-          j.ImageId "ami-a98d97c7" # amzn-ami-2016.03.b-amazon-ecs-optimized
+          j.ImageId "ami-095dbf68" # amzn-ami-2016.03.c-amazon-ecs-optimized
           j.InstanceType instance_type
           j.SecurityGroups [ref("InstanceSecurityGroup")]
           j.UserData instance_user_data

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -111,7 +111,7 @@ describe Barcelona::Network::NetworkStack do
         "Type" => "AWS::AutoScaling::LaunchConfiguration",
         "Properties" => {
           "IamInstanceProfile" => {"Ref"=>"ECSInstanceProfile"},
-          "ImageId" => "ami-a98d97c7",
+          "ImageId" => "ami-095dbf68",
           "InstanceType" => "t2.micro",
           "SecurityGroups" => [{"Ref"=>"InstanceSecurityGroup"}],
           "UserData" => instance_of(String),


### PR DESCRIPTION
The newest AMI 2016.03 includes docker engine update from 1.9.3 to 1.11.0 which is a significant change. Before merging I'll test with test cluster
