### PR TITLE
Select region

### DIFF
--- a/app/controllers/districts_controller.rb
+++ b/app/controllers/districts_controller.rb
@@ -42,6 +42,7 @@ class DistrictsController < ApplicationController
   def create_params
     params.permit(
       :name,
+      :region,
       :bastion_key_pair,
       :nat_type,
       :cluster_backend,

--- a/app/models/backend/ecs/service.rb
+++ b/app/models/backend/ecs/service.rb
@@ -82,7 +82,7 @@ module Backend::Ecs
     def reverse_proxy_definition
       base = service.heritage.base_task_definition("#{service.service_name}-revpro")
       base[:environment] += [
-        {name: "AWS_REGION", value: 'ap-northeast-1'},
+        {name: "AWS_REGION", value: district.region},
         {name: "UPSTREAM_NAME", value: "backend"},
         {name: "UPSTREAM_PORT", value: service.web_container_port.to_s},
         {name: "FORCE_SSL", value: (!!service.force_ssl).to_s},

--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -21,7 +21,7 @@ class ContainerInstance
       "  SIZE=4194304k",
       "fi",
       "fallocate -l $SIZE /swap.img && mkswap /swap.img && chmod 600 /swap.img && swapon /swap.img",
-      "AWS_REGION=ap-northeast-1",
+      "AWS_REGION=#{district.region}",
       "aws s3 cp s3://#{district.s3_bucket_name}/#{district.name}/ecs.config /etc/ecs/ecs.config",
       "chmod 600 /etc/ecs/ecs.config",
       "sed -i 's/^#\\s%wheel\\s*ALL=(ALL)\\s*NOPASSWD:\\sALL$/%wheel\\tALL=(ALL)\\tNOPASSWD:\\tALL/g' /etc/sudoers",
@@ -38,7 +38,7 @@ class ContainerInstance
 set -e
 
 stop() {
-  AWS_REGION=ap-northeast-1
+  AWS_REGION=#{district.region}
   ec2_instance_id=`curl http://169.254.169.254/latest/meta-data/instance-id`
   ecs_cluster=`curl http://localhost:51678/v1/metadata | jq -r .Cluster`
   container_instance_arn=`curl http://localhost:51678/v1/metadata | jq -r .ContainerInstanceArn | cut -d / -f2`

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -26,6 +26,12 @@ class District < ActiveRecord::Base
   validates :aws_access_key_id, presence: true, if: -> { !Rails.env.test? }
   validates :aws_secret_access_key, presence: true, if: -> { !Rails.env.test? }
 
+  ECS_REGIONS = Aws.
+                partition("aws").
+                regions.select { |r| r.services.include?("ECS") }.
+                map(&:name)
+  validates :region, inclusion: {in: ECS_REGIONS}
+
   validate :validate_cidr_block
 
   serialize :dockercfg, JSON
@@ -177,6 +183,7 @@ class District < ActiveRecord::Base
   end
 
   def set_default_attributes
+    self.region ||= "us-east-1"
     self.s3_bucket_name ||= "barcelona-#{name}-#{Time.now.to_i}"
     self.cidr_block     ||= "10.#{Random.rand(256)}.0.0/16"
     self.stack_name     ||= "barcelona-#{name}"

--- a/app/serializers/district_serializer.rb
+++ b/app/serializers/district_serializer.rb
@@ -1,5 +1,5 @@
 class DistrictSerializer < ActiveModel::Serializer
-  attributes :name, :vpc_id, :public_elb_security_group, :private_elb_security_group,
+  attributes :name, :region, :vpc_id, :public_elb_security_group, :private_elb_security_group,
              :instance_security_group, :ecs_service_role, :ecs_instance_profile,
              :private_hosted_zone_id, :s3_bucket_name, :container_instances,
              :stack_status, :nat_type, :cluster_size, :cluster_instance_type,

--- a/db/migrate/20160614143605_add_region_to_districts.rb
+++ b/db/migrate/20160614143605_add_region_to_districts.rb
@@ -1,0 +1,5 @@
+class AddRegionToDistricts < ActiveRecord::Migration
+  def change
+    add_column :districts, :region, :string
+  end
+end

--- a/db/migrate/20160614143648_fill_default_regions.rb
+++ b/db/migrate/20160614143648_fill_default_regions.rb
@@ -1,0 +1,5 @@
+class FillDefaultRegions < ActiveRecord::Migration
+  def change
+    District.update_all(region: 'ap-northeast-1')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160510094441) do
+ActiveRecord::Schema.define(version: 20160614143648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20160510094441) do
     t.integer  "cluster_size"
     t.string   "cluster_instance_type"
     t.string   "aws_access_key_id"
+    t.string   "region"
   end
 
   create_table "env_vars", force: :cascade do |t|

--- a/lib/barcelona/network/network_stack.rb
+++ b/lib/barcelona/network/network_stack.rb
@@ -13,6 +13,7 @@ module Barcelona::Network
     def initialize(district)
       @district = district
       options = {
+        region: district.region,
         cidr_block: district.cidr_block,
         bastion_key_pair: district.bastion_key_pair,
         nat_type: district.nat_type,

--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -96,7 +96,7 @@ module Barcelona
         end
 
         add_resource("AWS::EC2::DHCPOptions", "VPCDHCPOptions") do |j|
-          j.DomainName join(" ", "ap-northeast-1.compute.internal", "bcn")
+          j.DomainName join(" ", "#{options[:region]}.compute.internal", "bcn")
           j.DomainNameServers ["AmazonProvidedDNS"]
         end
 

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -36,7 +36,7 @@ describe Barcelona::Network::NetworkStack do
         "Type" => "AWS::EC2::DHCPOptions",
         "Properties" => {
           "DomainName" => {
-            "Fn::Join" => [" ", ["ap-northeast-1.compute.internal", "bcn"]]},
+            "Fn::Join" => [" ", ["us-east-1.compute.internal", "bcn"]]},
           "DomainNameServers" => ["AmazonProvidedDNS"]}},
       "VPCDHCPOptionsAssociation" => {
         "Type" => "AWS::EC2::VPCDHCPOptionsAssociation",

--- a/spec/models/backend/ecs/adapter_spec.rb
+++ b/spec/models/backend/ecs/adapter_spec.rb
@@ -132,7 +132,7 @@ describe Backend::Ecs::Adapter do
                   image: Service::DEFAULT_REVERSE_PROXY,
                   links: ["#{service.service_name}:backend"],
                   environment: [
-                    {name: "AWS_REGION", value: "ap-northeast-1"},
+                    {name: "AWS_REGION", value: "us-east-1"},
                     {name: "UPSTREAM_NAME", value: "backend"},
                     {name: "UPSTREAM_PORT", value: "3000"},
                     {name: "FORCE_SSL", value: "false"}

--- a/spec/requests/create_district_spec.rb
+++ b/spec/requests/create_district_spec.rb
@@ -6,6 +6,7 @@ describe "POST /districts", type: :request do
   let(:params) do
     {
       name: "district",
+      region: "ap-northeast-1",
       aws_access_key_id: "awsaccessskeyid",
       aws_secret_access_key: "secret key",
       bastion_key_pair: 'bastion-key-pair'
@@ -28,6 +29,7 @@ describe "POST /districts", type: :request do
 
       body = JSON.load(response.body)
       expect(body["district"]["name"]).to eq "district"
+      expect(body["district"]["region"]).to eq "ap-northeast-1"
       expect(body["district"]["cidr_block"]).to match %r{10\.[0-9]+\.0.0\/16}
       expect(body["district"]["stack_name"]).to eq "barcelona-district"
       expect(body["district"]["s3_bucket_name"]).to match %r{barcelona-district-[0-9]+}


### PR DESCRIPTION
Now users can choose AWS region. This is a very important change to make Barcelona OSS.
By default the district's region is `us-east-1` and since our current districts are all in Tokyo region I added a migration to fill the existing district's regions
