### PR TITLE
Open web container tty

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     ports:
      - "3333:3333"
     command: rails s -p 3333 -b 0.0.0.0
+    stdin_open: true
+    tty: true
     links:
      - db
     volumes:
@@ -24,8 +26,6 @@ services:
     <<: *app_base
     ports: []
     command: spring server
-    stdin_open: true
-    tty: true
     pid: host
     environment:
       DATABASE_URL: postgres://postgres:@db:5432


### PR DESCRIPTION
When I wanted to use `binding.pry` I needed to attach into the web container so the web container should open tty and stdin
