### PR TITLE
Don't upgrade packages at launch time

### DIFF
--- a/app/models/instance_user_data.rb
+++ b/app/models/instance_user_data.rb
@@ -30,8 +30,6 @@ class InstanceUserData
 
   def build
     user_data = {
-      "repo_update" => true,
-      "repo_upgrade" => "all",
       "packages" => packages.uniq,
       "write_files" => files,
       "bootcmd" => boot_commands,


### PR DESCRIPTION
When I terminated the running instance I noticed the new instance's docker version was different from other running servers. that is because the current user data allows to upgrade all packages, which should not happen.
In this change I removed that option so that the upgrade doesn't happen. even with this setting, an instance upgrades security-related packages at launch time.
