### PR TITLE
Exclude Dockerfile from .dockerignore

### DIFF
--- a/dockerfiles/run-pack/.dockerignore
+++ b/dockerfiles/run-pack/.dockerignore
@@ -1,3 +1,2 @@
 vendor
-Dockerfile*
 run-pack


### PR DESCRIPTION
I couldn't create a build trigger in quay.io because of https://docs.quay.io/guides/building.html

> Unlike the Docker Hub, the Dockerfile is part of the build context on Quay. Thus, it must not appear in .dockerignore file.
