### PR TITLE
Add newrelic plugin

### DIFF
--- a/lib/barcelona/plugins/newrelic_plugin.rb
+++ b/lib/barcelona/plugins/newrelic_plugin.rb
@@ -1,0 +1,21 @@
+module Barcelona
+  module Plugins
+    class NewrelicPlugin < Base
+      def on_container_instance_user_data(_instance, user_data)
+        user_data.add_file("/etc/newrelic-infra.yml", "root:root", "644", <<~EOS)
+          license_key: #{attributes[:license_key]}
+          custom_attributes:
+            role: barcelona-ci
+            district: #{district.name}
+        EOS
+
+        user_data.run_commands += [
+          "curl -s https://75aae388e7629eec895d26b0943bbfd06288356953c5777d:@packagecloud.io/install/repositories/newrelic/infra-beta/script.rpm.sh | bash",
+          "yum install newrelic-infra -y"
+        ]
+
+        user_data
+      end
+    end
+  end
+end

--- a/spec/lib/barcelona/plugins/newrelic_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/newrelic_plugin_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+module Barcelona
+  module Plugins
+    describe NewrelicPlugin do
+      let(:license_key) { SecureRandom.hex }
+      let!(:district) do
+        create :district, plugins_attributes: [
+                 {
+                   name: 'newrelic',
+                   plugin_attributes: {
+                     "license_key" => license_key
+                   }
+                 }
+               ]
+      end
+
+      it "gets hooked with container_instance_user_data trigger" do
+        ci = ContainerInstance.new(district)
+        user_data = YAML.load(Base64.decode64(ci.user_data.build))
+        expect(user_data["runcmd"]).to include "curl -s https://75aae388e7629eec895d26b0943bbfd06288356953c5777d:@packagecloud.io/install/repositories/newrelic/infra-beta/script.rpm.sh | bash"
+        expect(user_data["runcmd"]).to include "yum install newrelic-infra -y"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added newrelic plugin. Currently this plugin supports only New Relic Infrastructure

You can see the test project [here](https://infra.newrelic.com/accounts/693374/overview)
## USAGE

```
$ bcn request post /districts/<district name>/plugins '{"name": "newrelic", "attributes": {"license_key": "newrelic-license-key"}}'
```
