### PR TITLE
Simplify the instance shutdown script

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -37,24 +37,11 @@ set -e
 
 stop() {
   AWS_REGION=#{district.region}
-  ec2_instance_id=`curl http://169.254.169.254/latest/meta-data/instance-id`
   ecs_cluster=`curl http://localhost:51678/v1/metadata | jq -r .Cluster`
   container_instance_arn=`curl http://localhost:51678/v1/metadata | jq -r .ContainerInstanceArn | cut -d / -f2`
 
   aws ecs deregister-container-instance --region $AWS_REGION --cluster $ecs_cluster --container-instance $container_instance_arn --force
-
-  elb_names=`aws elb describe-load-balancers --region $AWS_REGION | jq -r ".LoadBalancerDescriptions | map(select(contains({Instances: [{InstanceId: \\"$ec2_instance_id\\"}]}))) | map(.LoadBalancerName) | join(\\" \\")"`
-
-  for elb in $elb_names
-  do
-      aws elb deregister-instances-from-load-balancer --region $AWS_REGION --load-balancer-name $elb --instances $ec2_instance_id
-  done
-
-  while [[ -n "$elb_names" ]]
-  do
-      elb_names=`aws elb describe-load-balancers --region $AWS_REGION | jq -r ".LoadBalancerDescriptions | map(select(contains({Instances: [{InstanceId: \\"$ec2_instance_id\\"}]}))) | map(.LoadBalancerName) | join(\\" \\")"`
-      sleep 3
-  done
+  sleep 60
 
   docker stop -t 90 $(docker ps -q)
 }


### PR DESCRIPTION
- According to the ECS doc, `DeregisterContainerInstance` API automatically deregisters tasks from ELB so no need for manually deregistering the instance from ELB 

http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeregisterContainerInstance.html

> Any containers in orphaned service tasks that are registered with a Classic load balancer or an Application load balancer target group are deregistered, and they will begin connection draining according to the settings on the load balancer or target group.
- Instead of checking ELB status periodically, just sleep 60 seconds which is Barcelona ELB's connection draining timeout. Since this is a shutdown script, total running time of the script doesn't matter
