### PR TITLE
Fix awscli signature version

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -20,6 +20,7 @@ class ContainerInstance
       "fi",
       "fallocate -l $SIZE /swap.img && mkswap /swap.img && chmod 600 /swap.img && swapon /swap.img",
       "AWS_REGION=#{district.region}",
+      "aws configure set s3.signature_version s3v4",
       "aws s3 cp s3://#{district.s3_bucket_name}/#{district.name}/ecs.config /etc/ecs/ecs.config",
       "chmod 600 /etc/ecs/ecs.config",
       "sed -i 's/^#\\s%wheel\\s*ALL=(ALL)\\s*NOPASSWD:\\sALL$/%wheel\\tALL=(ALL)\\tNOPASSWD:\\tALL/g' /etc/sudoers",


### PR DESCRIPTION
Now barcelona uses S3-SSE-KMS, the client's signature version must be v4.
