### PR TITLE
Remove unused permissions

### DIFF
--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -305,8 +305,6 @@ module Barcelona
                       "ecr:BatchGetImage",
                       "logs:CreateLogStream",
                       "logs:PutLogEvents",
-                      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                      "elasticloadbalancing:DescribeLoadBalancers",
                       "s3:Get*",
                       "s3:List*"
                     ],

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -254,8 +254,6 @@ describe Barcelona::Network::NetworkStack do
                       "ecr:BatchGetImage",
                       "logs:CreateLogStream",
                       "logs:PutLogEvents",
-                      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                      "elasticloadbalancing:DescribeLoadBalancers",
                       "s3:Get*",
                       "s3:List*"
                     ],


### PR DESCRIPTION
Those 2 permissions were used when terminating a container instance but now the shutdown script is simplified so that it doesn't call ELB APIs
