### PR TITLE
Support other regions

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -1,6 +1,20 @@
 module Barcelona
   module Network
     class AutoscalingBuilder < CloudFormation::Builder
+      # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+      # amzn-ami-2016.09.a-amazon-ecs-optimized
+      ECS_OPTIMIZED_AMI_IDS = {
+        "us-east-1" => "ami-1924770e",
+        "us-east-2" => "ami-bd3e64d8",
+        "us-west-1" => "ami-7f004b1f",
+        "us-west-2" => "ami-56ed4936",
+        "eu-west-1" => "ami-c8337dbb",
+        "eu-central-1" => "ami-dd12ebb2",
+        "ap-northeast-1" => "ami-c8b016a9",
+        "ap-southeast-1" => "ami-6d22840e",
+        "ap-southeast-2" => "ami-73407d10"
+      }
+
       def ebs_optimized_by_default?
         !!(instance_type =~ /\A(c4|m4|d2)\..*\z/)
       end
@@ -10,7 +24,7 @@ module Barcelona
                      "ContainerInstanceLaunchConfiguration") do |j|
 
           j.IamInstanceProfile ref("ECSInstanceProfile")
-          j.ImageId "ami-010ed160" # amzn-ami-2016.03.j-amazon-ecs-optimized
+          j.ImageId ECS_OPTIMIZED_AMI_IDS[stack.district.region]
           j.InstanceType instance_type
           j.SecurityGroups [ref("InstanceSecurityGroup")]
           j.UserData instance_user_data

--- a/lib/barcelona/network/bastion_server.rb
+++ b/lib/barcelona/network/bastion_server.rb
@@ -1,6 +1,20 @@
 module Barcelona
   module Network
     class BastionServer < CloudFormation::Resource
+      # https://aws.amazon.com/amazon-linux-ami/
+      # Amazon Linux AMI 2016.09.0
+      AMI_IDS = {
+        "us-east-1" => "ami-c481fad3",
+        "us-east-2" => "ami-71ca9114",
+        "us-west-1" => "ami-de347abe",
+        "us-west-2" => "ami-b04e92d0",
+        "eu-west-1" => "ami-d41d58a7",
+        "eu-central-1" => "ami-0044b96f",
+        "ap-northeast-1" => "ami-1a15c77b",
+        "ap-southeast-1" => "ami-7243e611",
+        "ap-southeast-2" => "ami-55d4e436"
+      }
+
       def self.type
         "AWS::EC2::Instance"
       end
@@ -9,7 +23,7 @@ module Barcelona
         super do |j|
           j.InstanceType "t2.nano"
           j.SourceDestCheck false
-          j.ImageId "ami-29160d47"
+          j.ImageId AMI_IDS[district.region]
           j.UserData user_data
           j.NetworkInterfaces [
             {

--- a/lib/barcelona/network/nat_builder.rb
+++ b/lib/barcelona/network/nat_builder.rb
@@ -1,6 +1,19 @@
 module Barcelona
   module Network
     class NatBuilder < CloudFormation::Builder
+      # amzn-ami-vpc-nat-hvm-2016.09.0.20160923-x86_64-ebs
+      VPC_NAT_AMI_IDS = {
+        "us-east-1" => "ami-d2ee95c5",
+        "us-east-2" => "ami-9fc299fa",
+        "us-west-1" => "ami-90357bf0",
+        "us-west-2" => "ami-c4469aa4",
+        "eu-west-1" => "ami-d41d58a7",
+        "eu-central-1" => "ami-b646bbd9",
+        "ap-northeast-1" => "ami-831fcde2",
+        "ap-southeast-1" => "ami-9c40e5ff",
+        "ap-southeast-2" => "ami-addbebce"
+      }
+
       def build_resources
         case options[:type]
         when :instance then
@@ -21,7 +34,7 @@ module Barcelona
                        depends_on: ["VPCGatewayAttachment"]) do |j|
             j.InstanceType options[:instance_type] || 't2.nano'
             j.SourceDestCheck false
-            j.ImageId "ami-5d170c33"
+            j.ImageId VPC_NAT_AMI_IDS[stack.district.region]
             j.NetworkInterfaces [
               {
                 "AssociatePublicIpAddress" => true,

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -188,7 +188,7 @@ describe Barcelona::Network::NetworkStack do
         "Properties" => {
           "InstanceType" => "t2.nano",
           "SourceDestCheck" => false,
-          "ImageId" => "ami-29160d47",
+          "ImageId" => kind_of(String),
           "UserData" => anything,
           "NetworkInterfaces" => [
             {


### PR DESCRIPTION
Now Barcelona supports 9 AWS regions!

I tested `ap-notheast-1` (Tokyo) and `us-east-1` (North Virginia) and those 2 regions worked correctly.
Note that this PR also updates AMIs to the latest ones
