### PR TITLE
Unset AWS env vars before creating a session

### DIFF
--- a/dockerfiles/run-pack/s3_client.go
+++ b/dockerfiles/run-pack/s3_client.go
@@ -47,10 +47,10 @@ func newSession(region string) (*session.Session, error) {
 			return nil, err
 		}
 
-		if os.Setenv("AWS_ACCESS_KEY_ID", keyId) != nil {
+		if err = os.Setenv("AWS_ACCESS_KEY_ID", keyId); err != nil {
 			return nil, err
 		}
-		if os.Setenv("AWS_SECRET_ACCESS_KEY", secretKey) != nil {
+		if err = os.Setenv("AWS_SECRET_ACCESS_KEY", secretKey); err != nil {
 			return nil, err
 		}
 		return sess, err


### PR DESCRIPTION
# Process to reproduce

- Add non-secret environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to a service
- Add some secret environment variables to the same service
- Deploy the service

# Expected behavior

The service run correctly with all the environment variables loaded

# Actual behavior

The service failed to load the secret environment variable

# Why the issue happens

When a service has a secret environment variable the `barcelona-run` binary tries to load the secret variable from S3 using go AWS client. The go AWS client uses `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as its credential by default and this default can't be changed.
So in this case the AWS credentials are supposed to be used by the service container but the credential is also used by `barcelona-run` and the credential may not have `s3:GetObject` permission.

# How the issued is fixed

I fixed `barcelona-run` to temporarily unset the AWS environment variables if those exist