### PR TITLE
Let revpro container die if rendering template fails

### DIFF
--- a/dockerfiles/reverse-proxy/entrypoint
+++ b/dockerfiles/reverse-proxy/entrypoint
@@ -1,4 +1,6 @@
 #!/bin/sh
 
+set -e
+
 ruby render_template.rb
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Minor but reverse proxy container should die if it fails to render templates