### PR TITLE
Add Scheduled tasks

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -112,6 +112,7 @@ class HeritagesController < ApplicationController
         }
       ]
     ]).tap do |whitelisted|
+      whitelisted[:scheduled_tasks] = params[:scheduled_tasks] if params[:scheduled_tasks].present?
       if params[:services].present?
         params[:services].each_with_index do |s, i|
           whitelisted[:services][i][:health_check] = s[:health_check].permit(:protocol, :port) if s.key?(:health_check)

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -27,6 +27,13 @@ class HeritageTaskDefinition
         memory: 512)
   end
 
+  def self.schedule_definition(heritage)
+    new(heritage: heritage,
+        family_name: "#{heritage.name}-schedule",
+        cpu: 128,
+        memory: 512)
+  end
+
   def to_task_definition
     containers = [container_definition, run_pack_definition]
     if web_service?

--- a/app/serializers/heritage_serializer.rb
+++ b/app/serializers/heritage_serializer.rb
@@ -1,6 +1,6 @@
 class HeritageSerializer < ActiveModel::Serializer
   attributes :name, :image_name, :image_tag, :env_vars, :before_deploy,
-             :slack_url, :token, :version
+             :slack_url, :token, :version, :scheduled_tasks
 
   has_many :services
   belongs_to :district

--- a/db/migrate/20161106141820_add_scheduled_tasks_to_heritages.rb
+++ b/db/migrate/20161106141820_add_scheduled_tasks_to_heritages.rb
@@ -1,0 +1,5 @@
+class AddScheduledTasksToHeritages < ActiveRecord::Migration
+  def change
+    add_column :heritages, :scheduled_tasks, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161008153656) do
+ActiveRecord::Schema.define(version: 20161106141820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,16 +86,17 @@ ActiveRecord::Schema.define(version: 20161008153656) do
   add_index "events", ["uuid"], name: "index_events_on_uuid", unique: true, using: :btree
 
   create_table "heritages", force: :cascade do |t|
-    t.string   "name",          null: false
+    t.string   "name",            null: false
     t.string   "image_name"
     t.string   "image_tag"
     t.integer  "district_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
     t.text     "before_deploy"
     t.text     "slack_url"
     t.string   "token"
     t.integer  "version"
+    t.text     "scheduled_tasks"
   end
 
   add_index "heritages", ["district_id"], name: "index_heritages_on_district_id", using: :btree

--- a/examples/rails-app/barcelona.yml
+++ b/examples/rails-app/barcelona.yml
@@ -2,6 +2,11 @@ environments:
   production:
     name: rails-app
     image_name: k2nr/rails-docker-sample
+    scheduled_tasks:
+      - schedule: rate(1 minute)
+        command: ["sh", "-c", "echo hello $SECRET_KEY_BASE"]
+      - schedule: rate(10 minutes)
+        command: echo hello hello
     services:
       - name: web
         service_type: web

--- a/schedule_handler.js
+++ b/schedule_handler.js
@@ -1,0 +1,27 @@
+var AWS = require('aws-sdk');
+var util = require('util');
+
+exports.handler = function(input, context) {
+  console.log(util.inspect(input, {showHidden: false, depth: null}))
+  console.log(context)
+
+  var ecs = new AWS.ECS();
+  var params = {
+    cluster: input.cluster,
+    taskDefinition: input.task_family,
+    overrides: {
+      containerOverrides: [
+        {
+          name: input.task_family,
+          command: input.command
+        }
+      ]
+    }
+  }
+
+  console.log(util.inspect(params, {depth: null}))
+  ecs.runTask(params, function(err, data) {
+    console.log(util.inspect(err, {depth: null}))
+    console.log(util.inspect(data, {depth: null}))
+  })
+}

--- a/spec/models/heritage_spec.rb
+++ b/spec/models/heritage_spec.rb
@@ -53,5 +53,18 @@ describe Heritage::Stack do
       }
       expect(generated["Resources"]).to eq expected
     end
+
+    context "when a heritage has scheduled tasks" do
+      let(:heritage) { build :heritage,
+                             scheduled_tasks: [{schedule: 'rate(1 minute)',
+                                                command: 'echo hello'}] }
+      it "generates a correct stack template" do
+        generated = JSON.load stack.target!
+        expect(generated["Resources"]["ScheduledEvent0"]).to be_present
+        expect(generated["Resources"]["PermissionForScheduledEvent0"]).to be_present
+        expect(generated["Resources"]["ScheduleHandler"]).to be_present
+        expect(generated["Resources"]["ScheduleHandlerRole"]).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently if you want to add some cron tasks you need to add "scheduler" service as a barcelona service, which works fine but has some disadvantages:

- the scheduler service consumes CPU and Memory permanently which is not cost efficient
- It is hard to ensure that a scheduled task runs **exactly once** because ECS service some times launch 2 or more containers even when the desired count is `1`, or otherwise it is possible that running container count temporarily  becomes 0

This PR adds Barcelona-managed **scheduled tasks** feature which is backed by CloudWatch Events and Lambda.

For the `schedule` attribute format, see http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html


Complete example:

```yaml
 environments:
   production:
     name: rails-app
     image_name: degica/your-application-image
     scheduled_tasks:
       - schedule: rate(1 minute) # every minute
         command: ["sh", "-c", "echo hello $SECRET_KEY_BASE"] # shell style command to use env var
       - schedule: cron(0 18 ? * MON-FRI *) # Run at 6:00 pm (UTC) every Monday through Friday
          command: rake batch:create_records
     services:
       - name: web
         service_type: web
         public: true
         cpu: 128
         memory: 256
         command: rails s -p $PORT -b 0.0.0.0
         listeners:
           - endpoint: test-endpoint
```