### PR TITLE
Extend rolling update timeout

### DIFF
--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -30,7 +30,7 @@ module Barcelona
             j.MaxBatchSize 1
             j.MinInstancesInService desired_capacity
             j.WaitOnResourceSignals true
-            j.PauseTime "PT20M"
+            j.PauseTime "PT60M"
           end
         end
       end

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -103,7 +103,7 @@ describe Barcelona::Network::NetworkStack do
             "MaxBatchSize" => 1,
             "MinInstancesInService" => 1,
             "WaitOnResourceSignals" => true,
-            "PauseTime" => "PT20M"
+            "PauseTime" => "PT60M"
           }
         }
       },


### PR DESCRIPTION
I've seen some instances that took over 15 minutes to launch. `PauseTime` should be a timeout value which instances normally don't exceed