### PR TITLE
Revert "Do not use task role to have migration window"

### DIFF
--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -34,7 +34,7 @@ class HeritageTaskDefinition
         memory: 512)
   end
 
-  def to_task_definition(without_task_role: true)
+  def to_task_definition(without_task_role: false)
     containers = [container_definition, run_pack_definition]
     if web_service?
       containers << case mode

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -25,7 +25,7 @@ describe HeritageTaskDefinition do
     it "returns a task definition for the service" do
       expect(subject).to eq({
                               family: service.service_name,
-#                              task_role_arn: "task-role",
+                              task_role_arn: "task-role",
                               container_definitions: [
                                 {
                                   name: service.service_name,
@@ -61,7 +61,7 @@ describe HeritageTaskDefinition do
       it "returns a task definition for the service" do
         expect(subject).to eq({
                                 family: service.service_name,
-#                                task_role_arn: "task-role",
+                                task_role_arn: "task-role",
                                 container_definitions: [
                                   {
                                     environment: [
@@ -162,7 +162,7 @@ describe HeritageTaskDefinition do
     it "returns a task definition for the oneoff" do
       expect(subject).to eq({
                               family: "#{heritage.name}-oneoff",
-#                              task_role_arn: "task-role",
+                              task_role_arn: "task-role",
                               container_definitions: [
                                 {
                                   name:  "#{heritage.name}-oneoff",


### PR DESCRIPTION
This reverts commit f8e40ef487d8bba935402d729cc7d55cf9256aa7.