### PR TITLE
WIP Role based Auth

### DIFF
--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -16,12 +16,6 @@ class District < ActiveRecord::Base
   validates :cluster_backend, inclusion: {in: %w(autoscaling)}
   validates :cluster_size, numericality: {greater_than_or_equal_to: 0}
 
-  # Allows nil when test environment
-  # This is because encrypting/decrypting value is very slow
-  # So to speed up specs we allow empty access keys
-  validates :aws_access_key_id, presence: true, if: -> { !Rails.env.test? }
-  validates :aws_secret_access_key, presence: true, if: -> { !Rails.env.test? }
-
   ECS_REGIONS = Aws.
                 partition("aws").
                 regions.select { |r| r.services.include?("ECS") }.
@@ -29,6 +23,7 @@ class District < ActiveRecord::Base
   validates :region, inclusion: {in: ECS_REGIONS}
 
   validate :validate_cidr_block
+  validate :presence_of_access_key_or_role, if: -> { !Rails.env.test? }
 
   serialize :dockercfg, JSON
 
@@ -37,8 +32,7 @@ class District < ActiveRecord::Base
   accepts_nested_attributes_for :plugins
 
   def aws
-    # these fallback "empty" value is a trick to speed up specs
-    @aws ||= AwsAccessor.new(aws_access_key_id || "empty", aws_secret_access_key || "empty", region)
+    @aws ||= AwsAccessor.new(self)
   end
 
   def to_param
@@ -199,5 +193,11 @@ class District < ActiveRecord::Base
 
   def assign_default_users
     self.users = User.all
+  end
+
+  def presence_of_access_key_or_role
+    unless [aws_role, aws_access_key_id, aws_secret_access_key].any?
+      errors.add(:aws_role, "aws_role or aws_access_key_id must be present")
+    end
   end
 end

--- a/db/migrate/20161212130243_add_aws_role_to_districts.rb
+++ b/db/migrate/20161212130243_add_aws_role_to_districts.rb
@@ -1,0 +1,5 @@
+class AddAwsRoleToDistricts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :districts, :aws_role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161106141820) do
+ActiveRecord::Schema.define(version: 20161212130243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,9 +27,8 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.string   "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
   end
-
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "districts", force: :cascade do |t|
     t.string   "name"
@@ -49,6 +47,7 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.string   "aws_access_key_id"
     t.string   "region"
     t.text     "ssh_ca_public_key"
+    t.string   "aws_role"
   end
 
   create_table "endpoints", force: :cascade do |t|
@@ -58,20 +57,18 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.string   "certificate_id"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.index ["district_id", "name"], name: "index_endpoints_on_district_id_and_name", unique: true, using: :btree
+    t.index ["district_id"], name: "index_endpoints_on_district_id", using: :btree
   end
-
-  add_index "endpoints", ["district_id", "name"], name: "index_endpoints_on_district_id_and_name", unique: true, using: :btree
-  add_index "endpoints", ["district_id"], name: "index_endpoints_on_district_id", using: :btree
 
   create_table "env_vars", force: :cascade do |t|
     t.integer "heritage_id"
     t.string  "key"
     t.text    "encrypted_value"
     t.boolean "secret",          default: false
+    t.index ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true, using: :btree
+    t.index ["heritage_id"], name: "index_env_vars_on_heritage_id", using: :btree
   end
-
-  add_index "env_vars", ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true, using: :btree
-  add_index "env_vars", ["heritage_id"], name: "index_env_vars_on_heritage_id", using: :btree
 
   create_table "events", force: :cascade do |t|
     t.string   "uuid"
@@ -80,10 +77,9 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.string   "level"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["heritage_id"], name: "index_events_on_heritage_id", using: :btree
+    t.index ["uuid"], name: "index_events_on_uuid", unique: true, using: :btree
   end
-
-  add_index "events", ["heritage_id"], name: "index_events_on_heritage_id", using: :btree
-  add_index "events", ["uuid"], name: "index_events_on_uuid", unique: true, using: :btree
 
   create_table "heritages", force: :cascade do |t|
     t.string   "name",            null: false
@@ -96,11 +92,11 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.text     "slack_url"
     t.string   "token"
     t.integer  "version"
+    t.text     "aws_actions"
     t.text     "scheduled_tasks"
+    t.index ["district_id"], name: "index_heritages_on_district_id", using: :btree
+    t.index ["name"], name: "index_heritages_on_name", unique: true, using: :btree
   end
-
-  add_index "heritages", ["district_id"], name: "index_heritages_on_district_id", using: :btree
-  add_index "heritages", ["name"], name: "index_heritages_on_name", unique: true, using: :btree
 
   create_table "listeners", force: :cascade do |t|
     t.integer  "endpoint_id"
@@ -111,11 +107,10 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.integer  "rule_priority"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
+    t.index ["endpoint_id", "service_id"], name: "index_listeners_on_endpoint_id_and_service_id", unique: true, using: :btree
+    t.index ["endpoint_id"], name: "index_listeners_on_endpoint_id", using: :btree
+    t.index ["service_id"], name: "index_listeners_on_service_id", using: :btree
   end
-
-  add_index "listeners", ["endpoint_id", "service_id"], name: "index_listeners_on_endpoint_id_and_service_id", unique: true, using: :btree
-  add_index "listeners", ["endpoint_id"], name: "index_listeners_on_endpoint_id", using: :btree
-  add_index "listeners", ["service_id"], name: "index_listeners_on_service_id", using: :btree
 
   create_table "oneoffs", force: :cascade do |t|
     t.string   "task_arn"
@@ -123,9 +118,8 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.text     "command"
+    t.index ["heritage_id"], name: "index_oneoffs_on_heritage_id", using: :btree
   end
-
-  add_index "oneoffs", ["heritage_id"], name: "index_oneoffs_on_heritage_id", using: :btree
 
   create_table "plugins", force: :cascade do |t|
     t.integer  "district_id"
@@ -133,9 +127,8 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.text     "plugin_attributes"
+    t.index ["district_id"], name: "index_plugins_on_district_id", using: :btree
   end
-
-  add_index "plugins", ["district_id"], name: "index_plugins_on_district_id", using: :btree
 
   create_table "port_mappings", force: :cascade do |t|
     t.integer  "host_port"
@@ -146,9 +139,8 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.datetime "updated_at",                            null: false
     t.string   "protocol"
     t.boolean  "enable_proxy_protocol", default: false
+    t.index ["service_id"], name: "index_port_mappings_on_service_id", using: :btree
   end
-
-  add_index "port_mappings", ["service_id"], name: "index_port_mappings_on_service_id", using: :btree
 
   create_table "releases", force: :cascade do |t|
     t.integer  "heritage_id"
@@ -157,9 +149,8 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.integer  "version"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.index ["heritage_id"], name: "index_releases_on_heritage_id", using: :btree
   end
-
-  add_index "releases", ["heritage_id"], name: "index_releases_on_heritage_id", using: :btree
 
   create_table "services", force: :cascade do |t|
     t.string   "name",                                    null: false
@@ -175,9 +166,9 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.boolean  "force_ssl"
     t.text     "hosts"
     t.text     "health_check"
+    t.text     "auto_scaling"
+    t.index ["heritage_id"], name: "index_services_on_heritage_id", using: :btree
   end
-
-  add_index "services", ["heritage_id"], name: "index_services_on_heritage_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"
@@ -186,20 +177,18 @@ ActiveRecord::Schema.define(version: 20161106141820) do
     t.datetime "updated_at", null: false
     t.text     "public_key"
     t.text     "roles"
+    t.index ["name"], name: "index_users_on_name", unique: true, using: :btree
+    t.index ["token_hash"], name: "index_users_on_token_hash", unique: true, using: :btree
   end
-
-  add_index "users", ["name"], name: "index_users_on_name", unique: true, using: :btree
-  add_index "users", ["token_hash"], name: "index_users_on_token_hash", unique: true, using: :btree
 
   create_table "users_districts", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "district_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["district_id"], name: "index_users_districts_on_district_id", using: :btree
+    t.index ["user_id"], name: "index_users_districts_on_user_id", using: :btree
   end
-
-  add_index "users_districts", ["district_id"], name: "index_users_districts_on_district_id", using: :btree
-  add_index "users_districts", ["user_id"], name: "index_users_districts_on_user_id", using: :btree
 
   add_foreign_key "endpoints", "districts"
   add_foreign_key "env_vars", "heritages"

--- a/spec/factories/districts.rb
+++ b/spec/factories/districts.rb
@@ -3,5 +3,7 @@ FactoryGirl.define do
     sequence :name do |n|
       "district#{n}"
     end
+    aws_access_key_id "aws_access_key_id"
+    aws_secret_access_key "aws_secret_access_key"
   end
 end

--- a/spec/models/district_spec.rb
+++ b/spec/models/district_spec.rb
@@ -8,15 +8,23 @@ describe District do
 
   describe "#validations" do
     let(:district) { build :district }
+
     before do
       allow(Rails).to receive_message_chain(:env, :test?) {
         false
       }
     end
-    context "when aws keys are nil" do
-      let(:district) { build :district }
+
+    context "when aws keys and role are nil" do
+      let(:district) { build :district, aws_role: nil, aws_access_key_id: nil, aws_secret_access_key: nil }
       it { expect(district).to_not be_valid }
     end
+
+    context "when role is present" do
+      let(:district) { build :district, aws_role: "role", aws_access_key_id: nil, aws_secret_access_key: nil }
+      it { expect(district).to be_valid }
+    end
+
     context "when aws keys are present" do
       let(:district) { build :district,
                              aws_access_key_id: "AWS_ACCESS_KEY_ID",


### PR DESCRIPTION
This is the last step to remove secret values from barcelona DB. Once this is merged Barcelona service/DB doesn't store any secret value (i.e. no need for data encryption)

This PR supports AWS STS "AssumeRole" API for calling AWS APIs to manipulate district.
Now Barcelona users can create a district without specifying AWS access keys like the below command:

```
$ bcn request post /districts '{"name": "district", "role": "arn:aws:iam::123456789012:role/role-to-be-assumed"}'
```

Instead of specifying AWS key, a user needs to specify "aws_role" which eventually assumes permissions to the Barcelona service role.

This way users no longer needs to get and set AWS access key to Barcelona so it's safer.

Note that `aws_access_key_id` and `aws_secret_access_key` still remain for development purpose but from now on "aws_role" is recommended way of creating a district