### PR TITLE
Fix DATABASE_URL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
+  url: <%= ENV["DATABASE_URL"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
database tasks such as `db:create` doesn't work without this fix when the DATABASE_URL is specified