### PR TITLE
Make force_ssl work again with ALB

### DIFF
--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -187,7 +187,8 @@ class HeritageTaskDefinition
       {name: "UPSTREAM_NAME", value: "backend"},
       {name: "UPSTREAM_PORT", value: web_container_port.to_s},
       {name: "DISABLE_PROXY_PROTOCOL", value: "true"},
-      {name: "FORCE_SSL", value: "false"}
+      {name: "FORCE_SSL", value: (!!force_ssl).to_s},
+      {name: "ALB", value: "true"}
     ].flatten
 
     base.merge(

--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -55,6 +55,14 @@ def download_s3(url, dest)
   )
 end
 
+def server_conf_template_path
+  if ENV['ALB'] == "true"
+    '/templates/alb_server.conf.erb'
+  else
+    '/templates/server.conf.erb'
+  end
+end
+
 render_template('/templates/nginx.conf.erb', '/etc/nginx/nginx.conf',
   upstream_name: ENV['UPSTREAM_NAME'],
   upstream_port: ENV['UPSTREAM_PORT']
@@ -84,15 +92,16 @@ hosts.each do |host|
     upstream_name: ENV['UPSTREAM_NAME'],
     upstream_port: ENV['UPSTREAM_PORT']
   )
-  render_template('/templates/server.conf.erb', "/etc/nginx/conf.d/#{host}.conf", decorator: decorator)
+  render_template(server_conf_template_path, "/etc/nginx/conf.d/#{host}.conf", decorator: decorator)
 end
 
 if hosts.empty?
   decorator = ServerDecorator.new(
     hostname: "_",
     proxy_protocol: !(ENV['DISABLE_PROXY_PROTOCOL'] == 'true'),
+    force_ssl: ENV['FORCE_SSL'] == 'true',
     upstream_name: ENV['UPSTREAM_NAME'],
     upstream_port: ENV['UPSTREAM_PORT']
   )
-  render_template('/templates/server.conf.erb', "/etc/nginx/conf.d/default.conf", decorator: decorator)
+  render_template(server_conf_template_path, "/etc/nginx/conf.d/default.conf", decorator: decorator)
 end

--- a/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
@@ -1,0 +1,36 @@
+# if user-agent is ELB health checker then nginx do not redirect
+# if originator protocol is https then nginx do not redirect
+# otherwise it redirects to https
+# i.e. if (user agent == health check && forwarded proto != https) then redirect
+map "$http_x_forwarded_proto:$http_user_agent" $redirect_to_https {
+  default 1;
+  "~*:ELB-HealthChecker" 0;
+  "~*^https:" 0;
+}
+
+server {
+  server_name <%= decorator.hostname %>;
+  listen 80 default_server;
+
+  <% if decorator.force_ssl %>
+  if ( $redirect_to_https ) {
+    return 301 https://$host$request_uri;
+  }
+  <% end %>
+
+  keepalive_timeout 5;
+
+  location / {
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+
+    proxy_read_timeout 60;
+    proxy_send_timeout 60;
+
+    proxy_pass http://<%= decorator.upstream_name %>;
+  }
+}


### PR DESCRIPTION
Currently Barcelona explicitly set `FORCE_SSL` environment variable to `false` if a service uses ALB because [the current nginx conf](https://github.com/degica/barcelona/blob/master/dockerfiles/reverse-proxy/templates/server.conf.erb) is not compatible with ALB that terminates HTTPS.

This PR adds a new nginx configuration file which is dedicated for ALB.

I tested this with my test barcelona app and it worked fine.

ref: [nginx map module](http://nginx.org/en/docs/http/ngx_http_map_module.html)