### PR TITLE
Use Shellwords to split command

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -18,7 +18,7 @@ class Heritage < ActiveRecord::Base
         heritage.scheduled_tasks.each_with_index do |s, i|
           event_name =  "ScheduledEvent#{i}"
           command = s["command"]
-          command = command.split(" ") if s["command"].is_a?(String)
+          command = Shellwords.split(command) if s["command"].is_a?(String)
           run_command = LaunchCommand.new(heritage, command,
                                           shell_format: false).to_command
           add_resource("AWS::Events::Rule", event_name) do |j|

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -46,7 +46,7 @@ class Oneoff < ActiveRecord::Base
   end
 
   def run_command
-    LaunchCommand.new(heritage, command.split(" "), shell_format: false).to_command
+    LaunchCommand.new(heritage, Shellwords.split(command), shell_format: false).to_command
   end
 
   def interactive_run_command


### PR DESCRIPTION
Previously Barcelona used `String#split` to split commands. this is troublesome in some cases as follows:

```
before_deploy: rails runner "puts :before_deploy"
```

the above command generates `["rails", "runner", "\"puts", ":before_deploy\""]` which eventually is passed to linux's `exec` system call and it doesn't work. The expected input is `["rails", "runner", "puts :before_deploy"]` and `Shellwords` does the trick.

`scheduled_tasks` also had the same issue so I fixed it as well

Thanks @essa for your advice!