### PR TITLE
Do not use create_or_update

### DIFF
--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -12,13 +12,15 @@ class ApplyDistrict
       generate_ssh_ca_key_pair
       create_ecs_cluster
     end
-    apply
+    district.save!
+    update_ecs_config
+    district.stack_executor.create
   end
 
   def apply
     district.save!
     update_ecs_config
-    create_or_update_network_stack
+    district.stack_executor.update
   end
 
   def destroy!


### PR DESCRIPTION
`create_or_update` could overwrite the existing CloudFormation stack that is not managed by Barcelona. Instead of `or update` now stack creation fails if a stack with the same name exists