### PR TITLE
Allow empty GitHub teams

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,13 +46,13 @@ class User < ActiveRecord::Base
   end
 
   def self.user_roles(user_teams)
-    user_teams.map{ |t| role_for(team: t.name, org: t.organization.login) }.compact
+    user_teams.map{ |t| roles_for(team: t.name, org: t.organization.login) }.flatten.uniq.compact
   end
 
-  def self.role_for(team:, org:)
-    allowed_teams.find { |t|
-      t[:team] == team && t[:org] == org
-    }&.dig(:role)
+  def self.roles_for(team:, org:)
+    allowed_teams.select { |t|
+      (t[:team] == team || t[:team] == nil) && t[:org] == org
+    }.map { |t| t[:role] }
   end
 
   def new_token!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,45 +4,93 @@ describe User do
   describe ".login!" do
     subject { User.login!("github_token") }
 
-    before do
-      allow(Octokit::Client).to receive(:new) { github_client }
-      allow(ENV).to receive(:[]).with('GITHUB_ORGANIZATION') { 'degica' }
-      allow(ENV).to receive(:[]).with('GITHUB_DEVELOPER_TEAM') { 'developers' }
-      allow(ENV).to receive(:[]).with('GITHUB_ADMIN_TEAM') { 'Admin developers' }
-    end
     let(:github_client) do
       double(user_teams: github_teams, user: double(login: "k2nr"))
     end
 
-    context "when a user belongs to a github admin team" do
-      let(:github_teams) do
-        [
-          double(name: "Admin developers", organization: double(login: "degica"))
-        ]
+    context "when teams are specified" do
+      before do
+        allow(Octokit::Client).to receive(:new) { github_client }
+        allow(ENV).to receive(:[]).with('GITHUB_ORGANIZATION') { 'degica' }
+        allow(ENV).to receive(:[]).with('GITHUB_DEVELOPER_TEAM') { 'developers' }
+        allow(ENV).to receive(:[]).with('GITHUB_ADMIN_TEAM') { 'Admin developers' }
+        allow(ENV).to receive(:[]).with('ENCRYPTION_KEY') { 'encryption' }
       end
-      its(:roles) { is_expected.to eq ["admin"] }
-      its(:token) { is_expected.to be_present }
+
+      context "when a user belongs to a github admin team" do
+        let(:github_teams) do
+          [
+            double(name: "Admin developers", organization: double(login: "degica"))
+          ]
+        end
+        its(:roles) { is_expected.to eq ["admin"] }
+        its(:token) { is_expected.to be_present }
+      end
+
+      context "when a user belongs to a github developers team" do
+        let(:github_teams) do
+          [
+            double(name: "developers", organization: double(login: "degica"))
+          ]
+        end
+        its(:roles) { is_expected.to eq ["developer"] }
+        its(:token) { is_expected.to be_present }
+      end
+
+      context "when a user doesn't belong to allowed github teams" do
+        let(:github_teams) do
+          [
+            double(name: "reviewers", organization: double(login: "degica"))
+          ]
+        end
+
+        it "raises an error" do
+          expect{subject}.to raise_error ExceptionHandler::Unauthorized
+        end
+      end
+
+      context "when a user doesn't belong to the organization" do
+        let(:github_teams) do
+          [
+            double(name: "Admin developers", organization: double(login: "other_org"))
+          ]
+        end
+
+        it "raises an error" do
+          expect{subject}.to raise_error ExceptionHandler::Unauthorized
+        end
+      end
     end
 
-    context "when a user belongs to a github developers team" do
+    context "when teams are not specified" do
+      before do
+        allow(Octokit::Client).to receive(:new) { github_client }
+        allow(ENV).to receive(:[]).with('GITHUB_ORGANIZATION') { 'degica' }
+        allow(ENV).to receive(:[]).with('GITHUB_DEVELOPER_TEAM') { nil }
+        allow(ENV).to receive(:[]).with('GITHUB_ADMIN_TEAM') { nil }
+        allow(ENV).to receive(:[]).with('ENCRYPTION_KEY') { 'encryption' }
+      end
+
       let(:github_teams) do
         [
+          double(name: "reviewers",  organization: double(login: "degica")),
           double(name: "developers", organization: double(login: "degica"))
         ]
       end
-      its(:roles) { is_expected.to eq ["developer"] }
+
+      its(:roles) { is_expected.to eq ["developer", "admin"] }
       its(:token) { is_expected.to be_present }
-    end
 
-    context "when a user doesn't belong to allowed github teams" do
-      let(:github_teams) do
-        [
-          double(name: "reviewers", organization: double(login: "degica"))
-        ]
-      end
+      context "when a user doesn't belong to the organization" do
+        let(:github_teams) do
+          [
+            double(name: "Admin developers", organization: double(login: "other_org"))
+          ]
+        end
 
-      it "raises an error" do
-        expect{subject}.to raise_error ExceptionHandler::Unauthorized
+        it "raises an error" do
+          expect{subject}.to raise_error ExceptionHandler::Unauthorized
+        end
       end
     end
   end


### PR DESCRIPTION
Currently there are 3 required environment variables to make Barcelona work

- `GITHUB_ORGANIZATION`
  - A GitHub organization which Barcelona users must belong to
- `GITHUB_DEVELOPER_TEAM`
  - Barcelona gives "developer" permission to users who belong to this team. (developer permission is a limited permission for example it can't update/delete VPC network stack)
- `GITHUB_ADMIN_TEAM`
  - Barcelona gives "admin" permission to users who belong to this team.

While this Authorization management is nice, it is hard for new users (who want to test Barcelona) to setup those team variables. In this PR I made those team variables optional.

Here's the new default behavior.
- If `GITHUB_DEVELOPER_TEAM` is `nil` all users who belong to `GITHUB_ORGANIZATION` has `developer` permission
- If `GITHUB_ADMIN_TEAM` is `nil` all users who belong to `GITHUB_ORGANIZATION` has `admin` permission