### PR TITLE
Add memory option to oneoff

### DIFF
--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -28,7 +28,8 @@ class OneoffsController < ApplicationController
 
   def create_params
     params.permit(
-      :command
+      :command,
+      :memory
     )
   end
 

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -24,7 +24,7 @@ class HeritageTaskDefinition
           "com.barcelona.oneoff-id" => oneoff.id.to_s
         },
         cpu: 128,
-        memory: 512)
+        memory: oneoff.memory)
   end
 
   def self.schedule_definition(heritage)

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -1,9 +1,17 @@
 class Oneoff < ActiveRecord::Base
   belongs_to :heritage
+
   validates :heritage, presence: true
+  validates :memory, numericality: {greater_than: 0, less_than_or_equal_to: 4096}, allow_nil: true
 
   delegate :district, to: :heritage
   delegate :aws, to: :district
+
+  attr_accessor :memory
+
+  after_initialize do |oneoff|
+    oneoff.memory ||= 512
+  end
 
   class ECSResourceError < RuntimeError
   end

--- a/app/serializers/oneoff_serializer.rb
+++ b/app/serializers/oneoff_serializer.rb
@@ -1,6 +1,6 @@
 class OneoffSerializer < ActiveModel::Serializer
   attributes :id, :task_arn, :command, :status, :exit_code, :reason,
-             :interactive_run_command, :container_instance_arn, :container_name
+             :interactive_run_command, :container_instance_arn, :container_name, :memory
 
   belongs_to :heritage
   belongs_to :district

--- a/spec/requests/create_oneoff_spec.rb
+++ b/spec/requests/create_oneoff_spec.rb
@@ -30,7 +30,8 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
     end
 
     params = {
-      command: "rake db:migrate"
+      command: "rake db:migrate",
+      memory: 1024
     }
     api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
     expect(response).to be_success
@@ -39,6 +40,7 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
     expect(oneoff["container_instance_arn"]).to eq "container_instance_arn"
     expect(oneoff["exit_code"]).to eq nil
     expect(oneoff["command"]).to eq "rake db:migrate"
+    expect(oneoff["memory"]).to eq 1024
   end
 
   context "when interactive oneoff is requested" do


### PR DESCRIPTION
This allows to specify memory size for oneoff memory size. Typical (and currently only) use case is when you use `bcn run` to run something heavy, the default 512MB may be not enough so you want to do like this

```
$ bcn run -e production --memory 1024 rails c
```

I'll add this option to barcelona client