### PR TITLE
Handle empty array correctly

### DIFF
--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -15,7 +15,7 @@ class BuildHeritage
       new_params[:services_attributes].each do |service|
         service[:port_mappings_attributes] = service.delete(:port_mappings) if service[:port_mappings].present?
 
-        if service[:listeners].present?
+        unless service[:listeners].nil?
           listener_map = Hash[Endpoint.where(name: service[:listeners].map { |e| e[:endpoint] }).pluck(:name, :id)]
           service[:listeners_attributes] = service.delete(:listeners).map do |listener|
             {

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -248,17 +248,34 @@ describe BuildHeritage do
     end
 
     context "deleting listeners" do
-      before do
-        new_params = params.dup
-        new_params[:services][0].delete(:listeners)
-        @updated_heritage = BuildHeritage.new(new_params).execute
-        @updated_heritage.save!
+      context "when listeners is nil" do
+        before do
+          new_params = params.dup
+          new_params[:services][0].delete :listeners
+          @updated_heritage = BuildHeritage.new(new_params).execute
+          @updated_heritage.save!
+        end
+
+        it "deletes listners" do
+          service1 = @updated_heritage.services.first
+          expect(service1).to be_present
+          expect(service1.listeners.count).to eq 0
+        end
       end
 
-      it "deletes listners" do
-        service1 = @updated_heritage.services.first
-        expect(service1).to be_present
-        expect(service1.listeners.count).to eq 0
+      context "when listeners is nil" do
+        before do
+          new_params = params.dup
+          new_params[:services][0][:listeners] = []
+          @updated_heritage = BuildHeritage.new(new_params).execute
+          @updated_heritage.save!
+        end
+
+        it "deletes listners" do
+          service1 = @updated_heritage.services.first
+          expect(service1).to be_present
+          expect(service1.listeners.count).to eq 0
+        end
       end
     end
   end


### PR DESCRIPTION
`listeners: null` and `listeners: []` in JSON should be handled same internally but currently barcelona raises an exception if `listeners: []`. This PR fixes the issue