### PR TITLE
Set X-Forwarded-Port on reverse-proxy

### DIFF
--- a/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
@@ -25,6 +25,7 @@ server {
     proxy_set_header Connection "upgrade";
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port  $http_x_forwarded_port;
     proxy_set_header Host $http_host;
     proxy_redirect off;
 

--- a/dockerfiles/reverse-proxy/templates/server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/server.conf.erb
@@ -42,9 +42,11 @@ server {
     proxy_set_header X-Real-IP         $proxy_protocol_addr;
     proxy_set_header X-Forwarded-For   $proxy_protocol_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port  $proxy_protocol_port;
     <% else %>
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Port  $http_x_forwarded_port;
     <% end %>
     proxy_set_header Host $http_host;
     proxy_redirect off;


### PR DESCRIPTION
When proxy_protocol is used, the port no used by ELB to accept client connection, is lost for applications behind reverse-proxy. This port number is rarely used but I think reverse-proxy should set it to `X-Forwarded-Port`.

For example, [Rack::Request#port](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L238) will return 80 even if proxy accepts request on non-standard port. And [OmniAuth has similar problem](http://stackoverflow.com/questions/6803307/omniauth-using-wrong-callback-port-in-a-reverse-proxy-setup#7135029).

And this is also consistent with [behavior of ELB http forwarding](http://docs.aws.amazon.com/ja_jp/elasticloadbalancing/latest/classic/x-forwarded-headers.html#x-forwarded-port)

When proxy_protocol is off, the ELB sets `X-Forwarded-Port` as well as `X-Forwarded-Proto`. So reverse-proxy doesn't need to set these two headers. I added X-Forwarded-Port to emphasize that these three headers are always set with or without proxy protocol.

