### PR TITLE
Add user option to oneoff

### DIFF
--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -29,7 +29,8 @@ class OneoffsController < ApplicationController
   def create_params
     params.permit(
       :command,
-      :memory
+      :memory,
+      :user
     )
   end
 

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -1,5 +1,5 @@
 class HeritageTaskDefinition
-  attr_accessor :heritage, :cpu, :memory, :family_name, :command, :port_mappings, :container_defintions, :force_ssl, :hosts, :reverse_proxy_image, :mode
+  attr_accessor :heritage, :user, :cpu, :memory, :family_name, :command, :port_mappings, :container_defintions, :force_ssl, :hosts, :reverse_proxy_image, :mode
   delegate :district, to: :heritage
 
   def self.service_definition(service)
@@ -24,7 +24,9 @@ class HeritageTaskDefinition
           "com.barcelona.oneoff-id" => oneoff.id.to_s
         },
         cpu: 128,
-        memory: oneoff.memory)
+        memory: oneoff.memory,
+        user: oneoff.user
+       )
   end
 
   def self.schedule_definition(heritage)
@@ -71,9 +73,10 @@ class HeritageTaskDefinition
     end
   end
 
-  def initialize(heritage:, family_name:, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil)
+  def initialize(heritage:, family_name:, user: nil, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil)
     @heritage = heritage
     @family_name = family_name
+    @user = user
     @cpu = cpu
     @memory = memory
     @command = command
@@ -126,6 +129,7 @@ class HeritageTaskDefinition
     ).compact
     base[:command] = LaunchCommand.new(heritage, command).to_command if command.present?
     base[:port_mappings] = port_mappings.to_task_definition if port_mappings.present?
+    base[:user] = user if user.present?
     base
   end
 

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -7,7 +7,7 @@ class Oneoff < ActiveRecord::Base
   delegate :district, to: :heritage
   delegate :aws, to: :district
 
-  attr_accessor :memory
+  attr_accessor :memory, :user
 
   after_initialize do |oneoff|
     oneoff.memory ||= 512

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -194,6 +194,13 @@ describe HeritageTaskDefinition do
                               ]
                            })
     end
+
+    context "when user is specified" do
+      it "sets user to task definition" do
+        oneoff.user = "user"
+        expect(subject[:container_definitions][0][:user]).to eq("user")
+      end
+    end
   end
 
   describe ".schedule_definition" do


### PR DESCRIPTION
Fix #345

This supports `--user` option for `bcn run` e.g. `bcn run -e production --user root bash`

The `--user` option is already supported in the new client (which I will announce soon)