### PR TITLE
Tweak health check configuration

### DIFF
--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -171,6 +171,7 @@ module Backend::Ecs::V2
           j.VpcId district.vpc_id
           j.HealthCheckIntervalSeconds listener.health_check_interval
           j.HealthCheckPath listener.health_check_path
+          j.HealthyThresholdCount 2
           j.Matcher do |j|
             j.HttpCode "200-299"
           end

--- a/app/models/listener.rb
+++ b/app/models/listener.rb
@@ -6,7 +6,7 @@ class Listener < ActiveRecord::Base
   serialize :rule_conditions, JsonWithIndifferentAccess
 
   after_initialize do |lis|
-    lis.health_check_interval ||= 30
+    lis.health_check_interval ||= 10
     lis.health_check_path ||= '/'
     lis.rule_conditions ||= [{type: "path-pattern", value: "*"}]
     lis.rule_priority ||= 100

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -241,7 +241,7 @@ describe BuildHeritage do
         service1 = @updated_heritage.services.first
         expect(service1).to be_present
         expect(service1.listeners.count).to eq 1
-        expect(service1.listeners.first.health_check_interval).to eq 30
+        expect(service1.listeners.first.health_check_interval).to eq 10
         expect(service1.listeners.first.health_check_path).to eq "/"
         expect(service1.listeners.first.endpoint.name).to eq endpoint2.name
       end


### PR DESCRIPTION
Changed as follows

- default health check interval 30s -> 10s
- healthy threshold 5 -> 2

The current configuration (30s * 5) makes deploy slower because it takes at least 2 mintues that a new container becomes healthy. with the new configuration deploy takes 10s at minimum