### PR TITLE
Publish SNS without creating event

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -4,32 +4,32 @@ class DeployRunnerJob < ActiveJob::Base
   def perform(heritage, without_before_deploy:, description: "")
     heritage.with_lock do
       if other_deploy_in_progress?(heritage)
-        heritage.events.create(level: :error, message: "The other deployment is in progress. Stopped deploying.")
+        notify(heritage, level: :error, message: "The other deployment is in progress. Stopped deploying.")
         return
       end
 
-      heritage.events.create(level: :good, message: "Deploying to #{heritage.district.name} district: #{description}")
+      notify(heritage, message: "Deploying to #{heritage.district.name} district: #{description}")
       before_deploy = heritage.before_deploy
       if before_deploy.present? && !without_before_deploy
         oneoff = heritage.oneoffs.create!(command: before_deploy)
         oneoff.run!(sync: true)
         if oneoff.exit_code != 0
-          heritage.events.create(level: :error, message: "The command `#{before_deploy}` failed. Stopped deploying.")
+          notify(heritage, level: :error, message: "The command `#{before_deploy}` failed. Stopped deploying.")
           return
         else
-          heritage.events.create(level: :good, message:  "before_deploy script `#{before_deploy}` successfully finished")
+          notify(heritage, message: "before_deploy script `#{before_deploy}` successfully finished")
         end
       end
 
       heritage.services.each do |service|
-        Rails.logger.info "Updating service #{service.service_name} ..."
         begin
           result = service.apply
           MonitorDeploymentJob.perform_later(service, deployment_id: result[:deployment_id])
         rescue => e
           Rails.logger.error "#{e.class}: #{e.message}"
           Rails.logger.error e.backtrace.join("\n")
-          heritage.events.create(
+          notify(
+            heritage,
             level: :error,
             message: "Deploy failed: Something went wrong with deploying #{service.name} service"
           )
@@ -39,11 +39,15 @@ class DeployRunnerJob < ActiveJob::Base
   rescue => e
     # Retrying failing deployment doesn't make any sense.
     # Just stop the deployment and let users know it thorough notification
-    heritage.events.create(level: :error, message: "Error occurred: #{e.message}")
+    notify(heritage, level: :error, message: "Error occurred: #{e.message}")
   end
 
   def other_deploy_in_progress?(heritage)
     return false if heritage.version == 1
     heritage.services.map { |s| !s.deployment_finished?(nil) }.any?
+  end
+
+  def notify(heritage, level: :good, message:)
+    Event.new(heritage.district).notify(level: level, message: "[#{heritage.name}] #{message}")
   end
 end

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -3,14 +3,18 @@ class MonitorDeploymentJob < ActiveJob::Base
 
   def perform(service, count: 0, deployment_id: nil)
     if service.deployment_finished?(deployment_id)
-      service.heritage.events.create!(level: :good, message: "#{service.name} service deployed")
+      notify(service, message: "#{service.name} service deployed")
     elsif count > 200
       # deploys not finished after 1000 seconds are marked as timeout
-      service.heritage.events.create!(level: :error, message: "Deploying #{service.name} service has not finished for a while.")
+      notify(service, level: :error, message: "Deploying #{service.name} service has not finished for a while.")
     else
       MonitorDeploymentJob.set(wait: 5.seconds).perform_later(service,
                                                               count: count + 1,
                                                               deployment_id: deployment_id)
     end
+  end
+
+  def notify(service, level: :good, message:)
+    Event.new(service.district).notify(level: level, message: "[#{service.heritage.name}] #{message}")
   end
 end

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -159,7 +159,6 @@ class Heritage < ActiveRecord::Base
   has_many :services, inverse_of: :heritage, dependent: :destroy
   has_many :env_vars, dependent: :destroy
   has_many :oneoffs, dependent: :destroy
-  has_many :events, dependent: :destroy
   has_many :releases, -> { order 'version DESC' }, dependent: :destroy, inverse_of: :heritage
   belongs_to :district, inverse_of: :heritages
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170228141152) do
+ActiveRecord::Schema.define(version: 20170315092538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,17 +68,6 @@ ActiveRecord::Schema.define(version: 20170228141152) do
     t.boolean "secret",          default: false
     t.index ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true, using: :btree
     t.index ["heritage_id"], name: "index_env_vars_on_heritage_id", using: :btree
-  end
-
-  create_table "events", force: :cascade do |t|
-    t.string   "uuid"
-    t.integer  "heritage_id"
-    t.text     "message"
-    t.string   "level"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["heritage_id"], name: "index_events_on_heritage_id", using: :btree
-    t.index ["uuid"], name: "index_events_on_uuid", unique: true, using: :btree
   end
 
   create_table "heritages", force: :cascade do |t|
@@ -198,7 +187,6 @@ ActiveRecord::Schema.define(version: 20170228141152) do
 
   add_foreign_key "endpoints", "districts"
   add_foreign_key "env_vars", "heritages"
-  add_foreign_key "events", "heritages"
   add_foreign_key "heritages", "districts"
   add_foreign_key "listeners", "endpoints"
   add_foreign_key "listeners", "services"


### PR DESCRIPTION
Second step to make notifications district-level. This PR changes `Event` model to be a normal ruby class so `events` table is no longer needed. `events` table has existed since the beginning but has never been useful. I think logging events to STDOUT and sending it to SNS is enough