### PR TITLE
Don't delete ECS cluster when destroying district

### DIFF
--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -39,7 +39,6 @@ class ApplyDistrict
 
   def destroy!
     district.destroy!
-    delete_ecs_cluster
   end
 
   def generate_ssh_ca_key_pair
@@ -103,10 +102,6 @@ class ApplyDistrict
 
   def create_or_update_network_stack
     district.stack_executor.create_or_update
-  end
-
-  def delete_ecs_cluster
-    aws.ecs.delete_cluster(cluster: district.name)
   end
 
   def create_district_role(access_key_id, secret_access_key)


### PR DESCRIPTION
When testing with AWS environment, deleting a district always failed because it tries to delete ECS cluster. Typically ECS cluster cannot be deleted at this time because

- Container instance count must be 0 before deleting a cluster
- Running task count must be 0 before deleting a cluster

ECS cluster is free of charge so there's no reason to delete it when destroying a district