### PR TITLE
Fix a bug where dockercfg is not updated

### DIFF
--- a/app/controllers/districts_controller.rb
+++ b/app/controllers/districts_controller.rb
@@ -66,7 +66,7 @@ class DistrictsController < ApplicationController
       :aws_access_key_id,
       :aws_secret_access_key
     ).tap do |whitelisted|
-      whitelisted[:dockercfg] = params[:dockercfg] if params[:dockercfg].present?
+      whitelisted[:dockercfg] = params[:dockercfg].permit! if params[:dockercfg].present?
     end
   end
 

--- a/spec/requests/update_district_spec.rb
+++ b/spec/requests/update_district_spec.rb
@@ -14,8 +14,28 @@ describe "PATCH /districts/:district", type: :request do
   context "when a user is an admin" do
     let(:user) { create :user, roles: ["admin"] }
     it "udpates a district" do
-      api_request :patch, "/v1/districts/#{district.name}"
+      dockercfg = {
+        "auths" => {
+          "quay.io" => {
+            "auth" => "abcdefgh"
+          }
+        }
+      }
+
+      params = {
+        cluster_size: 10,
+        cluster_instance_type: "m4.large",
+        dockercfg: dockercfg
+      }
+
+      api_request :patch, "/v1/districts/#{district.name}", params
       expect(response.status).to eq 200
+
+      district.reload
+
+      expect(district.cluster_size).to eq 10
+      expect(district.cluster_instance_type).to eq "m4.large"
+      expect(district.dockercfg).to eq dockercfg
     end
 
     context "when running in ECS environment" do


### PR DESCRIPTION
Seems updating dockercfg has not been working since the rails5 upgrade. I also updated the request spec to test dockercfg parameter.