### PR TITLE
Install AWS Inspector agent and harden sshd config

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -42,7 +42,10 @@ class ContainerInstance
       "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
       'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
       'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
-      "service awslogs start"
+      "service awslogs start",
+
+      # Install AWS Inspector agent
+      "curl https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install | bash"
     ]
 
     user_data.add_file("/etc/ssh/ssh_ca_key.pub", "root:root", "644", district.ssh_format_ca_public_key)

--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -31,6 +31,7 @@ class ContainerInstance
 
       # Configure sshd
       'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
+      'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',
       "service sshd restart",
 
       "chkconfig --add barcelona",

--- a/lib/barcelona/network/bastion_server.rb
+++ b/lib/barcelona/network/bastion_server.rb
@@ -49,7 +49,8 @@ module Barcelona
         ud.add_file("/etc/ssh/ssh_ca_key.pub", "root:root", "644", district.ssh_format_ca_public_key)
         ud.run_commands += [
           'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
-          "service sshd restart"
+          'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',
+          "service sshd restart",
         ]
         ud.build
       end

--- a/lib/barcelona/network/bastion_server.rb
+++ b/lib/barcelona/network/bastion_server.rb
@@ -51,6 +51,9 @@ module Barcelona
           'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
           'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',
           "service sshd restart",
+
+          # Install AWS Inspector agent
+          "curl https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install | bash"
         ]
         ud.build
       end


### PR DESCRIPTION
Fixes #308

This PR changes barcelona to install AWS Inspector agent when an instance launches. Currently Barcelona do not use Inspector but just installs the agent so that an infra administrator can run inspector against Barcelona instances without updating instances' userdata.

I also updated `/etc/ssh/sshd_config` to disable root login via SSH. this was found by Inspector when I ran it.

Ref: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_working-with-agents.html