### PR TITLE
Limit bastion and ELBs' outbound ports

### DIFF
--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -140,6 +140,14 @@ module Barcelona
           ]
         end
 
+        add_resource("AWS::EC2::SecurityGroupEgress", "PublicELBSecurityGroupEgress") do |j|
+          j.GroupId ref("PublicELBSecurityGroup")
+          j.IpProtocol "tcp"
+          j.FromPort 1
+          j.ToPort 65535
+          j.SourceSecurityGroupId ref("InstanceSecurityGroup")
+        end
+
         add_resource("AWS::EC2::SecurityGroup", "PrivateELBSecurityGroup") do |j|
           j.GroupDescription "SG for Private ELB"
           j.VpcId ref("VPC")
@@ -154,6 +162,14 @@ module Barcelona
           j.Tags [
             tag("barcelona", stack.district.name)
           ]
+        end
+
+        add_resource("AWS::EC2::SecurityGroupEgress", "PrivateELBSecurityGroupEgress") do |j|
+          j.GroupId ref("PrivateELBSecurityGroup")
+          j.IpProtocol "tcp"
+          j.FromPort 1
+          j.ToPort 65535
+          j.SourceSecurityGroupId ref("InstanceSecurityGroup")
         end
 
         add_resource("AWS::EC2::SecurityGroup", "ContainerInstanceAccessibleSecurityGroup") do |j|

--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -231,10 +231,28 @@ module Barcelona
           ]
           j.SecurityGroupEgress [
             {
-              "IpProtocol" => -1,
-              "FromPort" => -1,
-              "ToPort" => -1,
-              "CidrIp" => "0.0.0.0/0"
+              "IpProtocol" => "udp",
+              "FromPort" => 123,
+              "ToPort" => 123,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 22,
+              "ToPort" => 22,
+              "CidrIp" => options[:cidr_block]
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 80,
+              "ToPort" => 80,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 443,
+              "ToPort" => 443,
+              "CidrIp" => '0.0.0.0/0'
             }
           ]
           j.Tags [

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -69,6 +69,16 @@ describe Barcelona::Network::NetworkStack do
           "Tags" => [{"Key" => "barcelona", "Value" => district.name}],
         }
       },
+      "PublicELBSecurityGroupEgress" => {
+        "Type" => "AWS::EC2::SecurityGroupEgress",
+        "Properties" => {
+          "GroupId" => {"Ref" => "PublicELBSecurityGroup"},
+          "IpProtocol" => "tcp",
+          "FromPort" => 1,
+          "ToPort" => 65535,
+          "SourceSecurityGroupId" => {"Ref" => "InstanceSecurityGroup"}
+        }
+      },
       "PrivateELBSecurityGroup" => {
         "Type" => "AWS::EC2::SecurityGroup",
         "Properties" => {"GroupDescription" => "SG for Private ELB",
@@ -80,6 +90,16 @@ describe Barcelona::Network::NetworkStack do
                             "CidrIp" => district.cidr_block}],
                           "Tags" => [{"Key" => "barcelona", "Value" => district.name}],
                         }
+      },
+      "PrivateELBSecurityGroupEgress" => {
+        "Type" => "AWS::EC2::SecurityGroupEgress",
+        "Properties" => {
+          "GroupId" => {"Ref" => "PrivateELBSecurityGroup"},
+          "IpProtocol" => "tcp",
+          "FromPort" => 1,
+          "ToPort" => 65535,
+          "SourceSecurityGroupId" => {"Ref" => "InstanceSecurityGroup"}
+        }
       },
       "ContainerInstanceAccessibleSecurityGroup" => {
         "Type" => "AWS::EC2::SecurityGroup",
@@ -192,10 +212,23 @@ describe Barcelona::Network::NetworkStack do
              "ToPort" => 123,
              "CidrIp" => district.cidr_block}],
           "SecurityGroupEgress" => [
-            {"IpProtocol" => -1,
-             "FromPort" => -1,
-             "ToPort" => -1,
-             "CidrIp" => "0.0.0.0/0"}],
+            {"IpProtocol" => "udp",
+             "FromPort" => 123,
+             "ToPort" => 123,
+             "CidrIp" => "0.0.0.0/0"},
+            {"IpProtocol" => "tcp",
+             "FromPort" => 22,
+             "ToPort" => 22,
+             "CidrIp" => district.cidr_block},
+            {"IpProtocol" => "tcp",
+             "FromPort" => 80,
+             "ToPort" => 80,
+             "CidrIp" => "0.0.0.0/0"},
+            {"IpProtocol" => "tcp",
+             "FromPort" => 443,
+             "ToPort" => 443,
+             "CidrIp" => "0.0.0.0/0"},
+          ],
           "Tags" => [{"Key" => "barcelona", "Value" => district.name}]
         }
       },


### PR DESCRIPTION
For ELB, I followed [this best practice](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html) with modification that all TCP ports are allowed for container instances.


