### PR TITLE
Better instance replacement 2nd step

### DIFF
--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -11,6 +11,10 @@ module Barcelona
           j.DesiredCapacity desired_capacity
           j.Cooldown 0
           j.HealthCheckGracePeriod 0
+          # * 2: When instances are being replaced, instance count temporarily becomes
+          #      desired_count * 2
+          # + 1: There's a limitation "MinInstancesInService must be less than the autoscaling group's MaxSize"
+          #      without + 1, ASG cannot satisfy this requirement when desired_count == 0
           j.MaxSize(desired_capacity * 2 + 1)
           j.MinSize desired_capacity
           j.HealthCheckType "EC2"

--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -11,7 +11,7 @@ module Barcelona
           j.DesiredCapacity desired_capacity
           j.Cooldown 0
           j.HealthCheckGracePeriod 0
-          j.MaxSize(desired_capacity + 1)
+          j.MaxSize(desired_capacity * 2 + 1)
           j.MinSize desired_capacity
           j.HealthCheckType "EC2"
           j.LaunchConfigurationName ref("ContainerInstanceLaunchConfiguration")
@@ -37,10 +37,8 @@ module Barcelona
 
         json.UpdatePolicy do |j|
           j.AutoScalingRollingUpdate do |j|
-            j.MaxBatchSize 1
+            j.MaxBatchSize(desired_capacity > 0 ? desired_capacity : 1)
             j.MinInstancesInService desired_capacity
-            j.WaitOnResourceSignals true
-            j.PauseTime "PT60M"
           end
         end
       end

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -160,19 +160,6 @@ module Barcelona
 
       def instance_user_data
         user_data = options[:container_instance].user_data
-        user_data.run_commands += [
-          "start ecs",
-          "sleep 10", # Wait for ecs agent to be running
-          "ecs_cluster=$(curl http://localhost:51678/v1/metadata | jq -r .Cluster)",
-          # Wait for all tasks in the cluster to be running
-          "while : ; do",
-          "  pending_tasks_count=$(aws ecs describe-clusters --region=$AWS_REGION --clusters=$ecs_cluster | jq -r .clusters[0].pendingTasksCount)",
-          "  [[ $pending_tasks_count -eq 0 ]] && break",
-          "  sleep 3",
-          "done",
-          "sleep 30", # Wait for services to be attached to ELB
-          "/opt/aws/bin/cfn-signal -e $? --region $AWS_REGION --stack #{stack.name} --resource ContainerInstanceAutoScalingGroup || true"
-        ]
         user_data.build
       end
 

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -115,7 +115,7 @@ describe Barcelona::Network::NetworkStack do
           "DesiredCapacity" => 1,
           "Cooldown" => 0,
           "HealthCheckGracePeriod" => 0,
-          "MaxSize" => 2,
+          "MaxSize" => 3,
           "MinSize" => 1,
           "HealthCheckType" => "EC2",
           "LaunchConfigurationName" => {"Ref" => "ContainerInstanceLaunchConfiguration"},
@@ -132,9 +132,7 @@ describe Barcelona::Network::NetworkStack do
         "UpdatePolicy" => {
           "AutoScalingRollingUpdate" => {
             "MaxBatchSize" => 1,
-            "MinInstancesInService" => 1,
-            "WaitOnResourceSignals" => true,
-            "PauseTime" => "PT60M"
+            "MinInstancesInService" => 1
           }
         }
       },


### PR DESCRIPTION
This PR Changes the instance replacement strategy to https://aws.amazon.com/blogs/compute/how-to-automate-container-instance-draining-in-amazon-ecs/

This change should be applied in 2 steps

1. Add new resources (lifecycle hook and its lambda)
2. Remove the old script that checks current ECS status and increase rolling update batch size

This 2-step apply is needed because if we apply both changes at the same time, the lifecycle hook is not triggered (since it's being added and not ready) so ASG terminates old instances immediately