### PR TITLE
Manage bastion servers as AutoScalingGroup

### DIFF
--- a/lib/barcelona/network/bastion_auto_scaling.rb
+++ b/lib/barcelona/network/bastion_auto_scaling.rb
@@ -1,0 +1,44 @@
+module Barcelona
+  module Network
+    class BastionAutoScaling < CloudFormation::Resource
+      def self.type
+        "AWS::AutoScaling::AutoScalingGroup"
+      end
+
+      def define_resource(j)
+        super
+        j.Properties do |j|
+          j.DesiredCapacity 1
+          j.MaxSize 1
+          j.MinSize 1
+          j.HealthCheckType "EC2"
+          j.LaunchConfigurationName ref("BastionLaunchConfiguration")
+          j.VPCZoneIdentifier [ref("SubnetDmz1"), ref("SubnetDmz2")]
+          j.Tags [
+            {
+              "Key" => "Name",
+              "Value" => "barcelona-#{options[:district_name]}-bastion",
+              "PropagateAtLaunch" => true
+            },
+            {
+              "Key" => "barcelona",
+              "Value" => options[:district_name],
+              "PropagateAtLaunch" => true
+            },
+            {
+              "Key" => "barcelona-role",
+              "Value" => "bastion",
+              "PropagateAtLaunch" => true
+            }
+          ]
+        end
+
+        j.UpdatePolicy do |j|
+          j.AutoScalingReplacingUpdate do |j|
+            j.WillReplace true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -4,16 +4,20 @@ module Barcelona
       # https://aws.amazon.com/amazon-linux-ami/
       # Amazon Linux AMI 2016.09.0
       AMI_IDS = {
-        "us-east-1" => "ami-c481fad3",
-        "us-east-2" => "ami-71ca9114",
-        "us-west-1" => "ami-de347abe",
-        "us-west-2" => "ami-b04e92d0",
-        "eu-west-1" => "ami-d41d58a7",
-        "eu-central-1" => "ami-0044b96f",
-        "ap-northeast-1" => "ami-1a15c77b",
-        "ap-southeast-1" => "ami-7243e611",
-        "ap-southeast-2" => "ami-55d4e436",
-        "ca-central-1" => "ami-b48b39d0"
+        "us-east-1" => "ami-c58c1dd3",
+        "us-east-2" => "ami-4191b524",
+        "us-west-1" => "ami-7a85a01a",
+        "us-west-2" => "ami-4836a428",
+        "eu-west-1" => "ami-01ccc867",
+        "eu-west-2" => "ami-b6daced2",
+        "eu-central-1" => "ami-b968bad6",
+        "ap-northeast-1" => "ami-923d12f5",
+        "ap-northeast-2" => "ami-9d15c7f3",
+        "ap-southeast-1" => "ami-fc5ae39f",
+        "ap-southeast-2" => "ami-162c2575",
+        "ap-south-1" => "ami-52c7b43d",
+        "ca-central-1" => "ami-0bd66a6f",
+        "sa-east-1" => "ami-37cfad5b"
       }
 
       def build_resources

--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -294,9 +294,7 @@ module Barcelona
           ]
         end
 
-        add_resource(BastionServer, "BastionServer",
-                     district: stack.district,
-                     depends_on: ["VPCGatewayAttachment"])
+        add_builder BastionBuilder.new(options[:autoscaling])
 
         add_resource("AWS::IAM::Role", "ECSServiceRole") do |j|
           j.AssumeRolePolicyDocument do |j|

--- a/lib/barcelona/plugins/logentries_plugin.rb
+++ b/lib/barcelona/plugins/logentries_plugin.rb
@@ -25,12 +25,12 @@ module Barcelona
       end
 
       def on_network_stack_template(_stack, template)
-        bastion_server = template["BastionServer"]
-        return template if bastion_server.nil?
+        bastion_lc = template["BastionLaunchConfiguration"]
+        return template if bastion_lc.nil?
 
-        user_data = InstanceUserData.load_or_initialize(bastion_server["Properties"]["UserData"])
+        user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
         update_user_data(user_data, "bastion")
-        bastion_server["Properties"]["UserData"] = user_data.build
+        bastion_lc["Properties"]["UserData"] = user_data.build
         template
       end
 

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -668,13 +668,13 @@ EOS
       end
 
       def on_network_stack_template(_stack, template)
-        bastion_server = template["BastionServer"]
-        return template if bastion_server.nil?
+        bastion_lc = template["BastionLaunchConfiguration"]
+        return template if bastion_lc.nil?
 
-        user_data = InstanceUserData.load_or_initialize(bastion_server["Properties"]["UserData"])
+        user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
         user_data.packages += SYSTEM_PACKAGES
         user_data.run_commands += run_commands
-        bastion_server["Properties"]["UserData"] = user_data.build
+        bastion_lc["Properties"]["UserData"] = user_data.build
         template
       end
 

--- a/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
@@ -43,7 +43,7 @@ module Barcelona
 
       it "gets hooked with network_stack_template trigger" do
         template = JSON.load(::Barcelona::Network::NetworkStack.new(district).target!)
-        user_data = InstanceUserData.load(template["Resources"]["BastionServer"]["Properties"]["UserData"])
+        user_data = InstanceUserData.load(template["Resources"]["BastionLaunchConfiguration"]["Properties"]["UserData"])
         expect(user_data.packages).to include(*described_class::SYSTEM_PACKAGES)
         expect(user_data.run_commands).to include(*described_class::RUN_COMMANDS)
       end

--- a/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
@@ -60,7 +60,7 @@ module Barcelona
       it "gets hooked with network_stack_template trigger" do
         district.save!
         template = JSON.load(::Barcelona::Network::NetworkStack.new(district).target!)
-        user_data = InstanceUserData.load(template["Resources"]["BastionServer"]["Properties"]["UserData"])
+        user_data = InstanceUserData.load(template["Resources"]["BastionLaunchConfiguration"]["Properties"]["UserData"])
         plugin = district.plugins.find_by(name: 'pcidss').plugin
         expect(user_data.packages).to include(*described_class::SYSTEM_PACKAGES)
         expect(user_data.run_commands).to include(*plugin.run_commands)


### PR DESCRIPTION
This PR makes bastion servers be managed by AutoScalingGroup. Previously a bastion server is launched as a plain "EC2::Instance" resource by CloudFormation. This way has some problems:

- If the bastion server crashes there's no way to recover it except manual way and if the bastion server is recovered manually, the server no longer belongs to the CloudFormation stack
- When we updates bastion server's UserData, CloudFormation only updates the running instance's UserData if a bastion server is managed as `EC2::Instance`. To run UserData's init script, we need to recreate the bastion server, which causes the first problem

Using AutoScalingGroup solves both problems. The name of "AutoScaling" is very confusing in this aspect; For bastion servers, ASG is not for "scaling" but for high availability and easy-to-replace capability.