### PR TITLE
Healthcheck options

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -102,6 +102,9 @@ class HeritagesController < ApplicationController
             :endpoint,
             :health_check_interval,
             :health_check_path,
+            :health_check_timeout,
+            :healthy_threshold_count,
+            :unhealthy_threshold_count,
             :rule_priority,
             rule_conditions: [
               :type,

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -8,20 +8,20 @@ class HeritagesController < ApplicationController
   end
 
   def show
-    render json: @heritage
+    render json: @heritage, include: "services,services.listeners"
   end
 
   def create
     @heritage = BuildHeritage.new(permitted_params, district: @district).execute
     @heritage.save_and_deploy!(without_before_deploy: true, description: "Create")
-    render json: @heritage
+    render json: @heritage, include: "services,services.listeners"
   end
 
   def update
     @heritage = BuildHeritage.new(permitted_params).execute
     @heritage.save_and_deploy!(without_before_deploy: false,
                                description: "Update to #{@heritage.image_path}")
-    render json: @heritage
+    render json: @heritage, include: "services,services.listeners"
   end
 
   def destroy

--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -171,7 +171,9 @@ module Backend::Ecs::V2
           j.VpcId district.vpc_id
           j.HealthCheckIntervalSeconds listener.health_check_interval
           j.HealthCheckPath listener.health_check_path
-          j.HealthyThresholdCount 2
+          j.HealthCheckTimeoutSeconds listener.health_check_timeout
+          j.HealthyThresholdCount listener.healthy_threshold_count
+          j.UnhealthyThresholdCount listener.unhealthy_threshold_count
           j.Matcher do |j|
             j.HttpCode "200-299"
           end

--- a/app/models/listener.rb
+++ b/app/models/listener.rb
@@ -2,13 +2,31 @@ class Listener < ActiveRecord::Base
   belongs_to :endpoint, required: true, inverse_of: :listeners
   belongs_to :service, required: true, inverse_of: :listeners
   validates :endpoint_id, uniqueness: {scope: :service_id}
+  validates :health_check_interval,
+            numericality: {greater_than_or_equal_to: 5, less_than_or_equal_to: 300}
+  validates :health_check_timeout,
+            numericality: {greater_than_or_equal_to: 5, less_than_or_equal_to: 60}
+  validates :healthy_threshold_count,
+            numericality: {greater_than_or_equal_to: 2, less_than_or_equal_to: 10}
+  validates :unhealthy_threshold_count,
+            numericality: {greater_than_or_equal_to: 2, less_than_or_equal_to: 10}
+  validate :timeout_must_be_less_than_interval
 
   serialize :rule_conditions, JsonWithIndifferentAccess
 
-  after_initialize do |lis|
+  before_validation do |lis|
     lis.health_check_interval ||= 10
     lis.health_check_path ||= '/'
+    lis.health_check_timeout ||= 5
+    lis.healthy_threshold_count ||= 2
+    lis.unhealthy_threshold_count ||= 2
     lis.rule_conditions ||= [{type: "path-pattern", value: "*"}]
     lis.rule_priority ||= 100
+  end
+
+  def timeout_must_be_less_than_interval
+    if health_check_timeout >= health_check_interval
+      errors.add(:health_check_timeout, "must be less than health_check_interval")
+    end
   end
 end

--- a/app/serializers/listener_serializer.rb
+++ b/app/serializers/listener_serializer.rb
@@ -1,0 +1,8 @@
+class ListenerSerializer < ActiveModel::Serializer
+  attributes :endpoint, :health_check_interval, :health_check_timeout, :health_check_path,
+             :healthy_threshold_count, :unhealthy_threshold_count
+
+  def endpoint
+    object.endpoint.name
+  end
+end

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -4,6 +4,7 @@ class ServiceSerializer < ActiveModel::Serializer
              :reverse_proxy_image, :hosts, :service_type, :force_ssl, :health_check
 
   belongs_to :heritage
+  has_many :listeners
 
   def port_mappings
     object.port_mappings.map do |pm|

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -22,6 +22,9 @@ class BuildHeritage
               endpoint_id: listener_map[listener[:endpoint]],
               health_check_interval: listener[:health_check_interval],
               health_check_path: listener[:health_check_path],
+              health_check_timeout: listener[:health_check_timeout],
+              healthy_threshold_count: listener[:healthy_threshold_count],
+              unhealthy_threshold_count: listener[:unhealthy_threshold_count],
               rule_priority: listener[:rule_priority],
               rule_conditions: listener[:rule_conditions]
             }

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -12,6 +12,10 @@ environments:
         listeners:
           - endpoint: barcelona
             health_check_path: /health_check
+            health_check_interval: 12
+            health_check_timeout: 10
+            healthy_threshold_count: 3
+            unhealthy_threshold_count: 3
       - name: worker
         command: rake jobs:work
         cpu: 128

--- a/db/migrate/20170413055930_add_health_check_options_to_listeners.rb
+++ b/db/migrate/20170413055930_add_health_check_options_to_listeners.rb
@@ -1,0 +1,7 @@
+class AddHealthCheckOptionsToListeners < ActiveRecord::Migration[5.0]
+  def change
+    add_column :listeners, :health_check_timeout, :integer
+    add_column :listeners, :healthy_threshold_count, :integer
+    add_column :listeners, :unhealthy_threshold_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170411021604) do
+ActiveRecord::Schema.define(version: 20170413055930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,8 +93,11 @@ ActiveRecord::Schema.define(version: 20170411021604) do
     t.string   "health_check_path"
     t.text     "rule_conditions"
     t.integer  "rule_priority"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.integer  "health_check_timeout"
+    t.integer  "healthy_threshold_count"
+    t.integer  "unhealthy_threshold_count"
     t.index ["endpoint_id", "service_id"], name: "index_listeners_on_endpoint_id_and_service_id", unique: true, using: :btree
     t.index ["endpoint_id"], name: "index_listeners_on_endpoint_id", using: :btree
     t.index ["service_id"], name: "index_listeners_on_service_id", using: :btree

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -22,7 +22,7 @@ describe BuildHeritage do
           listeners: [
             {
               endpoint: endpoint.name,
-              health_check_interval: 5,
+              health_check_interval: 20,
               health_check_path: "/health_check",
               rule_priority: 99,
               rule_conditions: [
@@ -72,7 +72,7 @@ describe BuildHeritage do
       expect(service1.port_mappings.first.lb_port).to eq 80
       expect(service1.port_mappings.first.container_port).to eq 3000
       expect(service1.listeners.count).to eq 1
-      expect(service1.listeners.first.health_check_interval).to eq 5
+      expect(service1.listeners.first.health_check_interval).to eq 20
       expect(service1.listeners.first.health_check_path).to eq "/health_check"
       expect(service1.listeners.first.rule_priority).to eq 99
       expect(service1.listeners.first.rule_conditions).to eq [{"type" => 'path_pattern',
@@ -118,7 +118,7 @@ describe BuildHeritage do
         expect(service1.port_mappings.first.lb_port).to eq 80
         expect(service1.port_mappings.first.container_port).to eq 3000
         expect(service1.listeners.count).to eq 1
-        expect(service1.listeners.first.health_check_interval).to eq 5
+        expect(service1.listeners.first.health_check_interval).to eq 20
         expect(service1.listeners.first.health_check_path).to eq "/health_check"
         expect(service1.listeners.first.endpoint.name).to eq endpoint.name
 


### PR DESCRIPTION
This PR adds missing health check options that are available ALB Target Group. See `barcelona.yml` for example