### PR TITLE
Add OSSEC to PCIDSS plugin

### DIFF
--- a/dockerfiles/wazuh-kibana-proxy/Dockerfile
+++ b/dockerfiles/wazuh-kibana-proxy/Dockerfile
@@ -1,0 +1,21 @@
+FROM nginx:alpine
+
+RUN apk add --no-cache curl apache2-utils
+RUN mkdir /app
+WORKDIR /app
+RUN curl -L -o entrykit.tgz https://github.com/progrium/entrykit/releases/download/v0.4.0/entrykit_0.4.0_Linux_x86_64.tgz && \
+    tar xzf entrykit.tgz && \
+    mv ./entrykit /bin/ && \
+    rm ./entrykit.tgz
+
+RUN entrykit --symlink
+COPY nginx.conf.tmpl /app/nginx.conf.tmpl
+COPY entrypoint /bin/entrypoint
+
+EXPOSE 80
+ENV KIBANA_URL=ossec-manager.default.bcn
+ENV KIBANA_PORT=5601
+ENV BAUTH_USER user
+ENV BAUTH_PASSWORD password
+
+CMD ["entrypoint"]

--- a/dockerfiles/wazuh-kibana-proxy/barcelona.yml
+++ b/dockerfiles/wazuh-kibana-proxy/barcelona.yml
@@ -1,0 +1,14 @@
+environments:
+  production:
+    name: wazuh-kibana-proxy
+    image_name: quay.io/degica/wazuh-kibana-proxy
+    services:
+      - name: web
+        service_type: web
+        cpu: 64
+        memory: 128
+        command: entrypoint
+        force_ssl: true
+        listeners:
+          - endpoint: wazuh-kibana-proxy
+            health_check_path: /health_check

--- a/dockerfiles/wazuh-kibana-proxy/entrypoint
+++ b/dockerfiles/wazuh-kibana-proxy/entrypoint
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export RESOLVER_IP=$(cat /etc/resolv.conf | grep "^nameserver" | sed -e "s/^nameserver //")
+exec render /app/nginx.conf -- \
+  prehook "nginx -V" -- \
+  prehook "htpasswd -bc /app/htpasswd $BAUTH_USER $BAUTH_PASSWORD" -- \
+  /usr/sbin/nginx -c /app/nginx.conf

--- a/dockerfiles/wazuh-kibana-proxy/nginx.conf.tmpl
+++ b/dockerfiles/wazuh-kibana-proxy/nginx.conf.tmpl
@@ -1,0 +1,42 @@
+daemon off;
+error_log /dev/stdout notice;
+user nobody nogroup;
+worker_processes 1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+  server {
+    listen {{ var "PORT" | default "3000" }} default_server;
+    server_name _;
+    access_log /dev/stdout;
+
+    location /health_check {
+      return 200;
+    }
+
+    resolver {{ var "RESOLVER_IP" }} valid=60s;
+    resolver_timeout 10s;
+
+    location / {
+      auth_basic           "Protected";
+      auth_basic_user_file /app/htpasswd;
+
+      set $upstream {{ var "KIBANA_URL" }}:{{ var "KIBANA_PORT" }};
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+
+      proxy_read_timeout 60;
+      proxy_send_timeout 60;
+
+      proxy_pass http://$upstream;
+    }
+  }
+}

--- a/docs/admin_guide.md
+++ b/docs/admin_guide.md
@@ -88,3 +88,32 @@ When you change Barcelona ECS container instance security group, be aware that s
 - `udp:123`, `0.0.0.0/0`
 - `tcp:80`, `169.254.169.254/32`
 - `tcp:443`, `0.0.0.0/0`
+
+## Plugins
+
+Barcelona provides several plugins which adds/extends Barcelona features.
+
+### PCIDSS plugin
+
+PCIDSS plugin adds security features required by PCI DSS. The features include
+
+- Designated NTP server
+- ClamAV virus scan
+- OSSEC
+  - Barcelona uses [Wazuh](https://github.com/wazuh/wazuh) instead of plain OSSEC
+  
+This plugin doesn't have attributes, so you just run `bcn district put-plugin --apply <district name> pcidss`
+
+#### Wazuh Kibana proxy
+
+Wazuh has a Kibana integration which enables you to see various information on your browser. Since you need to secure access to Kibana, access to Kibana is limited to private network. To access Wazuh Kibana from your browser, you will need to create a nginx proxy which has basic authentication enabled and setup HTTPS configuration.
+
+
+Barcelona provides a simple nginx proxy for Wazuh Kibana. If you want just basic auth and HTTPS, you can use the proxy with the following setup.
+
+- Create `barcelona.yml`
+  - See `dockerfiles/wazuh-kibana-proxy/barcelona.yml`
+- `bcn endpoint create --district=<district name> --public --certificate-arn=<ACM CERT ARN> wazuh-kibana-proxy`
+- `bcn create -e production --district=<district name>`
+- `bcn env set -e production BAUTH_USER=<username> BAUTH_PASSWORD=password KIBANA_URL=ossec-manager.<district name>.bcn`
+- Set domain name for the endpoint

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -3,6 +3,8 @@
 ### - Adds designated NTP server and configure container instances so that their refers the private NTP server
 ### - Installs Clam AV in all instances. Scans run every day.
 ### - Installs fail2ban in all instances
+### - Installs OSSEC agent in all instances
+### - Adds OSSEC manager in the private subnet
 ###
 ### Currently this plugin works only in Tokyo (ap-notheast-1) region
 
@@ -10,6 +12,185 @@ module Barcelona
   module Plugins
     class PcidssBuilder < CloudFormation::Builder
       delegate :district, to: :stack
+
+      SCAN_COMMAND = "listfile=`mktemp` && find / -xdev -mtime -1 -type f -fprint $listfile && clamscan -i -f $listfile | logger -t clamscan"
+
+      def manager_user_data
+        user_data = InstanceUserData.new
+        user_data.packages += ["docker", "jq", "awslogs", "clamav", "clamav-update", "tmpwatch", "fail2ban"]
+
+        change_batch = {
+          "Changes" => [
+
+            {
+              "Action" => "UPSERT",
+              "ResourceRecordSet" => {
+                "Name" => "ossec-manager.#{district.name}.bcn",
+                "Type" => "A",
+                "TTL" => 60,
+                "ResourceRecords" => [
+                  "Value" => "{private_ip}"
+                ]
+              }
+            }
+          ]
+        }.to_json
+
+        user_data.run_commands += [
+          "set -ex",
+
+          # awslogs
+          "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
+          'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
+          'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
+          "service awslogs start",
+
+          # Enable freshclam configuration
+          "sed -i 's/^Example$//g' /etc/freshclam.conf",
+          "sed -i 's/^FRESHCLAM_DELAY=disabled-warn.*$//g' /etc/sysconfig/freshclam",
+
+          # Daily full file system scan
+          "echo '0 0 * * * root #{SCAN_COMMAND}' > /etc/cron.d/clamscan",
+          "service crond restart",
+
+          # fail2ban configurations
+          "echo '[DEFAULT]' > /etc/fail2ban/jail.local",
+          "echo 'bantime = 1800' >> /etc/fail2ban/jail.local",
+          "service fail2ban restart",
+
+          # SSH session timeout
+          "echo 'TMOUT=900 && readonly TMOUT && export TMOUT' > /etc/profile.d/tmout.sh",
+
+          # NTP
+          "sed -i '/^server /s/^/#/' /etc/ntp.conf",
+          "sed -i 's/^logconfig .*/logconfig =all/' /etc/ntp.conf",
+          'echo logfile /var/log/ntpstats/ntpd.log >> /etc/ntp.conf',
+          district.subnets("Public").map(&:subnet_id).map { |id|
+            "echo server #{id}.ntp.#{district.name}.bcn iburst >> /etc/ntp.conf"
+          },
+          "service ntpd restart",
+
+          # Configure sshd
+          'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
+          'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',
+          "service sshd restart",
+
+          # Attach OSSEC volume
+          "volume_id=$(aws ec2 describe-volumes --region ap-northeast-1 --filters Name=tag-key,Values=ossec-manager-volume | jq -r '.Volumes[0].VolumeId')",
+          "instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
+          "aws ec2 attach-volume --region ap-northeast-1 --volume-id $volume_id --instance-id $instance_id --device /dev/xvdh",
+
+          # Register its private IP to Route53
+          "private_ip=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)",
+          "change_batch=$(echo '#{change_batch}' | sed -e \"s/{private_ip}/$private_ip/\")",
+          "aws route53 change-resource-record-sets --hosted-zone-id #{district.private_hosted_zone_id} --change-batch $change_batch",
+
+          # Wait for the volume and route53 record to be ready
+          "sleep 60",
+
+          # Initialize the volume if not initialized
+          "[[ $(file -s /dev/xvdh) =~ :\\ data$ ]] && mkfs -t ext4 /dev/xvdh",
+          "mkdir /ossec_mnt",
+          "mount /dev/xvdh /ossec_mnt",
+          "mkdir -p /ossec_mnt/ossec_data",
+          "mkdir -p /ossec_mnt/elasticsearch",
+
+          # Start/Install docker and compose
+          "service docker start",
+          "usermod -a -G docker ec2-user",
+          "pip install docker-compose",
+
+          # Setup OSSEC manager
+          "sysctl -w vm.max_map_count=262144",
+          "cd /tmp && /usr/local/bin/docker-compose up -d"
+        ].flatten
+
+        # CloudWatch Logs configurations
+        # See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
+        log_group_name = "Barcelona/#{district.name}/ossec-manager"
+        user_data.add_file("/etc/awslogs/awslogs.conf", "root:root", "644", <<~EOS)
+          [general]
+          state_file = /var/lib/awslogs/agent-state
+
+          [/var/log/dmesg]
+          file = /var/log/dmesg
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/dmesg
+
+          [/var/log/messages]
+          file = /var/log/messages
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/messages
+          datetime_format = %b %d %H:%M:%S
+
+          [/var/log/secure]
+          file = /var/log/secure
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/secure
+          datetime_format = %b %d %H:%M:%S
+
+          [/ossec_mnt/ossec_data/logs/alerts/alerts.log]
+          file = /ossec_mnt/ossec_data/logs/alerts/alerts.log
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/ossec/data/logs/alerts.log
+        EOS
+
+        user_data.add_file("/etc/ssh/ssh_ca_key.pub", "root:root", "644", district.ssh_format_ca_public_key)
+
+        # Based on https://github.com/wazuh/wazuh-docker
+        user_data.add_file("/tmp/docker-compose.yml", "root:root", "644", <<~EOS)
+          version: '2'
+          services:
+            wazuh:
+              image: wazuh/wazuh
+              restart: always
+              ports:
+                - "1514/udp:1514/udp"
+                - "1515:1515"
+                - "514/udp:514/udp"
+              depends_on:
+                - logstash
+              links:
+                - logstash
+              volumes:
+                - /ossec_mnt/ossec_data:/var/ossec/data
+            logstash:
+              image: wazuh/wazuh-logstash
+              restart: always
+              command: -f /etc/logstash/conf.d/
+              links:
+               - elasticsearch
+              depends_on:
+                - elasticsearch
+              environment:
+                - LS_HEAP_SIZE=2048m
+            elasticsearch:
+              image: elasticsearch:5.3.0
+              restart: always
+              command: elasticsearch -E node.name="node-1" -E cluster.name="wazuh" -E network.host=0.0.0.0
+              environment:
+                ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+              ulimits:
+                nofile:
+                  soft: 65536
+                  hard: 65536
+              volumes:
+                - /ossec_mnt/elasticsearch:/usr/share/elasticsearch/data
+            kibana:
+              image: wazuh/wazuh-kibana
+              restart: always
+              ports:
+                - "5601:5601"
+              depends_on:
+                - elasticsearch
+              links:
+                - wazuh
+                - elasticsearch
+              entrypoint: sh wait-for-it.sh elasticsearch
+        EOS
+
+        user_data
+      end
 
       def ntp_server_user_data
         user_data = InstanceUserData.new
@@ -205,6 +386,180 @@ module Barcelona
               "FromPort" => 123,
               "ToPort" => 123,
               "CidrIp" => district.cidr_block
+            },
+          ]
+          j.SecurityGroupEgress [
+            {
+              "IpProtocol" => "udp",
+              "FromPort" => 123,
+              "ToPort" => 123,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 80,
+              "ToPort" => 80,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 443,
+              "ToPort" => 443,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "icmp",
+              "FromPort" => -1,
+              "ToPort" => -1,
+              "CidrIp" => '0.0.0.0/0'
+            }
+          ]
+          j.Tags [
+            tag("barcelona", district.name),
+            tag("barcelona-role", "pcidss")
+          ]
+        end
+
+        add_resource("AWS::EC2::Volume", "OSSECManagerVolume") do |j|
+          j.AvailabilityZone "ap-northeast-1a"
+          j.Encrypted true
+          j.Size 8
+          j.Tags [
+            tag("ossec-manager-volume"),
+            tag("barcelona", district.name),
+            tag("barcelona-role", "pcidss"),
+          ]
+        end
+
+        add_resource("AWS::AutoScaling::LaunchConfiguration",
+                     "OSSECManagerLaunchConfiguration") do |j|
+          j.IamInstanceProfile ref("OSSECManagerInstanceProfile")
+          j.ImageId "ami-923d12f5"
+          j.InstanceType "t2.medium"
+          j.SecurityGroups [ref("OSSECManagerSG")]
+          j.UserData manager_user_data.build
+          j.EbsOptimized false
+          j.BlockDeviceMappings [
+            {
+              "DeviceName" => "/dev/xvda",
+              "Ebs" => {
+                "DeleteOnTermination" => true,
+                "VolumeSize" => 8,
+                "VolumeType" => "gp2"
+              }
+            },
+          ]
+        end
+
+        add_resource("AWS::IAM::Role", "OSSECManagerRole") do |j|
+          j.AssumeRolePolicyDocument do |j|
+            j.Version "2012-10-17"
+            j.Statement [
+              {
+                "Effect" => "Allow",
+                "Principal" => {
+                  "Service" => ["ec2.amazonaws.com"]
+                },
+                "Action" => ["sts:AssumeRole"]
+              }
+            ]
+          end
+          j.Path "/"
+          j.Policies [
+            {
+              "PolicyName" => "ossec-manager-policy",
+              "PolicyDocument" => {
+                "Version" => "2012-10-17",
+                "Statement" => [
+                  {
+                    "Effect" => "Allow",
+                    "Action" => [
+                      "ec2:DescribeVolumes",
+                      "ec2:AttachVolume",
+                      "logs:CreateLogGroup",
+                      "logs:CreateLogStream",
+                      "logs:DescribeLogStreams",
+                      "logs:PutLogEvents",
+                      "route53:ChangeResourceRecordSets"
+                    ],
+                    "Resource" => ["*"]
+                  }
+                ]
+              }
+            }
+          ]
+        end
+
+        add_resource("AWS::IAM::InstanceProfile", "OSSECManagerInstanceProfile") do |j|
+          j.Path "/"
+          j.Roles [ref("OSSECManagerRole")]
+        end
+
+        add_resource("AWS::AutoScaling::AutoScalingGroup", "OSSECManagerASG") do |j|
+          j.DesiredCapacity 1
+          j.HealthCheckGracePeriod 0
+          j.MaxSize 1
+          j.MinSize 1
+          j.HealthCheckType "EC2"
+          j.LaunchConfigurationName ref("OSSECManagerLaunchConfiguration")
+          # AZ of OSSEC manager and its EBS volume must match
+          j.VPCZoneIdentifier [district.stack_resources["SubnetTrusted1"]]
+          j.Tags [
+            {
+              "Key" => "Name",
+              "Value" => join("-", cf_stack_name, "ossec-manager"),
+              "PropagateAtLaunch" => true
+            },
+            {
+              "Key" => "barcelona",
+              "Value" => district.name,
+              "PropagateAtLaunch" => true
+            },
+            {
+              "Key" => "barcelona-role",
+              "Value" => "pcidss",
+              "PropagateAtLaunch" => true
+            }
+          ]
+        end
+
+        add_resource("AWS::EC2::SecurityGroup", "OSSECManagerSG") do |j|
+          j.GroupDescription "SG for OSSEC Manager Instance"
+          j.VpcId district.vpc_id
+          j.SecurityGroupIngress [
+            # ERASEME
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 22,
+              "ToPort" => 22,
+              "SourceSecurityGroupId" => district.stack_resources["SecurityGroupBastion"]
+            },
+            {
+              "IpProtocol" => "icmp",
+              "FromPort" => -1,
+              "ToPort" => -1,
+              "CidrIp" => district.cidr_block
+            },
+            # OSSEC manager
+            {
+              "IpProtocol" => "udp",
+              "FromPort" => 1514,
+              "ToPort" => 1514,
+              "SourceSecurityGroupId" => district.instance_security_group
+            },
+            # OSSEC authd
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 1515,
+              "ToPort" => 1515,
+              "SourceSecurityGroupId" => district.instance_security_group
+            },
+            # Kibana
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 5601,
+              "ToPort" => 5601,
+              "SourceSecurityGroupId" => district.instance_security_group
             },
           ]
           j.SecurityGroupEgress [

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -254,12 +254,6 @@ module Barcelona
           log_stream_name = {ec2_id}/var/log/secure
           datetime_format = %b %d %H:%M:%S
 
-          [/var/log/ecs/audit.log]
-          file = /var/log/ecs/audit.log.*
-          log_group_name = #{log_group_name}
-          log_stream_name = {ec2_id}/var/log/ecs/audit.log
-          datetime_format = %Y-%m-%dT%H:%M:%SZ
-
           [/var/log/ntpstats/ntpd.log]
           file = /var/log/ntpstats/ntpd.log
           log_group_name = #{log_group_name}

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -521,7 +521,6 @@ module Barcelona
           j.GroupDescription "SG for OSSEC Manager Instance"
           j.VpcId district.vpc_id
           j.SecurityGroupIngress [
-            # ERASEME
             {
               "IpProtocol" => "tcp",
               "FromPort" => 22,

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -232,7 +232,7 @@ module Barcelona
 
         # CloudWatch Logs configurations
         # See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
-        log_group_name = "Barcelona/#{district.name}/ntp_server"
+        log_group_name = "Barcelona/#{district.name}/ntp-server"
         user_data.add_file("/etc/awslogs/awslogs.conf", "root:root", "644", <<~EOS)
           [general]
           state_file = /var/lib/awslogs/agent-state

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -415,7 +415,7 @@ module Barcelona
         end
 
         add_resource("AWS::EC2::Volume", "OSSECManagerVolume") do |j|
-          j.AvailabilityZone "ap-northeast-1a"
+          j.AvailabilityZone ossec_volume_az
           j.Encrypted true
           j.Size 8
           j.Tags [
@@ -586,6 +586,12 @@ module Barcelona
             tag("barcelona-role", "pcidss")
           ]
         end
+      end
+
+      def ossec_volume_az
+        district.subnets("Private").find { |s|
+          s.subnet_id == district.stack_resources["SubnetTrusted1"]
+        }.availability_zone
       end
     end
 

--- a/lib/cloud_formation/helper.rb
+++ b/lib/cloud_formation/helper.rb
@@ -4,8 +4,8 @@ module CloudFormation
       ref("AWS::Region")
     end
 
-    def tag(key, value)
-      {"Key" => key, "Value" => value}
+    def tag(key, value="")
+      {"Key" => key, "Value" => value}.compact
     end
 
     def ref(r)

--- a/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
@@ -4,7 +4,7 @@ require 'barcelona/plugins/pcidss_plugin'
 module Barcelona
   module Plugins
     describe PcidssStack do
-      let!(:district) do
+      let(:district) do
         create :district, bastion_key_pair: "bastion", plugins_attributes: [
                  {
                    name: 'pcidss',
@@ -13,6 +13,10 @@ module Barcelona
                ]
       end
       let(:stack) { described_class.new(district) }
+
+      before do
+        allow_any_instance_of(PcidssBuilder).to receive(:ossec_volume_az) { 'ap-northeast-1a' }
+      end
 
       it "generates a correct stack template" do
         generated = JSON.load stack.target!
@@ -38,6 +42,10 @@ module Barcelona
                    plugin_attributes: {}
                  }
                ]
+      end
+
+      before do
+        allow_any_instance_of(PcidssBuilder).to receive(:ossec_volume_az) { 'ap-northeast-1a' }
       end
 
       it "gets hooked with container_instance_user_data trigger" do

--- a/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
@@ -21,6 +21,12 @@ module Barcelona
         expect(generated["Resources"]["NTPServerProfile"]).to be_present
         expect(generated["Resources"]["NTPServerASG"]).to be_present
         expect(generated["Resources"]["NTPServerSG"]).to be_present
+        expect(generated["Resources"]["OSSECManagerVolume"]).to be_present
+        expect(generated["Resources"]["OSSECManagerLaunchConfiguration"]).to be_present
+        expect(generated["Resources"]["OSSECManagerRole"]).to be_present
+        expect(generated["Resources"]["OSSECManagerInstanceProfile"]).to be_present
+        expect(generated["Resources"]["OSSECManagerASG"]).to be_present
+        expect(generated["Resources"]["OSSECManagerSG"]).to be_present
       end
     end
 


### PR DESCRIPTION
This adds [Wazuh OSSEC HIDS](https://github.com/wazuh/wazuh) to PCIDSS plugin. Wazuh is a fork of [OSSEC](https://github.com/ossec/ossec-hids) which adds some nice features to OSSEC.

This plugin adds

- a new EC2 instance that runs Wazuh manager, logstash, kibana and elasticsearch
- Wazuh agent to container instances

Because Wazuh and elasticsearch stores files in local file system, I can't use ECS to run it, instead, I decided to run all services in a single EC2 instance with EBS volume for data persistence. AWS has a ElasticSearch service but I also decided not to use it because it's 1) complicated and 2) version is a little bit old (Wazuh Kibana app requires newer version)