### PR TITLE
Add/Use session token as a oneoff container identifier

### DIFF
--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -21,7 +21,7 @@ class HeritageTaskDefinition
     new(heritage: oneoff.heritage,
         family_name: "#{oneoff.heritage.name}-oneoff",
         app_container_labels: {
-          "com.barcelona.oneoff-id" => oneoff.id.to_s
+          "com.barcelona.oneoff-id" => oneoff.session_token
         },
         cpu: 128,
         memory: oneoff.memory,

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -22,7 +22,7 @@ class HeritageTaskDefinition
         family_name: "#{oneoff.heritage.name}-oneoff",
         app_container_labels: {
           "com.barcelona.oneoff-id" => oneoff.session_token
-        },
+        }.compact,
         cpu: 128,
         memory: oneoff.memory,
         user: oneoff.user

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -59,8 +59,9 @@ class Oneoff < ActiveRecord::Base
   end
 
   def interactive_run_command
+    return nil if self.session_token.nil?
     real_command = run_command.join(' ')
-    [self.id, real_command].join(' ')
+    [self.session_token, real_command].join(' ')
   end
 
   def watch_session_command

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -7,7 +7,7 @@ class Oneoff < ActiveRecord::Base
   delegate :district, to: :heritage
   delegate :aws, to: :district
 
-  attr_accessor :memory, :user
+  attr_accessor :memory, :user, :session_token
 
   after_initialize do |oneoff|
     oneoff.memory ||= 512
@@ -19,6 +19,7 @@ class Oneoff < ActiveRecord::Base
   def run(sync: false, interactive: false)
     raise ArgumentError if sync && interactive
 
+    self.session_token = SecureRandom.uuid if interactive
     definition = HeritageTaskDefinition.oneoff_definition(self)
     aws.ecs.register_task_definition(definition.to_task_definition)
     resp = aws.ecs.run_task(

--- a/app/serializers/oneoff_serializer.rb
+++ b/app/serializers/oneoff_serializer.rb
@@ -1,6 +1,6 @@
 class OneoffSerializer < ActiveModel::Serializer
   attributes :id, :task_arn, :command, :status, :exit_code, :reason,
-             :interactive_run_command, :container_instance_arn, :container_name, :memory
+             :interactive_run_command, :container_instance_arn, :container_name, :memory, :session_token
 
   belongs_to :heritage
   belongs_to :district

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -171,9 +171,6 @@ describe HeritageTaskDefinition do
                                   essential: true,
                                   image: heritage.image_path,
                                   environment: [],
-                                  docker_labels: {
-                                    "com.barcelona.oneoff-id" => oneoff.id.to_s
-                                  },
                                   volumes_from: [
                                     {
                                       source_container: "runpack",
@@ -193,6 +190,13 @@ describe HeritageTaskDefinition do
                                 }
                               ]
                            })
+    end
+
+    context "when session_token is not nil" do
+      it "sets user to task definition" do
+        oneoff.session_token = 'session-token'
+        expect(subject[:container_definitions][0][:docker_labels]).to eq({"com.barcelona.oneoff-id" => 'session-token'})
+      end
     end
 
     context "when user is specified" do


### PR DESCRIPTION
Currently barcelona uses `oneoff.id` to identify an interactive container that `bcn run` connects to. This way has worked for a long time without any problem but this way actually has a potential security problem.

If someone of our team is evil and wants to hijack the oneoff interactive session that someone else launched, the evil person could do hijack by guessing interactive container ID (because, again, the current oneoff identifier is primary, auto-increment `id` which is guessable)

This PR makes the interactive oneoff hijack impossible by changing identifier from `id` to randomly-generated `session_token`. `session_token` is not stored in DB so only a person who creates an interactive oneoff can know the session token.