### PR TITLE
Bring Chaos to Barcelona

### DIFF
--- a/app/models/aws_accessor.rb
+++ b/app/models/aws_accessor.rb
@@ -32,6 +32,10 @@ class AwsAccessor
     @sns ||= Aws::SNS::Client.new(client_config)
   end
 
+  def autoscaling
+    @autoscaling ||= Aws::AutoScaling::Client.new(client_config)
+  end
+
   private
 
   def client_config

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -2,6 +2,10 @@ environments:
   production:
     name: barcelona
     image_name: quay.io/degica/barcelona
+    scheduled_tasks:
+      # 10AM JST every week day
+      - schedule: cron(0 1 ? * MON-FRI *)
+        command: bin/chaos --only staging
     services:
       - name: web
         service_type: web

--- a/bin/chaos
+++ b/bin/chaos
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'thor'
+require File.expand_path('../../config/environment', __FILE__)
+
+class CLI < Thor
+  option :only, desc: 'district names', type: :array
+  option :exclude, desc: 'district names', type: :array
+  option :count, desc: 'instance count to terminate', type: :numeric, default: 1
+  desc "execute", "Terminate instances in each district"
+  def execute
+    district_names = options[:only] || District.pluck(:name)
+    district_names = district_names & options[:exclude] if options[:exclude].present?
+    Barcelona::Chaos.run(district_names, count: options[:count])
+  end
+
+  default_task :execute
+end
+
+CLI.start(ARGV)

--- a/bin/chaos
+++ b/bin/chaos
@@ -10,7 +10,7 @@ class CLI < Thor
   desc "execute", "Terminate instances in each district"
   def execute
     district_names = options[:only] || District.pluck(:name)
-    district_names = district_names & options[:exclude] if options[:exclude].present?
+    district_names = district_names - options[:exclude] if options[:exclude].present?
     Barcelona::Chaos.run(district_names, count: options[:count])
   end
 

--- a/lib/barcelona/chaos.rb
+++ b/lib/barcelona/chaos.rb
@@ -1,0 +1,42 @@
+module Barcelona
+  class Chaos
+    attr_accessor :district, :terminate_count
+
+    def self.run(district_names, count:)
+      District.where(name: district_names.uniq).each do |d|
+        self.new(d, count).run
+      end
+    end
+
+    def initialize(district, terminate_count)
+      @district = district
+      @terminate_count = terminate_count
+    end
+
+    def run
+      instances = district.container_instances.sort_by { |i| i[:launch_time] }
+      non_active_count = instances.select { |i| i[:status] != 'ACTIVE' }.count
+      if non_active_count > 0
+        notify("#{district.name} has one or more non-active instance(s). Skipping", level: :warn)
+        return
+      end
+
+      asg = district.aws.autoscaling
+
+      # Terminate n oldest instances
+      terminate_count.times do |n|
+        ins = instances[n]
+        break if ins.nil?
+        notify "Terminating #{ins[:ec2_instance_id]}"
+        asg.terminate_instance_in_auto_scaling_group(
+          instance_id: ins[:ec2_instance_id],
+          should_decrement_desired_capacity: false
+        )
+      end
+    end
+
+    def notify(message, level: :good)
+      Event.new(district).notify(level: level, message: "[Chaos] #{message}")
+    end
+  end
+end

--- a/lib/barcelona/chaos.rb
+++ b/lib/barcelona/chaos.rb
@@ -4,7 +4,7 @@ module Barcelona
 
     def self.run(district_names, count:)
       District.where(name: district_names.uniq).each do |d|
-        self.new(d, count).run
+        new(d, count).run
       end
     end
 
@@ -15,8 +15,7 @@ module Barcelona
 
     def run
       instances = district.container_instances.sort_by { |i| i[:launch_time] }
-      non_active_count = instances.select { |i| i[:status] != 'ACTIVE' }.count
-      if non_active_count > 0
+      if instances.detect { |i| i[:status] != 'ACTIVE' }
         notify("#{district.name} has one or more non-active instance(s). Skipping", level: :warn)
         return
       end

--- a/spec/lib/barcelona/chaos_spec.rb
+++ b/spec/lib/barcelona/chaos_spec.rb
@@ -14,13 +14,18 @@ describe Barcelona::Chaos do
       before do
         expect(district).to receive(:container_instances) do
           [
-            {status: 'ACTIVE', ec2_instance_id: 'i-11111111'}
+            {status: 'ACTIVE', ec2_instance_id: 'i-11111111', launch_time: 1.day.ago},
+            {status: 'ACTIVE', ec2_instance_id: 'i-22222222', launch_time: 2.days.ago}
           ]
         end
       end
 
       it "makes a terminate request for the instance" do
         expect(asg_mock).to receive(:terminate_instance_in_auto_scaling_group).with(
+                              instance_id: 'i-22222222',
+                              should_decrement_desired_capacity: false
+                            )
+        expect(asg_mock).to_not receive(:terminate_instance_in_auto_scaling_group).with(
                               instance_id: 'i-11111111',
                               should_decrement_desired_capacity: false
                             )
@@ -32,7 +37,8 @@ describe Barcelona::Chaos do
       before do
         expect(district).to receive(:container_instances) do
           [
-            {status: 'DRAINING', ec2_instance_id: 'i-11111111'}
+            {status: 'ACTIVE', ec2_instance_id: 'i-11111111', launch_time: 1.day.ago},
+            {status: 'DRAINING', ec2_instance_id: 'i-11111111', launch_time: 1.day.ago}
           ]
         end
       end

--- a/spec/lib/barcelona/chaos_spec.rb
+++ b/spec/lib/barcelona/chaos_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Barcelona::Chaos do
+  describe "#run" do
+    let(:district) { create :district }
+    let(:asg_mock) { double }
+    let(:chaos) { described_class.new(district, 1) }
+
+    before do
+      allow_any_instance_of(AwsAccessor).to receive(:autoscaling) { asg_mock }
+    end
+
+    context "when the district has only active instances" do
+      before do
+        expect(district).to receive(:container_instances) do
+          [
+            {status: 'ACTIVE', ec2_instance_id: 'i-11111111'}
+          ]
+        end
+      end
+
+      it "makes a terminate request for the instance" do
+        expect(asg_mock).to receive(:terminate_instance_in_auto_scaling_group).with(
+                              instance_id: 'i-11111111',
+                              should_decrement_desired_capacity: false
+                            )
+        chaos.run
+      end
+    end
+
+    context "when the district has non-active instance" do
+      before do
+        expect(district).to receive(:container_instances) do
+          [
+            {status: 'DRAINING', ec2_instance_id: 'i-11111111'}
+          ]
+        end
+      end
+
+      it "does not make a terminate request for the instance" do
+        expect(asg_mock).to_not receive(:terminate_instance_in_auto_scaling_group)
+        chaos.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello Chaos!

This PR adds a very simple version of [Chaos Monkey](https://github.com/Netflix/SimianArmy/wiki/Chaos-Monkey).
This chaos script terminates oldest instances in each district.
The main purpose of this script is (I think) not to test fault tolerance, but to keep instances in Barcelona fresh so the termination strategy is not disruptive `ec2:TerminateInstances` but `autoscaling:TerminateInstanceInAutoScalingGroup` which triggers the autoscaling lifecycle hook to make instance termination graceful (ref: #378).

Also, this script doesn't include scheduling mechanism because we can use Barcelona's scheduled tasks