### PR TITLE
Security Fixes

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -12,6 +12,7 @@ class ContainerInstance
       "set -ex",
       # Embed SHA2 hash dockercfg so that instance replacement happens when dockercfg is updated
       "# #{Digest::SHA256.hexdigest(district.dockercfg.to_s)}",
+      "yum update -y --security",
 
       # Setup swap
       "MEMSIZE=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`",

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -21,6 +21,54 @@ module Barcelona
       }
 
       def build_resources
+        add_resource("AWS::EC2::SecurityGroup", "SecurityGroupBastion") do |j|
+          j.GroupDescription "Security Group for bastion servers"
+          j.VpcId ref("VPC")
+          j.SecurityGroupIngress [
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 22,
+              "ToPort" => 22,
+              "CidrIp" => "0.0.0.0/0"
+            },
+            {
+              "IpProtocol" => "udp",
+              "FromPort" => 123,
+              "ToPort" => 123,
+              "CidrIp" => options[:cidr_block]
+            }
+          ]
+          j.SecurityGroupEgress [
+            {
+              "IpProtocol" => "udp",
+              "FromPort" => 123,
+              "ToPort" => 123,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 22,
+              "ToPort" => 22,
+              "CidrIp" => options[:cidr_block]
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 80,
+              "ToPort" => 80,
+              "CidrIp" => '0.0.0.0/0'
+            },
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 443,
+              "ToPort" => 443,
+              "CidrIp" => '0.0.0.0/0'
+            }
+          ]
+          j.Tags [
+            tag("barcelona", stack.district.name)
+          ]
+        end
+
         add_resource("AWS::IAM::InstanceProfile", "BastionProfile") do |j|
           j.Path "/"
           j.Roles [ref("BastionRole")]

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -127,7 +127,7 @@ module Barcelona
         add_resource("AWS::AutoScaling::LaunchConfiguration", "BastionLaunchConfiguration") do |j|
           j.IamInstanceProfile ref("BastionProfile")
           j.ImageId AMI_IDS[district.region]
-          j.InstanceType "t2.nano"
+          j.InstanceType "t2.micro"
           j.SecurityGroups [ref("SecurityGroupBastion")]
           j.AssociatePublicIpAddress true
           j.UserData user_data

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -62,7 +62,21 @@ module Barcelona
               "FromPort" => 443,
               "ToPort" => 443,
               "CidrIp" => '0.0.0.0/0'
-            }
+            },
+            # OSSEC manager
+            {
+              "IpProtocol" => "udp",
+              "FromPort" => 1514,
+              "ToPort" => 1514,
+              "CidrIp" => options[:cidr_block]
+            },
+            # OSSEC authd
+            {
+              "IpProtocol" => "tcp",
+              "FromPort" => 1515,
+              "ToPort" => 1515,
+              "CidrIp" => options[:cidr_block]
+            },
           ]
           j.Tags [
             tag("barcelona", stack.district.name)

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -21,7 +21,49 @@ module Barcelona
       }
 
       def build_resources
+        add_resource("AWS::IAM::InstanceProfile", "BastionProfile") do |j|
+          j.Path "/"
+          j.Roles [ref("BastionRole")]
+        end
+
+        add_resource("AWS::IAM::Role", "BastionRole") do |j|
+          j.AssumeRolePolicyDocument do |j|
+            j.Version "2012-10-17"
+            j.Statement [
+              {
+                "Effect" => "Allow",
+                "Principal" => {
+                  "Service" => ["ec2.amazonaws.com"]
+                },
+                "Action" => ["sts:AssumeRole"]
+              }
+            ]
+          end
+          j.Path "/"
+          j.Policies [
+            {
+              "PolicyName" => "bastion-role",
+              "PolicyDocument" => {
+                "Version" => "2012-10-17",
+                "Statement" => [
+                  {
+                    "Effect" => "Allow",
+                    "Action" => [
+                      "logs:CreateLogGroup",
+                      "logs:CreateLogStream",
+                      "logs:DescribeLogStreams",
+                      "logs:PutLogEvents",
+                    ],
+                    "Resource" => ["*"]
+                  }
+                ]
+              }
+            }
+          ]
+        end
+
         add_resource("AWS::AutoScaling::LaunchConfiguration", "BastionLaunchConfiguration") do |j|
+          j.IamInstanceProfile ref("BastionProfile")
           j.ImageId AMI_IDS[district.region]
           j.InstanceType "t2.nano"
           j.SecurityGroups [ref("SecurityGroupBastion")]
@@ -36,10 +78,40 @@ module Barcelona
 
       def user_data
         ud = InstanceUserData.new
-        ud.packages += ["aws-cli", "yum-cron-security"]
+        ud.packages += ["aws-cli", "awslogs", "yum-cron-security"]
         ud.add_user("hopper")
         ud.add_file("/etc/ssh/ssh_ca_key.pub", "root:root", "644", district.ssh_format_ca_public_key)
+
+        log_group_name = "Barcelona/#{district.name}/bastion"
+        ud.add_file("/etc/awslogs/awslogs.conf", "root:root", "644", <<~EOS)
+          [general]
+          state_file = /var/lib/awslogs/agent-state
+
+          [/var/log/dmesg]
+          file = /var/log/dmesg
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/dmesg
+
+          [/var/log/messages]
+          file = /var/log/messages
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/messages
+          datetime_format = %b %d %H:%M:%S
+
+          [/var/log/secure]
+          file = /var/log/secure
+          log_group_name = #{log_group_name}
+          log_stream_name = {ec2_id}/var/log/secure
+          datetime_format = %b %d %H:%M:%S
+        EOS
+
         ud.run_commands += [
+          # awslogs
+          "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
+          'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
+          'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
+          "service awslogs start",
+
           "service yum-cron start",
           'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
           'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -36,10 +36,11 @@ module Barcelona
 
       def user_data
         ud = InstanceUserData.new
-        ud.packages += ["aws-cli"]
+        ud.packages += ["aws-cli", "yum-cron-security"]
         ud.add_user("hopper")
         ud.add_file("/etc/ssh/ssh_ca_key.pub", "root:root", "644", district.ssh_format_ca_public_key)
         ud.run_commands += [
+          "service yum-cron start",
           'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
           'sed -i -e "s/^PermitRootLogin .*/PermitRootLogin no/" /etc/ssh/sshd_config',
           "service sshd restart",

--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -246,54 +246,6 @@ module Barcelona
           j.SourceSecurityGroupId ref("InstanceSecurityGroup")
         end
 
-        add_resource("AWS::EC2::SecurityGroup", "SecurityGroupBastion") do |j|
-          j.GroupDescription "Security Group for bastion servers"
-          j.VpcId ref("VPC")
-          j.SecurityGroupIngress [
-            {
-              "IpProtocol" => "tcp",
-              "FromPort" => 22,
-              "ToPort" => 22,
-              "CidrIp" => "0.0.0.0/0"
-            },
-            {
-              "IpProtocol" => "udp",
-              "FromPort" => 123,
-              "ToPort" => 123,
-              "CidrIp" => options[:cidr_block]
-            }
-          ]
-          j.SecurityGroupEgress [
-            {
-              "IpProtocol" => "udp",
-              "FromPort" => 123,
-              "ToPort" => 123,
-              "CidrIp" => '0.0.0.0/0'
-            },
-            {
-              "IpProtocol" => "tcp",
-              "FromPort" => 22,
-              "ToPort" => 22,
-              "CidrIp" => options[:cidr_block]
-            },
-            {
-              "IpProtocol" => "tcp",
-              "FromPort" => 80,
-              "ToPort" => 80,
-              "CidrIp" => '0.0.0.0/0'
-            },
-            {
-              "IpProtocol" => "tcp",
-              "FromPort" => 443,
-              "ToPort" => 443,
-              "CidrIp" => '0.0.0.0/0'
-            }
-          ]
-          j.Tags [
-            tag("barcelona", stack.district.name)
-          ]
-        end
-
         add_builder BastionBuilder.new(options[:autoscaling])
 
         add_resource("AWS::IAM::Role", "ECSServiceRole") do |j|

--- a/lib/barcelona/network/vpc_builder.rb
+++ b/lib/barcelona/network/vpc_builder.rb
@@ -246,7 +246,7 @@ module Barcelona
           j.SourceSecurityGroupId ref("InstanceSecurityGroup")
         end
 
-        add_builder BastionBuilder.new(options[:autoscaling])
+        add_builder BastionBuilder.new(options)
 
         add_resource("AWS::IAM::Role", "ECSServiceRole") do |j|
           j.AssumeRolePolicyDocument do |j|

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -235,7 +235,7 @@ module Barcelona
           "echo interface listen eth1 >> /etc/ntp.conf",
           "service ntpd restart",
 
-          "service stop sshd"
+          "service sshd stop"
         ]
 
         # CloudWatch Logs configurations

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -297,7 +297,7 @@ module Barcelona
                      "NTPServerLaunchConfiguration") do |j|
           j.IamInstanceProfile ref("NTPServerProfile")
           j.ImageId "ami-56d4ad31"
-          j.InstanceType "t2.nano"
+          j.InstanceType "t2.micro"
           j.AssociatePublicIpAddress true
           j.SecurityGroups [ref("NTPServerSG")]
           j.UserData ntp_server_user_data.build

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -17,7 +17,7 @@ module Barcelona
 
       def manager_user_data
         user_data = InstanceUserData.new
-        user_data.packages += ["docker", "jq", "awslogs", "clamav", "clamav-update", "tmpwatch", "fail2ban"]
+        user_data.packages += ["docker", "jq", "awslogs", "clamav", "clamav-update", "tmpwatch", "fail2ban", "yum-cron-security"]
 
         change_batch = {
           "Changes" => [
@@ -38,6 +38,7 @@ module Barcelona
 
         user_data.run_commands += [
           "set -ex",
+          "service yum-cron start",
 
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
@@ -194,7 +195,7 @@ module Barcelona
 
       def ntp_server_user_data
         user_data = InstanceUserData.new
-        user_data.packages += ["aws-cli", "awslogs", "jq"]
+        user_data.packages += ["aws-cli", "awslogs", "jq", "yum-cron-security"]
 
         find_eni_command = [
           "aws ec2 --region=#{district.region} describe-network-interfaces",
@@ -206,6 +207,7 @@ module Barcelona
         ].join(" ")
         user_data.run_commands += [
           "set -ex",
+          "service yum-cron start",
 
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -40,6 +40,9 @@ module Barcelona
           "set -ex",
           "service yum-cron start",
 
+          # Install AWS Inspector agent
+          "curl https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install | bash",
+
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
           'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
@@ -208,6 +211,9 @@ module Barcelona
         user_data.run_commands += [
           "set -ex",
           "service yum-cron start",
+
+          # Install AWS Inspector agent
+          "curl https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install | bash",
 
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -546,14 +546,14 @@ module Barcelona
               "IpProtocol" => "udp",
               "FromPort" => 1514,
               "ToPort" => 1514,
-              "SourceSecurityGroupId" => district.instance_security_group
+              "CidrIp" => district.cidr_block
             },
             # OSSEC authd
             {
               "IpProtocol" => "tcp",
               "FromPort" => 1515,
               "ToPort" => 1515,
-              "SourceSecurityGroupId" => district.instance_security_group
+              "CidrIp" => district.cidr_block
             },
             # Kibana
             {

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -682,6 +682,15 @@ EOS
         user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
         user_data.packages += SYSTEM_PACKAGES
         user_data.run_commands += run_commands
+        user_data.add_file("/etc/yum.repos.d/wazuh.repo", "root:root", "644", <<EOS)
+[wazuh_repo]
+gpgcheck=1
+gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
+enabled=1
+name=Wazuh
+baseurl=https://packages.wazuh.com/yum/el/7/x86_64
+protect=1
+EOS
         bastion_lc["Properties"]["UserData"] = user_data.build
         template
       end

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -335,14 +335,66 @@ describe Barcelona::Network::NetworkStack do
              "FromPort" => 443,
              "ToPort" => 443,
              "CidrIp" => "0.0.0.0/0"},
+            {"IpProtocol" => "udp",
+             "FromPort" => 1514,
+             "ToPort" => 1514,
+             "CidrIp" => district.cidr_block},
+            {"IpProtocol" => "tcp",
+             "FromPort" => 1515,
+             "ToPort" => 1515,
+             "CidrIp" => district.cidr_block},
           ],
           "Tags" => [{"Key" => "barcelona", "Value" => district.name}]
+        }
+      },
+      "BastionProfile" => {
+        "Type" => "AWS::IAM::InstanceProfile",
+        "Properties" => {
+          "Path" => "/",
+          "Roles" => [{"Ref" => "BastionRole"}]
+        }
+      },
+      "BastionRole" => {
+        "Type"=>"AWS::IAM::Role",
+        "Properties" => {
+          "AssumeRolePolicyDocument" => {
+            "Version"=>"2012-10-17",
+            "Statement" => [
+              {
+                "Effect"=>"Allow",
+                "Principal" => {"Service"=>["ec2.amazonaws.com"]},
+                "Action"=>["sts:AssumeRole"]
+              }
+            ]
+          },
+          "Path"=>"/",
+          "Policies" => [
+            {
+              "PolicyName" => "bastion-role",
+              "PolicyDocument" => {
+                "Version" => "2012-10-17",
+                "Statement" => [
+                  {
+                    "Effect"=>"Allow",
+                    "Action" => [
+                      "logs:CreateLogGroup",
+                      "logs:CreateLogStream",
+                      "logs:DescribeLogStreams",
+                      "logs:PutLogEvents",
+                    ],
+                    "Resource"=>["*"]
+                  }
+                ]
+              }
+            }
+          ]
         }
       },
       "BastionLaunchConfiguration" => {
         "Type" => "AWS::AutoScaling::LaunchConfiguration",
         "Properties" => {
           "InstanceType" => "t2.nano",
+          "IamInstanceProfile" => {"Ref" => "BastionProfile"},
           "ImageId" => kind_of(String),
           "UserData" => anything,
           "AssociatePublicIpAddress" => true,

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -393,7 +393,7 @@ describe Barcelona::Network::NetworkStack do
       "BastionLaunchConfiguration" => {
         "Type" => "AWS::AutoScaling::LaunchConfiguration",
         "Properties" => {
-          "InstanceType" => "t2.nano",
+          "InstanceType" => "t2.micro",
           "IamInstanceProfile" => {"Ref" => "BastionProfile"},
           "ImageId" => kind_of(String),
           "UserData" => anything,


### PR DESCRIPTION
This PR fixes some security issues about the network stack.

## Automate yum update

- install `yum-cron-security` package to instances except for container instances
- run `yum update --security` at launch for container instances

`yum-cron-security` periodically (daily) installs security updates if available. The reason why I didn't install the package to container instances is that updating packages of running instance might break instance functionality (for example, if there is an update for `docker`, it updates `docker` and **restarts** the daemon which makes all running containers temporarily down). Instead, I added `yum update --security` to container instances' user data. Now that we have chaos, running container instances periodically get terminated by chaos and new instances has latest security updates.

## Install AWS inspector in pcidss instances

PCIDSS plugin adds NTP server and OSSEC manager server, I forgot to install Inspector agent in those instances

## Install AWS logs agent in bastion server

Fixes https://github.com/degica/barcelona/issues/373

## Connect bastion server to OSSEC (PCIDSS plugin)

Bastion should be monitored by OSSEC