### PR TITLE
Enable Chaos for all districts

### DIFF
--- a/barcelona.yml
+++ b/barcelona.yml
@@ -5,7 +5,7 @@ environments:
     scheduled_tasks:
       # 10AM JST every week day
       - schedule: cron(0 1 ? * MON-FRI *)
-        command: bin/chaos --only staging
+        command: bin/chaos
     services:
       - name: web
         service_type: web


### PR DESCRIPTION
I confirmed that chaos gracefully terminated a staging instance this morning. Now I think it's ready to enable chaos for all districts