### PR TITLE
Fix PCIDSS plugin

### DIFF
--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -82,7 +82,7 @@ class ApplyDistrict
     config = {
       "ECS_CLUSTER" => district.name,
       "ECS_AVAILABLE_LOGGING_DRIVERS" => '["awslogs", "json-file", "syslog", "fluentd"]',
-      "ECS_RESERVED_MEMORY" => 128,
+      "ECS_RESERVED_MEMORY" => 256,
       "ECS_CONTAINER_STOP_TIMEOUT" => "5m",
       "ECS_ENABLE_TASK_IAM_ROLE" => "true",
       "ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST" => "true"

--- a/dockerfiles/wazuh-kibana-proxy/barcelona.yml
+++ b/dockerfiles/wazuh-kibana-proxy/barcelona.yml
@@ -1,7 +1,7 @@
 environments:
   production:
     name: wazuh-kibana-proxy
-    image_name: quay.io/degica/wazuh-kibana-proxy
+    image_name: quay.io/degica/barcelona-wazuh-kibana-proxy
     services:
       - name: web
         service_type: web
@@ -10,5 +10,5 @@ environments:
         command: entrypoint
         force_ssl: true
         listeners:
-          - endpoint: wazuh-kibana-proxy
+          - endpoint: wazuh
             health_check_path: /health_check

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -497,7 +497,7 @@ module Barcelona
           j.Roles [ref("OSSECManagerRole")]
         end
 
-        add_resource("AWS::AutoScaling::AutoScalingGroup", "OSSECManagerASG") do |j|
+        add_resource("AWS::AutoScaling::AutoScalingGroup", "OSSECManagerASG", depends_on: ["OSSECManagerVolume"]) do |j|
           j.DesiredCapacity 1
           j.HealthCheckGracePeriod 0
           j.MaxSize 1

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -80,7 +80,7 @@ module Barcelona
           "service sshd restart",
 
           # Attach OSSEC volume
-          "volume_id=$(aws ec2 describe-volumes --region ap-northeast-1 --filters Name=tag-key,Values=ossec-manager-volume | jq -r '.Volumes[0].VolumeId')",
+          "volume_id=$(aws ec2 describe-volumes --region ap-northeast-1 --filters Name=tag-key,Values=ossec-manager-volume Name=tag:barcelona,Values=#{district.name} | jq -r '.Volumes[0].VolumeId')",
           "instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
           "aws ec2 attach-volume --region ap-northeast-1 --volume-id $volume_id --instance-id $instance_id --device /dev/xvdh",
 

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -652,10 +652,13 @@ module Barcelona
           },
           "service ntpd restart",
 
+          # Ignores error on OSSEC installation process.
+          "set +e",
           "yum install -y wazuh-agent",
           "sed -i 's/<server-ip>.*<\\/server-ip>/<server-hostname>ossec-manager.#{district.name}.bcn<\\/server-hostname>/g' /var/ossec/etc/ossec.conf",
           "/var/ossec/bin/agent-auth -m ossec-manager.#{district.name}.bcn",
-          "/var/ossec/bin/ossec-control restart"
+          "/var/ossec/bin/ossec-control restart",
+          "set -e",
         ].flatten
       end
 


### PR DESCRIPTION
- If there are 2 districts which both have PCIDSS plugin, then EBS to be attached may be conflicted so I added `barcelona` tag to the filter
- Add `OSSECManagerVolume` dependency on `OSSECManagerASG` to make sure that the volume is availabe when the manager volume starts
- Increase reserved memory from 128MB to 256MB. this is not necessary because container instances have swap area but in order to keep instances stable, it's time to increase the size since now contaienr isntances run many services outside ECS.