### PR TITLE
Add random serial number to certificate

### DIFF
--- a/app/services/sign_ssh_key.rb
+++ b/app/services/sign_ssh_key.rb
@@ -23,12 +23,15 @@ class SignSSHKey
     public_key_file.write(user.public_key)
     public_key_file.close
 
+    serial_number = SecureRandom.random_number(2 ** 32)
+
     comm = [
       "ssh-keygen",
       "-s", secret_key_path,
       "-I", identity,
       "-n", principals.join(','),
-      "-V", validity
+      "-V", validity,
+      "-z", serial_number
     ]
     comm += ["-O", "force-command='#{force_command}'"] if force_command
     comm += [public_key_file.path]
@@ -38,7 +41,7 @@ class SignSSHKey
       File.open(secret_key_path, 'w') { |f| f.write(ca_key) }
       Process.wait(pid)
     }
-    Event.new(district).notify(message: "Signed public key for user #{user.name} with identity #{identity}")
+    Event.new(district).notify(message: "Signed public key for user #{user.name} with identity #{identity} serial_number: #{serial_number}")
 
     File.read(public_key_file.path + "-cert.pub")
   rescue Timeout::Error


### PR DESCRIPTION
This PR adds random serial number to signed certificate. The serial number of certificate is shown in `sshd` log so we can know that when a certificate used to ssh is signed, which improves auditability.

manpage of `ssh-keygen`:
```
-z serial_number
    Specifies a serial number to be embedded in the certificate to distinguish this certificate from others from the same CA.  The default serial number is zero.
    When generating a KRL, the -z flag is used to specify a KRL version number.
```