### PR TITLE
Update OSSEC configuration

### DIFF
--- a/dockerfiles/wazuh/Dockerfile
+++ b/dockerfiles/wazuh/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:7
+
+COPY wazuh.repo /etc/yum.repos.d/wazuh.repo
+
+RUN groupadd -g 1000 ossec
+RUN useradd -u 1000 -g 1000 ossec
+RUN yum -y update && \
+    yum -y install epel-release && \
+    sed -i "s/#baseurl=/baseurl=/" /etc/yum.repos.d/epel.repo && \
+    sed -i "s/mirrorlist=/#mirrorlist=/" /etc/yum.repos.d/epel.repo && \
+    yum -y install openssl postfix mailx cyrus-sasl cyrus-sasl-plain wazuh-manager wazuh-api&& \
+    yum clean all
+
+COPY data_dirs.env /data_dirs.env
+COPY init.bash /init.bash
+COPY run.sh /tmp/run.sh
+#COPY local_decoder.xml /var/ossec/ruleset/decoders/local_decoder.xml
+COPY local_rules.xml /var/ossec/ruleset/rules/local_rules.xml
+COPY ossec.conf /var/ossec/ossec.conf
+COPY filebeat.yml /etc/filebeat/
+
+RUN /init.bash
+
+RUN  curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-5.4.2-x86_64.rpm &&\
+  rpm -vi filebeat-5.4.2-x86_64.rpm && \
+  rm filebeat-5.4.2-x86_64.rpm
+
+
+
+VOLUME ["/var/ossec/data"]
+
+EXPOSE 55000/tcp 1514/udp 1515/tcp 514/udp
+
+# Run supervisord so that the container will stay alive
+
+ENTRYPOINT ["/tmp/run.sh"]

--- a/dockerfiles/wazuh/data_dirs.env
+++ b/dockerfiles/wazuh/data_dirs.env
@@ -1,0 +1,8 @@
+i=0
+DATA_DIRS[((i++))]="etc"
+DATA_DIRS[((i++))]="logs"
+DATA_DIRS[((i++))]="stats"
+DATA_DIRS[((i++))]="queue"
+DATA_DIRS[((i++))]="var/db"
+DATA_DIRS[((i++))]="api"
+export DATA_DIRS

--- a/dockerfiles/wazuh/filebeat.yml
+++ b/dockerfiles/wazuh/filebeat.yml
@@ -1,0 +1,17 @@
+
+filebeat:
+ prospectors:
+  - input_type: log
+    paths:
+     - "/var/ossec/data/logs/alerts/alerts.json"
+    document_type: wazuh-alerts
+    json.message_key: log
+    json.keys_under_root: true
+    json.overwrite_keys: true
+
+output:
+ logstash:
+   # The Logstash hosts
+   hosts: ["logstash:5000"]
+#   ssl:
+#     certificate_authorities: ["/etc/filebeat/logstash.crt"]

--- a/dockerfiles/wazuh/init.bash
+++ b/dockerfiles/wazuh/init.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+# Initialize the custom data directory layout
+#
+source /data_dirs.env
+
+cd /var/ossec
+for ossecdir in "${DATA_DIRS[@]}"; do
+  mv ${ossecdir} ${ossecdir}-template
+  ln -s $(realpath --relative-to=$(dirname ${ossecdir}) data)/${ossecdir} ${ossecdir}
+done

--- a/dockerfiles/wazuh/local_rules.xml
+++ b/dockerfiles/wazuh/local_rules.xml
@@ -1,0 +1,9 @@
+<group name="audit,">
+  <rule id="80710" level="10" overwrite="yes" noalert="1">
+    <if_sid>80700</if_sid>
+    <field name="audit.type">ANOM_PROMISCUOUS</field>
+    <match>prom=256</match>
+    <description>Auditd: device enables promiscuous mode</description>
+    <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
+  </rule>
+</group>

--- a/dockerfiles/wazuh/ossec.conf
+++ b/dockerfiles/wazuh/ossec.conf
@@ -1,0 +1,216 @@
+<!--
+  Wazuh - Manager - Default configuration.
+  More info at: https://documentation.wazuh.com
+  Mailing list: https://groups.google.com/forum/#!forum/wazuh
+-->
+
+<ossec_config>
+  <integration>
+    <name>slack</name>
+    <hook_url>{{SLACK_URL}}</hook_url>
+    <level>12</level>
+  </integration>
+
+  <global>
+    <jsonout_output>yes</jsonout_output>
+    <alerts_log>yes</alerts_log>
+    <logall>no</logall>
+    <logall_json>no</logall_json>
+    <email_notification>no</email_notification>
+    <smtp_server>smtp.example.wazuh.com</smtp_server>
+    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_to>recipient@example.wazuh.com</email_to>
+    <email_maxperhour>12</email_maxperhour>
+  </global>
+
+  <alerts>
+    <log_alert_level>3</log_alert_level>
+    <email_alert_level>12</email_alert_level>
+  </alerts>
+
+  <remote>
+    <connection>syslog</connection>
+    <port>514</port>
+    <protocol>udp</protocol>
+  </remote>
+
+  <remote>
+    <connection>secure</connection>
+    <port>1514</port>
+    <protocol>udp</protocol>
+  </remote>
+
+  <!-- Policy monitoring -->
+  <rootcheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that rootcheck is executed - every 12 hours -->
+    <frequency>43200</frequency>
+
+    <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
+    <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
+
+    <system_audit>/var/ossec/etc/shared/system_audit_rcl.txt</system_audit>
+    <system_audit>/var/ossec/etc/shared/system_audit_ssh.txt</system_audit>
+    <system_audit>/var/ossec/etc/shared/cis_debian_linux_rcl.txt</system_audit>
+
+    <skip_nfs>yes</skip_nfs>
+  </rootcheck>
+
+  <wodle name="open-scap">
+    <disabled>yes</disabled>
+    <timeout>1800</timeout>
+    <interval>1d</interval>
+    <scan-on-start>yes</scan-on-start>
+
+    <content type="xccdf" path="ssg-debian-8-ds.xml">
+      <profile>xccdf_org.ssgproject.content_profile_common</profile>
+    </content>
+    <content type="oval" path="cve-debian-oval.xml"/>
+  </wodle>
+
+  <!-- File integrity monitoring -->
+  <syscheck>
+    <disabled>no</disabled>
+
+    <!-- Frequency that syscheck is executed default every 12 hours -->
+    <frequency>43200</frequency>
+
+    <scan_on_start>yes</scan_on_start>
+
+    <!-- Generate alert when new file detected -->
+    <alert_new_files>yes</alert_new_files>
+
+    <!-- Don't ignore files that change more than 3 times -->
+    <auto_ignore>no</auto_ignore>
+
+    <!-- Directories to check  (perform all possible verifications) -->
+    <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
+
+    <!-- Files/directories to ignore -->
+    <ignore>/etc/mtab</ignore>
+    <ignore>/etc/hosts.deny</ignore>
+    <ignore>/etc/mail/statistics</ignore>
+    <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
+    <ignore>/etc/adjtime</ignore>
+    <ignore>/etc/httpd/logs</ignore>
+    <ignore>/etc/utmpx</ignore>
+    <ignore>/etc/wtmpx</ignore>
+    <ignore>/etc/cups/certs</ignore>
+    <ignore>/etc/dumpdates</ignore>
+    <ignore>/etc/svc/volatile</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
+
+    <skip_nfs>yes</skip_nfs>
+  </syscheck>
+
+  <!-- Active response -->
+  <global>
+    <white_list>127.0.0.1</white_list>
+    <white_list>^localhost.localdomain$</white_list>
+    <white_list>10.0.0.2</white_list>
+  </global>
+
+  <command>
+    <name>disable-account</name>
+    <executable>disable-account.sh</executable>
+    <expect>user</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>restart-ossec</name>
+    <executable>restart-ossec.sh</executable>
+    <expect></expect>
+  </command>
+
+  <command>
+    <name>firewall-drop</name>
+    <executable>firewall-drop.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>host-deny</name>
+    <executable>host-deny.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>route-null</name>
+    <executable>route-null.sh</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <command>
+    <name>win_route-null</name>
+    <executable>route-null.cmd</executable>
+    <expect>srcip</expect>
+    <timeout_allowed>yes</timeout_allowed>
+  </command>
+
+  <!--
+  <active-response>
+    active-response options here
+  </active-response>
+  -->
+
+  <!-- Log analysis -->
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/ossec/logs/active-responses.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/messages</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/auth.log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/var/log/syslog</location>
+  </localfile>
+
+  <localfile>
+    <log_format>command</log_format>
+    <command>df -P</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>netstat -tan |grep LISTEN |grep -v 127.0.0.1 | sort</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <localfile>
+    <log_format>full_command</log_format>
+    <command>last -n 5</command>
+    <frequency>360</frequency>
+  </localfile>
+
+  <ruleset>
+    <!-- Default ruleset -->
+    <decoder_dir>ruleset/decoders</decoder_dir>
+    <rule_dir>ruleset/rules</rule_dir>
+    <rule_exclude>0215-policy_rules.xml</rule_exclude>
+    <list>etc/lists/audit-keys</list>
+
+    <!-- User-defined ruleset -->
+    <decoder_dir>etc/decoders</decoder_dir>
+    <rule_dir>etc/rules</rule_dir>
+  </ruleset>
+
+</ossec_config>

--- a/dockerfiles/wazuh/run.sh
+++ b/dockerfiles/wazuh/run.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Based on https://github.com/wazuh/wazuh-docker/blob/master/wazuh/Dockerfile
+#
+# OSSEC container bootstrap. See the README for information of the environment
+# variables expected by this script.
+#
+
+source /data_dirs.env
+FIRST_TIME_INSTALLATION=false
+DATA_PATH=/var/ossec/data
+
+for ossecdir in "${DATA_DIRS[@]}"; do
+  if [ ! -e "${DATA_PATH}/${ossecdir}" ]
+  then
+    echo "Installing ${ossecdir}"
+    mkdir -p $(dirname ${DATA_PATH}/${ossecdir})
+    cp -pr /var/ossec/${ossecdir}-template ${DATA_PATH}/${ossecdir}
+    FIRST_TIME_INSTALLATION=true
+  fi
+done
+
+rm -f ${DATA_PATH}/etc/ossec.conf
+ln -s /var/ossec/ossec.conf ${DATA_PATH}/etc/ossec.conf
+
+touch ${DATA_PATH}/process_list
+chgrp ossec ${DATA_PATH}/process_list
+chmod g+rw ${DATA_PATH}/process_list
+
+AUTO_ENROLLMENT_ENABLED=${AUTO_ENROLLMENT_ENABLED:-true}
+
+if [ $FIRST_TIME_INSTALLATION == true ]
+then
+
+  if [ $AUTO_ENROLLMENT_ENABLED == true ]
+  then
+    if [ ! -e ${DATA_PATH}/etc/sslmanager.key ]
+    then
+      echo "Creating ossec-authd key and cert"
+      openssl genrsa -out ${DATA_PATH}/etc/sslmanager.key 4096
+      openssl req -new -x509 -key ${DATA_PATH}/etc/sslmanager.key\
+        -out ${DATA_PATH}/etc/sslmanager.cert -days 3650\
+        -subj /CN=${HOSTNAME}/
+    fi
+  fi
+fi
+
+function ossec_shutdown(){
+  /var/ossec/bin/ossec-control stop;
+  if [ $AUTO_ENROLLMENT_ENABLED == true ]
+  then
+     kill $AUTHD_PID
+  fi
+}
+
+# Trap exit signals and do a proper shutdown
+trap "ossec_shutdown; exit" SIGINT SIGTERM
+
+chmod -R g+rw ${DATA_PATH}
+
+if [ $AUTO_ENROLLMENT_ENABLED == true ]
+then
+  echo "Starting ossec-authd..."
+  /var/ossec/bin/ossec-authd -p 1515 -g ossec $AUTHD_OPTIONS >/dev/null 2>&1 &
+  AUTHD_PID=$!
+fi
+sleep 15 # give ossec a reasonable amount of time to start before checking status
+LAST_OK_DATE=`date +%s`
+
+# Use ' ' as a delimiter
+sed -i -e "s {{SLACK_URL}} $SLACK_URL " /var/ossec/ossec.conf
+
+## Start services
+/usr/sbin/postfix start
+/bin/node /var/ossec/api/app.js &
+/usr/bin/filebeat.sh &
+/var/ossec/bin/ossec-control enable integrator
+/var/ossec/bin/ossec-control restart
+
+
+tail -f /var/ossec/logs/ossec.log

--- a/dockerfiles/wazuh/wazuh.repo
+++ b/dockerfiles/wazuh/wazuh.repo
@@ -1,0 +1,7 @@
+[wazuh_repo]
+gpgcheck=1
+gpgkey=https://packages.wazuh.com/key/GPG-KEY-WAZUH
+enabled=1
+name=CENTOS-$releasever - Wazuh
+baseurl=https://packages.wazuh.com/yum/el/$releasever/$basearch
+protect=1

--- a/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
@@ -12,7 +12,7 @@ module Barcelona
                  }
                ]
       end
-      let(:stack) { described_class.new(district) }
+      let(:stack) { described_class.new(district, Plugin.find_by(name: 'pcidss')) }
 
       before do
         allow_any_instance_of(PcidssBuilder).to receive(:ossec_volume_az) { 'ap-northeast-1a' }


### PR DESCRIPTION
This PR updates (almost rewrite from scratch..) our OSSEC configuration.

- Changed to use our own Wazuh image instead of the official one
  - The official image is not flexible enough, so I copied the files from the original repository and updated to make it work better with Barcelona
- Support Slack notification
  - a new option `slack_url` is added to pcidss plugin. if set, OSSEC (wazuh) sends alerts that are >= 12
- Suppress promiscuous mode alert
  - docker creates a veth for each container and set the veth promiscuous mode. This is a normal behavior so don't need to be alerted