### PR TITLE
Allow large file upload through reverse-proxy

### DIFF
--- a/dockerfiles/reverse-proxy/templates/nginx.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/nginx.conf.erb
@@ -21,6 +21,9 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
+  # allow large file upload
+  client_max_body_size 10m;
+
   gzip  on;
   gzip_static  on;
   gzip_http_version 1.0;


### PR DESCRIPTION

Extinguisher contains a CMS which supports file upload. So proxies front of it must allow large file upload. degica-production-nginx has definition for it [here](https://github.com/degica/degica-production-nginx/blob/fbce97d68f031c1bccc963b3e8cf6cf9cde31ffc/templates/extinguisher-site.conf.erb#L6).

Same is needed for barcelona-reverse-proxy. But 10m is enough for now.
