### PR TITLE
Do not alert syslog too large to slack

### DIFF
--- a/dockerfiles/wazuh/local_rules.xml
+++ b/dockerfiles/wazuh/local_rules.xml
@@ -7,3 +7,9 @@
     <group>audit_anom,pci_dss_11.4,pci_dss_10.6.1,</group>
   </rule>
 </group>
+
+<group name="syslog,errors,">
+  <rule id="1003" level="7" overwrite="yes" maxsize="1025" noalert="1">
+    <description>Non standard syslog message (size too large).</description>
+  </rule>
+</group>


### PR DESCRIPTION
This is set as "noalert" here https://github.com/wazuh/wazuh-ruleset/blob/master/rules/0020-syslog_rules.xml#L30 but this setting doesn't stop sending alerts to slack which we use.
alerts whose level is higher than 12 is alerted to slack, so I set the level to `7`