### PR TITLE
[WIP] Ignore long pending tasks on drainning

### DIFF
--- a/drain_instance.py
+++ b/drain_instance.py
@@ -36,6 +36,7 @@ def lambda_handler(event, context):
         ecs.update_container_instances_state(cluster=clusterName,containerInstances=[ciId],status='DRAINING')
 
     tasks = ecs.list_tasks(cluster=clusterName, containerInstance=ciId)['taskArns']
+    tasks = [ t['taskArn'] for t in ecs.describe_tasks(cluster=clusterName, tasks=tasks)['tasks'] if t['lastStatus'] == 'RUNNING' or (datetime.datetime.now(t['createdAt'].tzinfo) - t['createdAt']).seconds < 1800 ]
     if len(tasks) > 0:
         time.sleep(1)
         session.client('sns').publish(TopicArn=topicArn, Message=json.dumps(msg), Subject='Invoking lambda again')


### PR DESCRIPTION
This is a temporary fix for an ECS issue which suddenly stops reporting task status.

If this issue happens, the tasks status remain 'PENDING' forever, even after completion. This PR enables terminating instance. It filters out long 'PENDING' tasks for count.