### PR TITLE
Disable yum update --security on startup

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -12,7 +12,6 @@ class ContainerInstance
       "set -ex",
       # Embed SHA2 hash dockercfg so that instance replacement happens when dockercfg is updated
       "# #{Digest::SHA256.hexdigest(district.dockercfg.to_s)}",
-      "yum update -y --security",
 
       # Setup swap
       "MEMSIZE=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`",


### PR DESCRIPTION
I found that some times this setting causes weird errors so I'd like to disable it for now until we find a better solution