### PR TITLE
Loosen lifecycle check period 1s -> 5s

### DIFF
--- a/drain_instance.py
+++ b/drain_instance.py
@@ -37,7 +37,7 @@ def lambda_handler(event, context):
 
     tasks = ecs.list_tasks(cluster=clusterName, containerInstance=ciId)['taskArns']
     if len(tasks) > 0:
-        time.sleep(1)
+        time.sleep(5)
         session.client('sns').publish(TopicArn=topicArn, Message=json.dumps(msg), Subject='Invoking lambda again')
     else:
         session.client('autoscaling').complete_lifecycle_action(LifecycleHookName=lifecycleHookName, AutoScalingGroupName=asgName, LifecycleActionResult='CONTINUE', InstanceId=ec2Id)

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -116,7 +116,7 @@ module Barcelona
 
           j.Handler "index.lambda_handler"
           j.Runtime "python2.7"
-          j.Timeout "10"
+          j.Timeout "15"
           j.Role get_attr("ASGDrainingFunctionRole", "Arn")
           j.Environment do |j|
             j.Variables do |j|

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -219,7 +219,7 @@ describe Barcelona::Network::NetworkStack do
           },
           "Handler" => "index.lambda_handler",
           "Runtime" => "python2.7",
-          "Timeout" => "10",
+          "Timeout" => "15",
           "Role" => {"Fn::GetAtt" => ["ASGDrainingFunctionRole", "Arn"]},
           "Environment" => {
             "Variables" => {


### PR DESCRIPTION
checking container instance status every second seems to be too frequent so it may exceed the API rate limit. I changed the interval of 1 second to 5 seconds. 5 seconds in Lambda world is huge, but since the function is triggered only a few hundred times a day, I think it doesn't exceed the lambda free tier.