### PR TITLE
Increase proxy buffer size

### DIFF
--- a/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
@@ -31,6 +31,10 @@ server {
     proxy_read_timeout 60;
     proxy_send_timeout 60;
 
+    proxy_buffering on;
+    proxy_buffer_size 8k;
+    proxy_buffers 8 8k;
+
     proxy_pass http://<%= decorator.upstream_name %>;
   }
 }

--- a/dockerfiles/reverse-proxy/templates/server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/server.conf.erb
@@ -52,6 +52,10 @@ server {
     proxy_read_timeout 60;
     proxy_send_timeout 60;
 
+    proxy_buffering on;
+    proxy_buffer_size 8k;
+    proxy_buffers 8 8k;
+
     proxy_pass http://<%= decorator.upstream_name %>;
   }
 }


### PR DESCRIPTION
Currently if response headers from app is bigger than 4kb, nginx returns an error because its proxy buffer is not enough to store the large response. This PR doubles the buffer size