### PR TITLE
Set started_by to oneoff tasks

### DIFF
--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -9,7 +9,7 @@ class OneoffsController < ApplicationController
   def create
     interactive = !!params[:interactive]
     @oneoff = @heritage.oneoffs.create!(create_params)
-    @oneoff.run!(sync: !!params[:sync], interactive: interactive)
+    @oneoff.run!(sync: !!params[:sync], interactive: interactive, started_by: "barcelona/#{current_user.name}")
     json = if interactive
              certificate = @heritage.district.ca_sign_public_key(
                current_user,

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -16,7 +16,7 @@ class Oneoff < ActiveRecord::Base
   class ECSResourceError < RuntimeError
   end
 
-  def run(sync: false, interactive: false)
+  def run(sync: false, interactive: false, started_by: "barcelona")
     raise ArgumentError if sync && interactive
 
     self.session_token = SecureRandom.uuid if interactive
@@ -25,6 +25,7 @@ class Oneoff < ActiveRecord::Base
     resp = aws.ecs.run_task(
       cluster: district.name,
       task_definition: definition.family_name,
+      started_by: started_by,
       overrides: {
         container_overrides: [
           {

--- a/spec/models/oneoff_spec.rb
+++ b/spec/models/oneoff_spec.rb
@@ -47,6 +47,7 @@ describe Oneoff do
         with(
           cluster: heritage.district.name,
           task_definition: "#{heritage.name}-oneoff",
+          started_by: "barcelona",
           overrides: {
             container_overrides: [
               {
@@ -66,6 +67,7 @@ describe Oneoff do
                               with(
                                 cluster: heritage.district.name,
                                 task_definition: "#{heritage.name}-oneoff",
+                                started_by: "barcelona",
                                 overrides: {
                                   container_overrides: [
                                     {


### PR DESCRIPTION
Sometimes oneoff interactive container remains running after a developer disconnected from it. When many of such "zombie containers" exist in a cluster, they occupies the entire cluster resource preventing new service containers from launching. So if it happens, I manually kill those zombie containers. If I can know "who created those oneoffs" it's easier to be sure if I can safely kill them

Below is the example of "started by". the empty one is the oneoff container.

![image](https://user-images.githubusercontent.com/356330/33066037-84e0c8ae-ceed-11e7-8b97-a1f3ada7ec5d.png)
