### PR TITLE
Use Amazon Time Sync Service instead of built-in ntpd

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -13,6 +13,10 @@ class ContainerInstance
       # Embed SHA2 hash dockercfg so that instance replacement happens when dockercfg is updated
       "# #{Digest::SHA256.hexdigest(district.dockercfg.to_s)}",
 
+      "yum erase -y ntp*",
+      "yum install -y chrony",
+      "service chronyd start",
+
       # Setup swap
       "MEMSIZE=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`",
       "if [ $MEMSIZE -lt 2097152 ]; then",

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -168,6 +168,10 @@ module Barcelona
         EOS
 
         ud.run_commands += [
+          "yum erase -y ntp*",
+          "yum install -y chrony",
+          "service chronyd start",
+
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
           'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -64,14 +64,9 @@ module Barcelona
           # SSH session timeout
           "echo 'TMOUT=900 && readonly TMOUT && export TMOUT' > /etc/profile.d/tmout.sh",
 
-          # NTP
-          "sed -i '/^server /s/^/#/' /etc/ntp.conf",
-          "sed -i 's/^logconfig .*/logconfig =all/' /etc/ntp.conf",
-          'echo logfile /var/log/ntpstats/ntpd.log >> /etc/ntp.conf',
-          district.subnets("Public").map(&:subnet_id).map { |id|
-            "echo server #{id}.ntp.#{district.name}.bcn iburst >> /etc/ntp.conf"
-          },
-          "service ntpd restart",
+          "yum erase -y ntp*",
+          "yum install -y chrony",
+          "service chronyd start",
 
           # Configure sshd
           'printf "\nTrustedUserCAKeys /etc/ssh/ssh_ca_key.pub\n" >> /etc/ssh/sshd_config',
@@ -683,15 +678,6 @@ EOS
 
           # SSH session timeout
           "echo 'TMOUT=900 && readonly TMOUT && export TMOUT' > /etc/profile.d/tmout.sh",
-
-          # NTP
-          "sed -i '/^server /s/^/#/' /etc/ntp.conf",
-          "sed -i 's/^logconfig .*/logconfig =all/' /etc/ntp.conf",
-          'echo logfile /var/log/ntpstats/ntpd.log >> /etc/ntp.conf',
-          district.subnets("Public").map(&:subnet_id).map { |id|
-            "echo server #{id}.ntp.#{district.name}.bcn iburst >> /etc/ntp.conf"
-          },
-          "service ntpd restart",
 
           # Ignores error on OSSEC installation process.
           "set +e",


### PR DESCRIPTION
Fixes #441 

The motivation is that with the time sync service, we don't need the complex NTP configuration in PCIDSS plugin (a dedicated NTP server, hot-standby ENI, right ENI selection)

the following error occurred during the initialization

```
+ service chronyd start
Generating chrony command key: tr: write error: Broken pipe
tr: write error
[  OK  ]
```

but I confirmed that the right chrony key is generated & stroed in the right place (/etc/chrony.keys)

the instance in test district with this configuration has been running for a few days and chrony correctly syncing time