### PR TITLE
Revert "Upgrade nodejs runtime version"

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -49,7 +49,7 @@ class Heritage < ActiveRecord::Base
         add_resource("AWS::Lambda::Function", "ScheduleHandler") do |j|
           j.Handler "index.handler"
           j.Role get_attr("ScheduleHandlerRole", "Arn")
-          j.Runtime "nodejs8.10"
+          j.Runtime "nodejs6.10"
           j.Timeout 60
           j.Code do |j|
             j.ZipFile schedule_handler_code

--- a/app/models/notification_stack.rb
+++ b/app/models/notification_stack.rb
@@ -64,7 +64,7 @@ class NotificationStack < CloudFormation::Stack
                 j.DISTRICT stack.district.name
               end
             end
-            j.Runtime "nodejs8.10"
+            j.Runtime "nodejs6.10"
             j.Code do |j|
               j.ZipFile slack_notification_code
             end


### PR DESCRIPTION
Reverts degica/barcelona#457

Node 8 is still not supported by CloudFormation...