### PR TITLE
Add X-Request-Start to the reverse proxy headers

### DIFF
--- a/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
@@ -26,6 +26,7 @@ server {
     proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Request-Start "t=${msec}";
     proxy_redirect off;
 
     proxy_read_timeout 60;

--- a/dockerfiles/reverse-proxy/templates/server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/server.conf.erb
@@ -47,6 +47,7 @@ server {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     <% end %>
     proxy_set_header Host $http_host;
+    proxy_set_header X-Request-Start "t=${msec}";
     proxy_redirect off;
 
     proxy_read_timeout 60;


### PR DESCRIPTION
To gain capability to get E2E metric https://docs.newrelic.com/docs/apm/applications-menu/features/request-queue-server-configuration-examples