### PR TITLE
Bootstrap script requires secret key base

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,9 @@ development:
 test:
   secret_key_base: 1eae0f2519e8131371e9c85ad9de83912ba3786edd020ce1333c010d0a025503166d74236e5c57b261c2f4b672feae8fdfb206c75a2b51f312887f177c3dda80
 
+bootstrap:
+  secret_key_base: edda5913057f53efb49839662569b4f57366a5775648acbdc95f824c9a2a40c7dc7a3683f825482fd617fe9573ae03c9a14964ae1225dfb68353a237d2a8c925
+
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:


### PR DESCRIPTION
I noticed the bootstrap script no longer works with the current version of Rails. It's throwing an exception for me because it won't load the Rails environment without a secret key base defined.