### PR TITLE
Update ECS optimized AMI to 2018.03.e

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -2,23 +2,23 @@ module Barcelona
   module Network
     class AutoscalingBuilder < CloudFormation::Builder
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-      # amzn-ami-2018.03.d-amazon-ecs-optimized
+      # amzn-ami-2018.03.e-amazon-ecs-optimized
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-112e366e",
-        "us-east-2"      => "ami-0e65e665ff5f3fc5f",
-        "us-west-1"      => "ami-dd0de2be",
-        "us-west-2"      => "ami-a1f8dfd9",
-        "eu-west-1"      => "ami-0612d1ef7f8e72c06",
-        "eu-west-2"      => "ami-c3ea1fa4",
-        "eu-west-3"      => "ami-0e4185127a627bbac",
-        "eu-central-1"   => "ami-c7e9e72c",
-        "ap-northeast-1" => "ami-256c15c8",
-        "ap-northeast-2" => "ami-02b0706448bd6fb5e",
-        "ap-southeast-1" => "ami-0e1566e9c8eb85002",
-        "ap-southeast-2" => "ami-df49e9bd",
-        "ca-central-1"   => "ami-cf60edab",
-        "ap-south-1"     => "ami-0c814df738f3c9fd5",
-        "sa-east-1"      => "ami-085384d0e5fd5ae0a",
+        "us-east-1"      => "ami-00129b193dc81bc31",
+        "us-east-2"      => "ami-028a9de0a7e353ed9",
+        "us-west-1"      => "ami-0d438d09af26c9583",
+        "us-west-2"      => "ami-00d4f478",
+        "eu-west-1"      => "ami-0af844a965e5738db",
+        "eu-west-2"      => "ami-a44db8c3",
+        "eu-west-3"      => "ami-07da674f0655ef4e1",
+        "eu-central-1"   => "ami-0291ba887ba0d515f",
+        "ap-northeast-1" => "ami-0041c416aa23033a2",
+        "ap-northeast-2" => "ami-047d2a61f94f862dc",
+        "ap-southeast-1" => "ami-091bf462afdb02c60",
+        "ap-southeast-2" => "ami-0092e55c70015d8c3",
+        "ca-central-1"   => "ami-192fa27d",
+        "ap-south-1"     => "ami-0c179ca015d301829",
+        "sa-east-1"      => "ami-0018ff8ee48970ac3",
       }
 
       def ebs_optimized_by_default?


### PR DESCRIPTION
This PR will update the ami as following page.

* [Amazon ECS\-Optimized AMI \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

So frequent release! 😢 