### PR TITLE
Show amazon-linux ami as well as ecs-optimized

### DIFF
--- a/bin/show_ecs_images
+++ b/bin/show_ecs_images
@@ -1,15 +1,7 @@
 #!/usr/bin/env ruby
 
-IMAGE_LOCATION=ARGV.first
-unless IMAGE_LOCATION
-  STDERR.puts "usage: show_ecs_images amzn-ami-2017.09.i-amazon-ecs-optimized"
-  exit 1
-end
-
-AMAZON_OWNER_ID="591542846629"
-
 # us-gov-west-1 is excluded because it requires special privilage
-REGIONS=%w(
+regions=%w(
         us-east-1
         us-east-2
         us-west-1
@@ -26,10 +18,27 @@ REGIONS=%w(
         ap-south-1
         sa-east-1
 )
+def show_image_id_for_amazon_linux(regions)
+  path = '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2'
+  STDERR.puts "getting image id of #{path}..."
 
-REGIONS.each do |region|
-  image_id=`aws --region #{region} ec2 describe-images --owners #{AMAZON_OWNER_ID} | jq -r '.Images[] | select(.ImageLocation|match("#{IMAGE_LOCATION}"))|.ImageId'`.chomp
-  puts %Q{        "#{region}"      => "#{image_id}",}
+  regions.each do |region|
+    image_id=`aws ssm get-parameters --names #{path} --region #{region} --query 'Parameters[0].Value'`.chomp
+    puts %Q{        "#{region}"      => "#{image_id}",}
+  end
 end
 
 
+def show_image_id_for_ecs_optimized(regions)
+  path = '/aws/service/ecs/optimized-ami/amazon-linux/recommended'
+  image_name=`aws ssm get-parameters --names #{path} --region us-east-1 --query 'Parameters[0].Value' --output text | jq -r '.image_name'`
+  STDERR.puts "getting image id of #{path} ( latest version is #{image_name} )..."
+
+  regions.each do |region|
+    image_id=`aws ssm get-parameters --names #{path} --region #{region} --query 'Parameters[0].Value' --output text | jq -r '.image_id'`.chomp
+    puts %Q{        "#{region}"      => "#{image_id}",}
+  end
+end
+
+show_image_id_for_amazon_linux(regions)
+show_image_id_for_ecs_optimized(regions)


### PR DESCRIPTION
Resolves #477

This PR modifies `bin/show_ecs_image`

* Show the latest ami of amazon-linux as well as ecs-optimized
* Get the latest version of ecs-optimized
* Do it with `aws ssm` and public parameters 

Sample Output
```
$ bin/show_ecs_images
getting image id of /aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2...
        "us-east-1"      => ""ami-0ff8a91507f77f867"",
        "us-east-2"      => ""ami-0b59bfac6be064b78"",
        "us-west-1"      => ""ami-0bdb828fd58c52235"",
        "us-west-2"      => ""ami-a0cfeed8"",
        "eu-west-1"      => ""ami-047bb4163c506cd98"",
        "eu-west-2"      => ""ami-f976839e"",
        "eu-west-3"      => ""ami-0ebc281c20e89ba4b"",
        "eu-central-1"      => ""ami-0233214e13e500f77"",
        "ap-northeast-1"      => ""ami-06cd52961ce9f0d85"",
        "ap-northeast-2"      => ""ami-0a10b2721688ce9d2"",
        "ap-southeast-1"      => ""ami-08569b978cc4dfa10"",
        "ap-southeast-2"      => ""ami-09b42976632b27e9b"",
        "ca-central-1"      => ""ami-0b18956f"",
        "ap-south-1"      => ""ami-0912f71e06545ad88"",
        "sa-east-1"      => ""ami-07b14488da8ea02a0"",
getting image id of /aws/service/ecs/optimized-ami/amazon-linux/recommended ( latest version is amzn-ami-2018.03.g-amazon-ecs-optimized
 )...
        "us-east-1"      => "ami-0b9a214f40c38d5eb",
        "us-east-2"      => "ami-09a64272e7fe706b6",
        "us-west-1"      => "ami-0e7dd5fe55b87a5fe",
        "us-west-2"      => "ami-00430184c7bb49914",
        "eu-west-1"      => "ami-05b65c0f6a75c1c64",
        "eu-west-2"      => "ami-0209769f0c963e791",
        "eu-west-3"      => "ami-06b685336aa497c15",
        "eu-central-1"      => "ami-0bb804e8cd910a664",
        "ap-northeast-1"      => "ami-08681de00a0aae54f",
        "ap-northeast-2"      => "ami-0d947b1901b27a37c",
        "ap-southeast-1"      => "ami-0a3f70f0255af1d29",
        "ap-southeast-2"      => "ami-05b48eda7f92aadbe",
        "ca-central-1"      => "ami-00d1bdbd447b5933a",
        "ap-south-1"      => "ami-0590d0dd683026eab",
        "sa-east-1"      => "ami-01bca91ecf4c1f494",
```

There are some variants of amazon linux.

- [AWS Systems Manager Parameter Store を使用して最新の Amazon Linux AMI IDを取得する \| Amazon Web Services ブログ](https://aws.amazon.com/jp/blogs/news/query-for-the-latest-amazon-linux-ami-ids-using-aws-systems-manager-parameter-store/)

```
/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs
/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-x86_64-ebs
/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-ebs
/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2
/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-s3
/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-ebs
/aws/service/ami-amazon-linux-latest/amzn-ami-minimal-hvm-x86_64-s3
```

I think `/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2` is what we are using for bastion server.
