### PR TITLE
Update AMIs for ecs instances, bastion instances and nat instances

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -2,23 +2,23 @@ module Barcelona
   module Network
     class AutoscalingBuilder < CloudFormation::Builder
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
-      # amzn-ami-2018.03.g-amazon-ecs-optimized
+      # amzn-ami-2018.03.h-amazon-ecs-optimized
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0b9a214f40c38d5eb",
-        "us-east-2"      => "ami-09a64272e7fe706b6",
-        "us-west-1"      => "ami-0e7dd5fe55b87a5fe",
-        "us-west-2"      => "ami-00430184c7bb49914",
-        "eu-west-1"      => "ami-05b65c0f6a75c1c64",
-        "eu-west-2"      => "ami-0209769f0c963e791",
-        "eu-west-3"      => "ami-06b685336aa497c15",
-        "eu-central-1"   => "ami-0bb804e8cd910a664",
-        "ap-northeast-1" => "ami-08681de00a0aae54f",
-        "ap-northeast-2" => "ami-0d947b1901b27a37c",
-        "ap-southeast-1" => "ami-0a3f70f0255af1d29",
-        "ap-southeast-2" => "ami-05b48eda7f92aadbe",
-        "ca-central-1"   => "ami-00d1bdbd447b5933a",
-        "ap-south-1"     => "ami-0590d0dd683026eab",
-        "sa-east-1"      => "ami-01bca91ecf4c1f494",
+        "us-east-1"      => "ami-07eb698ce660402d2",
+        "us-east-2"      => "ami-0a0c6574ce16ce87a",
+        "us-west-1"      => "ami-04c22ba97a0c063c4",
+        "us-west-2"      => "ami-09568291a9d6c804c",
+        "eu-west-1"      => "ami-066826c6a40879d75",
+        "eu-west-2"      => "ami-0cb31bf24b130a0f9",
+        "eu-west-3"      => "ami-0a0948de946510ec0",
+        "eu-central-1"      => "ami-0b9fee3a2d0596ed1",
+        "ap-northeast-1"      => "ami-0edf19001c48838c7",
+        "ap-northeast-2"      => "ami-0b52e57bed048ca48",
+        "ap-southeast-1"      => "ami-08d4fe232c67b81b8",
+        "ap-southeast-2"      => "ami-08c26730c8ee004fa",
+        "ca-central-1"      => "ami-055750f063052ec55",
+        "ap-south-1"      => "ami-05f009513cd58ac90",
+        "sa-east-1"      => "ami-0ada25501ac1375b3",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -4,20 +4,21 @@ module Barcelona
       # https://aws.amazon.com/amazon-linux-ami/
       # Amazon Linux AMI 2017.03.1
       AMI_IDS = {
-        "us-east-1" => "ami-4fffc834",
-        "us-east-2" => "ami-ea87a78f",
-        "us-west-1" => "ami-3a674d5a",
-        "us-west-2" => "ami-aa5ebdd2",
-        "eu-west-1" => "ami-ebd02392",
-        "eu-west-2" => "ami-489f8e2c",
-        "eu-central-1" => "ami-657bd20a",
-        "ap-northeast-1" => "ami-4af5022c",
-        "ap-northeast-2" => "ami-8663bae8",
-        "ap-southeast-1" => "ami-fdb8229e",
-        "ap-southeast-2" => "ami-30041c53",
-        "ap-south-1" => "ami-d7abd1b8",
-        "ca-central-1" => "ami-5ac17f3e",
-        "sa-east-1" => "ami-d27203be"
+        "us-east-1"      => "ami-0ff8a91507f77f867",
+        "us-east-2"      => "ami-0b59bfac6be064b78",
+        "us-west-1"      => "ami-0bdb828fd58c52235",
+        "us-west-2"      => "ami-a0cfeed8",
+        "eu-west-1"      => "ami-047bb4163c506cd98",
+        "eu-west-2"      => "ami-f976839e",
+        "eu-west-3"      => "ami-0ebc281c20e89ba4b",
+        "eu-central-1"      => "ami-0233214e13e500f77",
+        "ap-northeast-1"      => "ami-06cd52961ce9f0d85",
+        "ap-northeast-2"      => "ami-0a10b2721688ce9d2",
+        "ap-southeast-1"      => "ami-08569b978cc4dfa10",
+        "ap-southeast-2"      => "ami-09b42976632b27e9b",
+        "ca-central-1"      => "ami-0b18956f",
+        "ap-south-1"      => "ami-0912f71e06545ad88",
+        "sa-east-1"      => "ami-07b14488da8ea02a0",
       }
 
       def build_resources

--- a/lib/barcelona/network/nat_builder.rb
+++ b/lib/barcelona/network/nat_builder.rb
@@ -1,18 +1,24 @@
 module Barcelona
   module Network
     class NatBuilder < CloudFormation::Builder
-      # amzn-ami-vpc-nat-hvm-2016.09.0.20160923-x86_64-ebs
+      # https://aws.amazon.com/jp/amazon-linux-ami/
+      # amzn-ami-vpc-nat-hvm-2018.03.0.20180811-x86_64-ebs
       VPC_NAT_AMI_IDS = {
-        "us-east-1" => "ami-d2ee95c5",
-        "us-east-2" => "ami-9fc299fa",
-        "us-west-1" => "ami-90357bf0",
-        "us-west-2" => "ami-c4469aa4",
-        "eu-west-1" => "ami-d41d58a7",
-        "eu-central-1" => "ami-b646bbd9",
-        "ap-northeast-1" => "ami-831fcde2",
-        "ap-southeast-1" => "ami-9c40e5ff",
-        "ap-southeast-2" => "ami-addbebce",
-        "ca-central-1" => "ami-a88735cc"
+        "us-east-1"      => "ami-0422d936d535c63b1",
+        "us-east-2"      => "ami-0f9c61b5a562a16af",
+        "us-west-1"      => "ami-0d4027d2cdbca669d",
+        "us-west-2"      => "ami-40d1f038",
+        "eu-west-1"      => "ami-0ea87e2bfa81ca08a",
+        "eu-west-2"      => "ami-e6768381",
+        "eu-west-3"      => "ami-0050bb60cea70c5b3",
+        "eu-central-1"      => "ami-06465d49ba60cf770",
+        "ap-northeast-1"      => "ami-0cf78ae724f63bac0",
+        "ap-northeast-2"      => "ami-08cfa02141f9e9bee",
+        "ap-southeast-1"      => "ami-0cf24653bcf894797",
+        "ap-southeast-2"      => "ami-00c1445796bc0a29f",
+        "ca-central-1"      => "ami-b61b96d2",
+        "ap-south-1"      => "ami-0aba92643213491b9",
+        "sa-east-1"      => "ami-09c013530239687aa",
       }
 
       def build_resources


### PR DESCRIPTION
I updated ami ids for ecs container instances, bastion instances and nat instances with [the new version of show_ecs_images]( https://github.com/degica/barcelona/pull/478).

