### PR TITLE
Use bastion's AMI ID for ossec manager

### DIFF
--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -2,7 +2,7 @@ module Barcelona
   module Network
     class BastionBuilder < CloudFormation::Builder
       # https://aws.amazon.com/amazon-linux-ami/
-      # Amazon Linux AMI 2017.03.1
+      # Amazon Linux AMI 2018.03.0
       AMI_IDS = {
         "us-east-1"      => "ami-0ff8a91507f77f867",
         "us-east-2"      => "ami-0b59bfac6be064b78",

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -211,7 +211,8 @@ module Barcelona
         add_resource("AWS::AutoScaling::LaunchConfiguration",
                      "OSSECManagerLaunchConfiguration") do |j|
           j.IamInstanceProfile ref("OSSECManagerInstanceProfile")
-          j.ImageId "ami-92df37ed"
+          # Bastion AMI is a plain Amazon Linux AMI. we just reuse it for OSSEC manager
+          j.ImageId Barcelona::Network::BastionBuilder::AMI_IDS["ap-northeast-1"]
           j.InstanceType "t2.medium"
           j.SecurityGroups [ref("OSSECManagerSG")]
           j.UserData manager_user_data.build


### PR DESCRIPTION
Instead of hard-coding the ID here, it is better to refer the bastion's AMI ID since both instances should use the same AMI