### PR TITLE
Support latest instance types for container instances

### DIFF
--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -182,7 +182,7 @@ class District < ActiveRecord::Base
     self.nat_type       ||= "instance"
     self.cluster_backend  ||= 'autoscaling'
     self.cluster_size     ||= 1
-    self.cluster_instance_type ||= "t2.small"
+    self.cluster_instance_type ||= "t3.small"
   end
 
   def network_stack

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -22,7 +22,8 @@ module Barcelona
       }
 
       def ebs_optimized_by_default?
-        !!(instance_type =~ /\A(c4|m4|d2)\..*\z/)
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
+        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
       end
 
       def build_resources

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -141,10 +141,10 @@ describe Barcelona::Network::NetworkStack do
         "Properties" => {
           "IamInstanceProfile" => {"Ref"=>"ECSInstanceProfile"},
           "ImageId" => kind_of(String),
-          "InstanceType" => "t2.small",
+          "InstanceType" => "t3.small",
           "SecurityGroups" => [{"Ref"=>"InstanceSecurityGroup"}],
           "UserData" => instance_of(String),
-          "EbsOptimized" => false,
+          "EbsOptimized" => true,
           "BlockDeviceMappings" => [
             {
               "DeviceName"=>"/dev/xvda",

--- a/spec/requests/create_district_spec.rb
+++ b/spec/requests/create_district_spec.rb
@@ -33,7 +33,7 @@ describe "POST /districts", type: :request do
       expect(body["district"]["nat_type"]).to eq "instance"
       expect(body["district"]["cluster_size"]).to eq 1
       expect(body["district"]["cluster_backend"]).to eq "autoscaling"
-      expect(body["district"]["cluster_instance_type"]).to eq "t2.small"
+      expect(body["district"]["cluster_instance_type"]).to eq "t3.small"
     end
 
     context "when running in ECS environment" do


### PR DESCRIPTION
The regex looks crazy but couldn't find a better solution. we can remove that logic entirely when we drop support for instance types that do not support EBS-optimized (namely, t2 instances)