### PR TITLE
Update bastion

### DIFF
--- a/bin/show_ecs_images
+++ b/bin/show_ecs_images
@@ -18,8 +18,8 @@ regions=%w(
         ap-south-1
         sa-east-1
 )
-def show_image_id_for_amazon_linux(regions)
-  path = '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2'
+def show_image_id_for_amazon_linux2(regions)
+  path = '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
   STDERR.puts "getting image id of #{path}..."
 
   regions.each do |region|
@@ -51,6 +51,6 @@ def show_image_id_for_nat_instance(regions)
   end
 end
 
-show_image_id_for_amazon_linux(regions)
+show_image_id_for_amazon_linux2(regions)
 show_image_id_for_ecs_optimized(regions)
 show_image_id_for_nat_instance(regions)

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # https://aws.amazon.com/amazon-linux-ami/
       # Amazon Linux 2 AMI
       AMI_IDS = {
-        "us-east-1"      => "ami-035be7bafff33b6b6",
-        "us-east-2"      => "ami-04328208f4f0cf1fe",
-        "us-west-1"      => "ami-0799ad445b5727125",
-        "us-west-2"      => "ami-032509850cf9ee54e",
-        "eu-west-1"      => "ami-0fad7378adf284ce0",
-        "eu-west-2"      => "ami-0664a710233d7c148",
-        "eu-west-3"      => "ami-0854d53ce963f69d8",
-        "eu-central-1"      => "ami-0eaec5838478eb0ba",
-        "ap-northeast-1"      => "ami-0d7ed3ddb85b521a6",
-        "ap-northeast-2"      => "ami-018a9a930060d38aa",
-        "ap-southeast-1"      => "ami-04677bdaa3c2b6e24",
-        "ap-southeast-2"      => "ami-0c9d48b5db609ad6e",
-        "ca-central-1"      => "ami-0de8b8e4bc1f125fe",
-        "ap-south-1"      => "ami-0937dcc711d38ef3f",
-        "sa-east-1"      => "ami-0b04450959586da29",
+        "us-east-1"      => "ami-02da3a138888ced85",
+        "us-east-2"      => "ami-0de7daa7385332688",
+        "us-west-1"      => "ami-09bfcadb25ee95bec",
+        "us-west-2"      => "ami-095cd038eef3e5074",
+        "eu-west-1"      => "ami-02a39bdb8e8ee056a",
+        "eu-west-2"      => "ami-07a5200f3fa9c33d3",
+        "eu-west-3"      => "ami-0e9073d7ac75f4491",
+        "eu-central-1"      => "ami-07f1fbbff759e24dd",
+        "ap-northeast-1"      => "ami-097473abce069b8e9",
+        "ap-northeast-2"      => "ami-045e355a6004a67c4",
+        "ap-southeast-1"      => "ami-00158b185c8cc09dc",
+        "ap-southeast-2"      => "ami-0c3228fd049cdb151",
+        "ca-central-1"      => "ami-05f9d71283317f5c9",
+        "ap-south-1"      => "ami-03103e7ded4c02ef8",
+        "sa-east-1"      => "ami-095a33e72f6bb89c3",
       }
 
       def build_resources

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -313,16 +313,8 @@ describe Barcelona::Network::NetworkStack do
             {"IpProtocol" => "tcp",
              "FromPort" => 22,
              "ToPort" => 22,
-             "CidrIp" => "0.0.0.0/0"},
-            {"IpProtocol" => "udp",
-             "FromPort" => 123,
-             "ToPort" => 123,
-             "CidrIp" => district.cidr_block}],
+             "CidrIp" => "0.0.0.0/0"}],
           "SecurityGroupEgress" => [
-            {"IpProtocol" => "udp",
-             "FromPort" => 123,
-             "ToPort" => 123,
-             "CidrIp" => "0.0.0.0/0"},
             {"IpProtocol" => "tcp",
              "FromPort" => 22,
              "ToPort" => 22,
@@ -368,32 +360,16 @@ describe Barcelona::Network::NetworkStack do
             ]
           },
           "Path"=>"/",
-          "Policies" => [
-            {
-              "PolicyName" => "bastion-role",
-              "PolicyDocument" => {
-                "Version" => "2012-10-17",
-                "Statement" => [
-                  {
-                    "Effect"=>"Allow",
-                    "Action" => [
-                      "logs:CreateLogGroup",
-                      "logs:CreateLogStream",
-                      "logs:DescribeLogStreams",
-                      "logs:PutLogEvents",
-                    ],
-                    "Resource"=>["*"]
-                  }
-                ]
-              }
-            }
-          ]
+          "ManagedPolicyArns" => [
+            "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM",
+            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+          ],
         }
       },
       "BastionLaunchConfiguration" => {
         "Type" => "AWS::AutoScaling::LaunchConfiguration",
         "Properties" => {
-          "InstanceType" => "t2.micro",
+          "InstanceType" => "t3.micro",
           "IamInstanceProfile" => {"Ref" => "BastionProfile"},
           "ImageId" => kind_of(String),
           "UserData" => anything,

--- a/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/pcidss_plugin_spec.rb
@@ -48,7 +48,6 @@ module Barcelona
         ci = ContainerInstance.new(district)
         plugin = district.plugins.find_by(name: 'pcidss').plugin
         user_data = YAML.load(Base64.decode64(ci.user_data.build))
-        expect(user_data["packages"]).to include(*described_class::SYSTEM_PACKAGES)
         expect(user_data["runcmd"]).to include(*plugin.run_commands)
       end
 
@@ -57,7 +56,6 @@ module Barcelona
         template = JSON.load(::Barcelona::Network::NetworkStack.new(district).target!)
         user_data = InstanceUserData.load(template["Resources"]["BastionLaunchConfiguration"]["Properties"]["UserData"])
         plugin = district.plugins.find_by(name: 'pcidss').plugin
-        expect(user_data.packages).to include(*described_class::SYSTEM_PACKAGES)
         expect(user_data.run_commands).to include(*plugin.run_commands)
       end
 


### PR DESCRIPTION
- Use Amazon Linux 2 for bastion servers
- Removed unused ports from SG
- Added managed policies for SSM and CW logs and removed inline policy
- OSSEC manager do not start ssh daemon because we'll use SSM session manager