### PR TITLE
Declarative environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :test do
   gem 'rspec-rails'
   gem 'rspec-its'
   gem 'factory_bot_rails'
-  gem 'database_rewinder'
   gem 'stub_env'
   gem 'webmock'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    database_rewinder (0.9.1)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -264,7 +263,6 @@ DEPENDENCIES
   aws-sdk-route53
   aws-sdk-s3
   aws-sdk-sns
-  database_rewinder
   delayed_job_active_record
   factory_bot_rails
   gibberish

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -113,6 +113,11 @@ class HeritagesController < ApplicationController
       scheduled_tasks: [
         :schedule,
         :command
+      ],
+      environment: [
+        :name,
+        :value,
+        :value_from
       ]
     ]).tap do |whitelisted|
       if params[:services].present?

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -3,6 +3,10 @@ class HeritagesController < ApplicationController
   before_action :load_heritage, except: [:index, :create, :trigger]
   skip_before_action :authenticate, only: [:trigger]
 
+  # Declarative environment doesn't work for scheduled tasks because scheduled tasks use CloudFormation
+  # for creating task definitions and CF still does not support `ContainerDefinitions.Secrets` parameters.
+  before_action :forbid_environment, only: [:create, :update, :trigger], unless: -> { Rails.env.test? }
+
   def index
     render json: @district.heritages
   end
@@ -134,5 +138,9 @@ class HeritagesController < ApplicationController
 
   def load_district
     @district = District.find_by!(name: params[:district_id])
+  end
+
+  def forbid_environment
+    raise "Specifying environment is not yet supproted for normal deployments" if params[:environment].present?
   end
 end

--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -8,6 +8,12 @@ class DeployRunnerJob < ActiveJob::Base
         return
       end
 
+      loop do
+        break unless heritage.cf_executor.in_progress?
+        puts "Waiting for heritage stack to be complete"
+        sleep 5
+      end
+
       notify(heritage, message: "Deploying to #{heritage.district.name} district: #{description}")
       before_deploy = heritage.before_deploy
       if before_deploy.present? && !without_before_deploy

--- a/app/models/district.rb
+++ b/app/models/district.rb
@@ -151,7 +151,8 @@ class District < ActiveRecord::Base
 
   def base_task_definition
     base = {
-      environment: []
+      environment: [],
+      secrets: []
     }
     hook_plugins(:district_task_definition, self, base)
   end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -9,17 +9,13 @@ class Environment < ApplicationRecord
   validates :value, presence: true, if: -> { value_from.blank? }
   validates :value_from, presence: true, if: -> { value.blank? }
 
+  attr_accessor :ssm_path
 
-  # If value_from is nil return it as-is
-  # if value_from is a relative name prefix /barcelona/district-name/
-  #   ECS resolves relative value_from as a SSM parameter in the same account and region
-  def namespaced_value_from
-    return nil if value_from.nil?
-    return value_from if value_from.start_with?("arn:aws:")
-
-    s = value_from
-    s = "/" + s unless s.start_with?("/")
-    s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")
-    s
+  before_validation do
+    if ssm_path
+      s = "/" + ssm_path unless ssm_path.start_with?("/")
+      s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")
+      self.value_from = s
+    end
   end
 end

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -10,6 +10,8 @@ class Environment < ApplicationRecord
   validates :value_from, presence: true, if: -> { value.blank? }
 
   def namespaced_value_from
+    return value_from if value_from.start_with?("arn:aws:")
+
     s = value_from
     s = "/" + s unless s.start_with?("/")
     s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -13,6 +13,7 @@ class Environment < ApplicationRecord
 
   before_validation do
     if ssm_path
+      s = ssm_path
       s = "/" + ssm_path unless ssm_path.start_with?("/")
       s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")
       self.value_from = s

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -9,7 +9,12 @@ class Environment < ApplicationRecord
   validates :value, presence: true, if: -> { value_from.blank? }
   validates :value_from, presence: true, if: -> { value.blank? }
 
+
+  # If value_from is nil return it as-is
+  # if value_from is a relative name prefix /barcelona/district-name/
+  #   ECS resolves relative value_from as a SSM parameter in the same account and region
   def namespaced_value_from
+    return nil if value_from.nil?
     return value_from if value_from.start_with?("arn:aws:")
 
     s = value_from

--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -1,0 +1,18 @@
+class Environment < ApplicationRecord
+  belongs_to :heritage
+  delegate :district, to: :heritage
+
+  scope :plains, -> { where(value_from: nil) }
+  scope :secrets, -> { where.not(value_from: nil) }
+
+  validates :name, uniqueness: {scope: :heritage_id}, presence: true
+  validates :value, presence: true, if: -> { value_from.blank? }
+  validates :value_from, presence: true, if: -> { value.blank? }
+
+  def namespaced_value_from
+    s = value_from
+    s = "/" + s unless s.start_with?("/")
+    s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")
+    s
+  end
+end

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -272,7 +272,7 @@ class Heritage < ActiveRecord::Base
     )
     if with_environment
       base[:environment] += environment_set
-      base[:secrets] += environments.secrets.map { |e| {name: e.name, value_from: e.namespaced_value_from} }
+      base[:secrets] += environments.secrets.map { |e| {name: e.name, value_from: e.value_from} }
     end
 
     district.hook_plugins(:heritage_task_definition, self, base)

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -304,6 +304,10 @@ class Heritage < ActiveRecord::Base
     union.map { |k, v| {name: k, value: v} }
   end
 
+  def legacy_secrets
+    env_vars.where(secret: true).where.not(key: environments.secrets.pluck(:name))
+  end
+
   private
 
   def update_services(release, without_before_deploy)

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -47,7 +47,7 @@ class HeritageTaskDefinition
                     end
     end
     ret = {family: family_name, container_definitions: containers}
-    ret = ret.merge(task_role_arn: heritage.task_role_id) unless without_task_role
+    ret = ret.merge(task_role_arn: heritage.task_role_id, execution_role_arn: heritage.task_execution_role_id) unless without_task_role
     if camelize
       ret = deep_transform_keys_with_parent_keys(ret) do |k, parents|
         (parents.last(2) != [:log_configuration, :options] &&

--- a/app/serializers/heritage_serializer.rb
+++ b/app/serializers/heritage_serializer.rb
@@ -1,6 +1,6 @@
 class HeritageSerializer < ActiveModel::Serializer
   attributes :name, :image_name, :image_tag, :env_vars, :before_deploy,
-             :token, :version, :scheduled_tasks
+             :token, :version, :scheduled_tasks, :environment
 
   has_many :services
   belongs_to :district
@@ -9,5 +9,11 @@ class HeritageSerializer < ActiveModel::Serializer
     Hash[object.env_vars.map do |e|
       [e.key, e.value.presence || "<secret>"]
     end]
+  end
+
+  def environment
+    object.environments.
+      map { |e| e.slice(:name, :value, :value_from) }.
+      sort_by { |e| e[:name] }
   end
 end

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -32,7 +32,7 @@ class BuildHeritage
 
     if new_params[:environment]
       new_params[:environments_attributes] = new_params.delete(:environment).map do |e|
-        e.slice(:name, :value, :value_from)
+        e.slice(:name, :value, :value_from, :ssm_path)
       end
       new_params[:environments_attributes] = sync_resources(new_params[:environments_attributes], heritage.environments, :name)
     end

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -30,6 +30,14 @@ class BuildHeritage
       end
     end
 
+    if new_params[:environment]
+      new_params[:environments_attributes] = new_params.delete(:environment).map do |e|
+        e.slice(:name, :value, :value_from)
+      end
+      new_params[:environments_attributes] = sync_resources(new_params[:environments_attributes], heritage.environments, :name)
+    end
+
+
     unless heritage.new_record?
       new_params.delete :name
 

--- a/app/values/launch_command.rb
+++ b/app/values/launch_command.rb
@@ -21,7 +21,7 @@ class LaunchCommand
       "load-env-and-run",
       "--region", heritage.district.region,
       "--bucket-name", heritage.district.s3_bucket_name,
-      heritage.env_vars.where(secret: true).map { |e| ["-e", "#{e.key}=#{e.s3_path}"] },
+      heritage.legacy_secrets.map { |e| ["-e", "#{e.key}=#{e.s3_path}"] },
       @command
     ].flatten
   end

--- a/db/migrate/20190223124754_create_environments.rb
+++ b/db/migrate/20190223124754_create_environments.rb
@@ -1,0 +1,12 @@
+class CreateEnvironments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :environments do |t|
+      t.references :heritage, null: false, foreign_key: {on_delete: :cascade}
+      t.string :name, null: false
+      t.text :value
+      t.text :value_from
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017_06_19_094107) do
+ActiveRecord::Schema.define(version: 2019_02_23_124754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,16 @@ ActiveRecord::Schema.define(version: 2017_06_19_094107) do
     t.boolean "secret", default: false
     t.index ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true
     t.index ["heritage_id"], name: "index_env_vars_on_heritage_id"
+  end
+
+  create_table "environments", force: :cascade do |t|
+    t.bigint "heritage_id", null: false
+    t.string "name", null: false
+    t.text "value"
+    t.text "value_from"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["heritage_id"], name: "index_environments_on_heritage_id"
   end
 
   create_table "heritages", force: :cascade do |t|
@@ -189,6 +199,7 @@ ActiveRecord::Schema.define(version: 2017_06_19_094107) do
 
   add_foreign_key "endpoints", "districts"
   add_foreign_key "env_vars", "heritages"
+  add_foreign_key "environments", "heritages", on_delete: :cascade
   add_foreign_key "heritages", "districts"
   add_foreign_key "listeners", "endpoints"
   add_foreign_key "listeners", "services"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,181 +10,181 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619094107) do
+ActiveRecord::Schema.define(version: 2017_06_19_094107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
-    t.text     "last_error"
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "districts", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "s3_bucket_name"
-    t.text     "dockercfg"
-    t.text     "encrypted_aws_secret_access_key"
-    t.string   "cidr_block"
-    t.string   "bastion_key_pair"
-    t.string   "stack_name"
-    t.string   "nat_type"
-    t.string   "cluster_backend"
-    t.integer  "cluster_size"
-    t.string   "cluster_instance_type"
-    t.string   "aws_access_key_id"
-    t.string   "region"
-    t.text     "ssh_ca_public_key"
-    t.string   "aws_role"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "s3_bucket_name"
+    t.text "dockercfg"
+    t.text "encrypted_aws_secret_access_key"
+    t.string "cidr_block"
+    t.string "bastion_key_pair"
+    t.string "stack_name"
+    t.string "nat_type"
+    t.string "cluster_backend"
+    t.integer "cluster_size"
+    t.string "cluster_instance_type"
+    t.string "aws_access_key_id"
+    t.string "region"
+    t.text "ssh_ca_public_key"
+    t.string "aws_role"
   end
 
   create_table "endpoints", force: :cascade do |t|
-    t.integer  "district_id"
-    t.string   "name"
-    t.boolean  "public"
-    t.string   "certificate_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.string   "ssl_policy"
-    t.index ["district_id", "name"], name: "index_endpoints_on_district_id_and_name", unique: true, using: :btree
-    t.index ["district_id"], name: "index_endpoints_on_district_id", using: :btree
+    t.integer "district_id"
+    t.string "name"
+    t.boolean "public"
+    t.string "certificate_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "ssl_policy"
+    t.index ["district_id", "name"], name: "index_endpoints_on_district_id_and_name", unique: true
+    t.index ["district_id"], name: "index_endpoints_on_district_id"
   end
 
   create_table "env_vars", force: :cascade do |t|
     t.integer "heritage_id"
-    t.string  "key"
-    t.text    "encrypted_value"
-    t.boolean "secret",          default: false
-    t.index ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true, using: :btree
-    t.index ["heritage_id"], name: "index_env_vars_on_heritage_id", using: :btree
+    t.string "key"
+    t.text "encrypted_value"
+    t.boolean "secret", default: false
+    t.index ["heritage_id", "key"], name: "index_env_vars_on_heritage_id_and_key", unique: true
+    t.index ["heritage_id"], name: "index_env_vars_on_heritage_id"
   end
 
   create_table "heritages", force: :cascade do |t|
-    t.string   "name",            null: false
-    t.string   "image_name"
-    t.string   "image_tag"
-    t.integer  "district_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.text     "before_deploy"
-    t.string   "token"
-    t.integer  "version"
-    t.text     "scheduled_tasks"
-    t.index ["district_id"], name: "index_heritages_on_district_id", using: :btree
-    t.index ["name"], name: "index_heritages_on_name", unique: true, using: :btree
+    t.string "name", null: false
+    t.string "image_name"
+    t.string "image_tag"
+    t.integer "district_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "before_deploy"
+    t.string "token"
+    t.integer "version"
+    t.text "scheduled_tasks"
+    t.index ["district_id"], name: "index_heritages_on_district_id"
+    t.index ["name"], name: "index_heritages_on_name", unique: true
   end
 
   create_table "listeners", force: :cascade do |t|
-    t.integer  "endpoint_id"
-    t.integer  "service_id"
-    t.integer  "health_check_interval"
-    t.string   "health_check_path"
-    t.text     "rule_conditions"
-    t.integer  "rule_priority"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
-    t.index ["endpoint_id", "service_id"], name: "index_listeners_on_endpoint_id_and_service_id", unique: true, using: :btree
-    t.index ["endpoint_id"], name: "index_listeners_on_endpoint_id", using: :btree
-    t.index ["service_id"], name: "index_listeners_on_service_id", using: :btree
+    t.integer "endpoint_id"
+    t.integer "service_id"
+    t.integer "health_check_interval"
+    t.string "health_check_path"
+    t.text "rule_conditions"
+    t.integer "rule_priority"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["endpoint_id", "service_id"], name: "index_listeners_on_endpoint_id_and_service_id", unique: true
+    t.index ["endpoint_id"], name: "index_listeners_on_endpoint_id"
+    t.index ["service_id"], name: "index_listeners_on_service_id"
   end
 
   create_table "notifications", force: :cascade do |t|
-    t.string   "target",      null: false
-    t.string   "endpoint",    null: false
-    t.integer  "district_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["district_id"], name: "index_notifications_on_district_id", using: :btree
+    t.string "target", null: false
+    t.string "endpoint", null: false
+    t.integer "district_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["district_id"], name: "index_notifications_on_district_id"
   end
 
   create_table "oneoffs", force: :cascade do |t|
-    t.string   "task_arn"
-    t.integer  "heritage_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.text     "command"
-    t.index ["heritage_id"], name: "index_oneoffs_on_heritage_id", using: :btree
+    t.string "task_arn"
+    t.integer "heritage_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "command"
+    t.index ["heritage_id"], name: "index_oneoffs_on_heritage_id"
   end
 
   create_table "plugins", force: :cascade do |t|
-    t.integer  "district_id"
-    t.string   "name"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
-    t.text     "plugin_attributes"
-    t.index ["district_id"], name: "index_plugins_on_district_id", using: :btree
+    t.integer "district_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "plugin_attributes"
+    t.index ["district_id"], name: "index_plugins_on_district_id"
   end
 
   create_table "port_mappings", force: :cascade do |t|
-    t.integer  "host_port"
-    t.integer  "lb_port"
-    t.integer  "container_port"
-    t.integer  "service_id"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.string   "protocol"
-    t.boolean  "enable_proxy_protocol", default: false
-    t.index ["service_id"], name: "index_port_mappings_on_service_id", using: :btree
+    t.integer "host_port"
+    t.integer "lb_port"
+    t.integer "container_port"
+    t.integer "service_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "protocol"
+    t.boolean "enable_proxy_protocol", default: false
+    t.index ["service_id"], name: "index_port_mappings_on_service_id"
   end
 
   create_table "releases", force: :cascade do |t|
-    t.integer  "heritage_id"
-    t.text     "description"
-    t.text     "heritage_params"
-    t.integer  "version"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.index ["heritage_id"], name: "index_releases_on_heritage_id", using: :btree
+    t.integer "heritage_id"
+    t.text "description"
+    t.text "heritage_params"
+    t.integer "version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["heritage_id"], name: "index_releases_on_heritage_id"
   end
 
   create_table "services", force: :cascade do |t|
-    t.string   "name",                                    null: false
-    t.integer  "cpu"
-    t.integer  "memory"
-    t.text     "command"
-    t.boolean  "public"
-    t.integer  "heritage_id"
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
-    t.string   "reverse_proxy_image"
-    t.string   "service_type",        default: "default"
-    t.boolean  "force_ssl"
-    t.text     "hosts"
-    t.text     "health_check"
-    t.index ["heritage_id"], name: "index_services_on_heritage_id", using: :btree
+    t.string "name", null: false
+    t.integer "cpu"
+    t.integer "memory"
+    t.text "command"
+    t.boolean "public"
+    t.integer "heritage_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "reverse_proxy_image"
+    t.string "service_type", default: "default"
+    t.boolean "force_ssl"
+    t.text "hosts"
+    t.text "health_check"
+    t.index ["heritage_id"], name: "index_services_on_heritage_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "name"
-    t.string   "token_hash"
+    t.string "name"
+    t.string "token_hash"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text     "public_key"
-    t.text     "roles"
-    t.string   "auth"
-    t.index ["name", "auth"], name: "index_users_on_name_and_auth", unique: true, using: :btree
-    t.index ["token_hash"], name: "index_users_on_token_hash", unique: true, using: :btree
+    t.text "public_key"
+    t.text "roles"
+    t.string "auth"
+    t.index ["name", "auth"], name: "index_users_on_name_and_auth", unique: true
+    t.index ["token_hash"], name: "index_users_on_token_hash", unique: true
   end
 
   create_table "users_districts", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "district_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["district_id"], name: "index_users_districts_on_district_id", using: :btree
-    t.index ["user_id"], name: "index_users_districts_on_user_id", using: :btree
+    t.integer "user_id"
+    t.integer "district_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["district_id"], name: "index_users_districts_on_district_id"
+    t.index ["user_id"], name: "index_users_districts_on_user_id"
   end
 
   add_foreign_key "endpoints", "districts"

--- a/lib/cloud_formation/helper.rb
+++ b/lib/cloud_formation/helper.rb
@@ -20,6 +20,14 @@ module CloudFormation
       {"Fn::Join" => [sep, vals]}
     end
 
+    def sub(s, mapping = {})
+      if mapping.empty?
+        {"Fn::Sub" => s}
+      else
+        {"Fn::Sub" => [s, mapping]}
+      end
+    end
+
     def select(index, list)
       {"Fn::Select" => [index, list]}
     end

--- a/spec/factories/environments.rb
+++ b/spec/factories/environments.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :environment do
+    name { "ENV" }
+    value { "VALUE" }
+    association :heritage
+  end
+
+  factory :secret_environment, class: "Environment" do
+    name { "ENV" }
+    value_from { "/production/database_url" }
+    association :heritage
+  end
+end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Environment do
+  describe "#namespaced_value_from" do
+    it "returns full arn" do
+      value_from = "arn:aws:region:account-id:secret:barcelona/district/secrets"
+      env = Environment.new(name: "ENV", value_from: value_from)
+      expect(env.namespaced_value_from).to eq value_from
+    end
+
+    it "returns namespaced relative path" do
+      value_from = "production/database_url"
+      env = build :secret_environment, name: "ENV", value_from: value_from
+      expect(env.namespaced_value_from).to eq "/barcelona/#{env.district.name}/production/database_url"
+    end
+  end
+end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,17 +1,4 @@
 require "rails_helper"
 
 describe Environment do
-  describe "#namespaced_value_from" do
-    it "returns full arn" do
-      value_from = "arn:aws:region:account-id:secret:barcelona/district/secrets"
-      env = Environment.new(name: "ENV", value_from: value_from)
-      expect(env.namespaced_value_from).to eq value_from
-    end
-
-    it "returns namespaced relative path" do
-      value_from = "production/database_url"
-      env = build :secret_environment, name: "ENV", value_from: value_from
-      expect(env.namespaced_value_from).to eq "/barcelona/#{env.district.name}/production/database_url"
-    end
-  end
 end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,4 +1,17 @@
 require "rails_helper"
 
 describe Environment do
+  describe "#ssm_path" do
+    let(:heritage) { create :heritage }
+
+    it "generates value_from" do
+      env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "/path/to/secret")
+      expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/path/to/secret"
+    end
+
+    it "generates value_from" do
+      env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "path/to/secret")
+      expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/path/to/secret"
+    end
+  end
 end

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -20,12 +20,14 @@ describe HeritageTaskDefinition do
 
     before do
       allow(heritage).to receive(:task_role_id) { "task-role" }
+      allow(heritage).to receive(:task_execution_role_id) { "task-execution-role" }
     end
 
     it "returns a task definition for the service" do
       expect(subject).to eq({
                               family: service.service_name,
                               task_role_arn: "task-role",
+                              execution_role_arn: "task-execution-role",
                               container_definitions: [
                                 {
                                   name: service.service_name,
@@ -35,6 +37,7 @@ describe HeritageTaskDefinition do
                                   image: heritage.image_path,
                                   command: LaunchCommand.new(heritage, service.command).to_command,
                                   environment: [],
+                                  secrets: [],
                                   volumes_from: [
                                     {
                                       source_container: "runpack",
@@ -50,6 +53,7 @@ describe HeritageTaskDefinition do
                                   essential: false,
                                   image: "quay.io/degica/barcelona-run-pack",
                                   environment: [],
+                                  secrets: [],
                                   log_configuration: expected_log_configuration
                                 }
                               ]
@@ -62,6 +66,7 @@ describe HeritageTaskDefinition do
         expect(subject).to eq({
                                 family: service.service_name,
                                 task_role_arn: "task-role",
+                                execution_role_arn: "task-execution-role",
                                 container_definitions: [
                                   {
                                     environment: [
@@ -78,6 +83,7 @@ describe HeritageTaskDefinition do
                                         value: "3000"
                                       }
                                     ],
+                                    secrets: [],
                                     name: service.service_name,
                                     cpu: service.cpu,
                                     memory: service.memory,
@@ -102,6 +108,7 @@ describe HeritageTaskDefinition do
                                     essential: false,
                                     image: "quay.io/degica/barcelona-run-pack",
                                     environment: [],
+                                    secrets: [],
                                     log_configuration: expected_log_configuration
                                   },
                                   {
@@ -129,6 +136,7 @@ describe HeritageTaskDefinition do
                                         value: "false"
                                       }
                                     ],
+                                    secrets: [],
                                     port_mappings: [
                                       {
                                         container_port: 80,
@@ -157,12 +165,14 @@ describe HeritageTaskDefinition do
 
     before do
       allow(heritage).to receive(:task_role_id) { "task-role" }
+      allow(heritage).to receive(:task_execution_role_id) { "task-execution-role" }
     end
 
     it "returns a task definition for the oneoff" do
       expect(subject).to eq({
                               family: "#{heritage.name}-oneoff",
                               task_role_arn: "task-role",
+                              execution_role_arn: "task-execution-role",
                               container_definitions: [
                                 {
                                   name:  "#{heritage.name}-oneoff",
@@ -171,6 +181,7 @@ describe HeritageTaskDefinition do
                                   essential: true,
                                   image: heritage.image_path,
                                   environment: [],
+                                  secrets: [],
                                   volumes_from: [
                                     {
                                       source_container: "runpack",
@@ -186,6 +197,7 @@ describe HeritageTaskDefinition do
                                   essential: false,
                                   image: "quay.io/degica/barcelona-run-pack",
                                   environment: [],
+                                  secrets: [],
                                   log_configuration: expected_log_configuration
                                 }
                               ]
@@ -224,12 +236,14 @@ describe HeritageTaskDefinition do
 
     before do
       allow(heritage).to receive(:task_role_id) { "task-role" }
+      allow(heritage).to receive(:task_execution_role_id) { "task-execution-role" }
     end
 
     it "returns a task definition for the schedule" do
       expect(subject).to eq({
                               "Family" => "#{heritage.name}-schedule",
                               "TaskRoleArn" => "task-role",
+                              "ExecutionRoleArn" => "task-execution-role",
                               "ContainerDefinitions" => [
                                 {
                                   "Name" =>  "#{heritage.name}-schedule",
@@ -238,6 +252,7 @@ describe HeritageTaskDefinition do
                                   "Essential" => true,
                                   "Image" => heritage.image_path,
                                   "Environment" => [],
+                                  "Secrets" => [],
                                   "VolumesFrom" => [
                                     {
                                       "SourceContainer" => "runpack",
@@ -253,6 +268,7 @@ describe HeritageTaskDefinition do
                                   "Essential" => false,
                                   "Image" => "quay.io/degica/barcelona-run-pack",
                                   "Environment" => [],
+                                  "Secrets" => [],
                                   "LogConfiguration" => expected_log_configuration
                                 }
                               ]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,12 +58,6 @@ RSpec.configure do |config|
     ENV['VAULT_PATH_PREFIX'] ||= "prefix"
   end
 
-  config.before :suite do
-    DatabaseRewinder.clean_all
-    # or
-    # DatabaseRewinder.clean_with :any_arg_that_would_be_actually_ignored_anyway
-  end
-
   config.before :each do
     stub_const("Gibberish::AES::SJCL::DEFAULTS", {
                  v:1, iter:1, ks:256, ts:96,
@@ -166,9 +160,5 @@ RSpec.configure do |config|
                       physical_resource_id: "barce-VPCGa-1LOOQNJB1WRUG")
              ])
     }
-  end
-
-  config.after :each do
-    DatabaseRewinder.clean
   end
 end

--- a/spec/requests/update_heritage_spec.rb
+++ b/spec/requests/update_heritage_spec.rb
@@ -10,6 +10,10 @@ describe "updating a heritage" do
       image_name: "nginx",
       image_tag: "latest",
       before_deploy: "echo hello",
+      environment: [
+        {name: "ENV_KEY", value: "my value"},
+        {name: "SECRET", value_from: "arn"}
+      ],
       services: [
         {
           name: "web",
@@ -30,7 +34,7 @@ describe "updating a heritage" do
         }
       ]
     }
-    api_request :post, "/v1/districts/#{district.name}/heritages", params
+    api_request :post, "/v1/districts/#{district.name}/heritages?debug=true", params
   end
 
   describe "PATCH /heritages/:heritage", type: :request do
@@ -38,6 +42,10 @@ describe "updating a heritage" do
       params = {
         image_tag: "v3",
         before_deploy: nil,
+        environment: [
+          {name: "ENV2", value: "my value 2"},
+          {name: "SECRET", value_from: "arn"}
+        ],
         services: [
           {
             name: "web",
@@ -59,6 +67,13 @@ describe "updating a heritage" do
       expect(heritage["image_name"]).to eq "nginx"
       expect(heritage["image_tag"]).to eq "v3"
       expect(heritage["before_deploy"]).to eq nil
+      expect(heritage["environment"].count).to eq 2
+      expect(heritage["environment"][0]["name"]).to eq "ENV2"
+      expect(heritage["environment"][0]["value"]).to eq "my value 2"
+      expect(heritage["environment"][0]["value_from"]).to eq nil
+      expect(heritage["environment"][1]["name"]).to eq "SECRET"
+      expect(heritage["environment"][1]["value"]).to eq nil
+      expect(heritage["environment"][1]["value_from"]).to eq "arn"
       web_service = heritage["services"].find { |s| s["name"] == "web" }
       expect(web_service["public"]).to eq true
       expect(web_service["cpu"]).to eq 128


### PR DESCRIPTION
**Note: this feature doesn't work for normal deployments. For now, only review apps (#502) can use `environment`**

Official documentation: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html

# Description

This PR adds support for "declarative envrionment" which allows you to specify `environment` section in your `barcelona.yml`. You can also you secret parameters using SSM parameter store and Secrets Manager.

Barcelona does not set secret values (nor has permission to do that) but it just lets ECS tasks to fetch secret values at runtime. Developers need to set app's secrets on AWS web console beforehand.

## Usage

In `barcelona.yml`:

```yaml
image_name: quay.io/degica/repo
environment:
# Plain environment variable
- name: RAILS_ENV
  value: production
# this is resolved as SSM parameter store "/barcelona/district-name/production/secret_key_base"
- name: SECRET_KEY_BASE
  value_from: /production/secret_key_base
# You can also use SecretsManager by specifying full ARN for your secrets
- name: DATABASE_URL
  value_from: arn:aws:secretsmanager:region:aws_account_id:secret:secrets-name-a1b2c3
