### PR TITLE
Add Review App Feature

### DIFF
--- a/app/controllers/review_apps_controller.rb
+++ b/app/controllers/review_apps_controller.rb
@@ -1,0 +1,49 @@
+class ReviewAppsController < ApplicationController
+  skip_before_action :authenticate, only: [:trigger]
+  before_action :authorize_app, only: [:create, :trigger]
+
+  def create
+    group = ReviewGroup.find_by!(name: params[:review_group_id])
+    reviewapp = group.review_apps.find_or_initialize_by(subject: params[:subject])
+    reviewapp.attributes = {
+      subject: params[:subject],
+      retention_hours: 12,
+      image_name: params[:image_name],
+      image_tag: params[:image_tag],
+      before_deploy: params[:before_deploy],
+      environment: (params[:environment] || []).map { |e| e.permit!.to_h },
+      service_params: (params[:service] || {}).permit!.to_h
+    }
+    reviewapp.save!
+
+    render json: reviewapp
+  end
+
+  def trigger
+    group = ReviewGroup.find_by!(name: params[:review_group_id])
+
+    if Rack::Utils.secure_compare(params[:token], group.token)
+      create
+    else
+      raise ExceptionHandler::NotFound
+    end
+  end
+
+  def index
+    group = ReviewGroup.find_by!(name: params[:review_group_id])
+    render json: group.review_apps
+  end
+
+  def destroy
+    group = ReviewGroup.find_by!(name: params[:review_group_id])
+    review_app = group.review_apps.find_by!(subject: params[:id])
+    authorize_resource review_app
+    review_app.destroy!
+
+    head 204
+  end
+
+  def authorize_app
+    authorize_resource ReviewApp
+  end
+end

--- a/app/controllers/review_apps_controller.rb
+++ b/app/controllers/review_apps_controller.rb
@@ -7,7 +7,7 @@ class ReviewAppsController < ApplicationController
     reviewapp = group.review_apps.find_or_initialize_by(subject: params[:subject])
     reviewapp.attributes = {
       subject: params[:subject],
-      retention_hours: 12,
+      retention_hours: 24,
       image_name: params[:image_name],
       image_tag: params[:image_tag],
       before_deploy: params[:before_deploy],

--- a/app/controllers/review_apps_controller.rb
+++ b/app/controllers/review_apps_controller.rb
@@ -4,15 +4,7 @@ class ReviewAppsController < ApplicationController
   def create
     group = ReviewGroup.find_by!(name: params[:review_group_id])
     reviewapp = group.review_apps.find_or_initialize_by(subject: params[:subject])
-    reviewapp.attributes = {
-      subject: params[:subject],
-      retention_hours: 24,
-      image_name: params[:image_name],
-      image_tag: params[:image_tag],
-      before_deploy: params[:before_deploy],
-      environment: (params[:environment] || []).map { |e| e.permit!.to_h },
-      service_params: (params[:service] || {}).permit!.to_h
-    }
+    reviewapp.attributes = permitted_params
     authorize_resource reviewapp
     reviewapp.save!
 
@@ -51,5 +43,31 @@ class ReviewAppsController < ApplicationController
     else
       raise ExceptionHandler::NotFound
     end
+  end
+
+  private
+
+  def permitted_params
+    params.permit([
+                    :subject,
+                    :retention,
+                    :image_name,
+                    :image_tag,
+                    :before_deploy,
+                    environment: [
+                      :name,
+                      :value,
+                      :ssm_path,
+                      :value_from
+                    ],
+                    services: [
+                      :name,
+                      :service_type,
+                      :cpu,
+                      :memory,
+                      :command,
+                      :force_ssl
+                    ]
+                  ])
   end
 end

--- a/app/controllers/review_groups_controller.rb
+++ b/app/controllers/review_groups_controller.rb
@@ -1,0 +1,31 @@
+class ReviewGroupsController < ApplicationController
+  def create
+    authorize_resource ReviewGroup
+    endpoint = Endpoint.find_by!(name: params[:endpoint])
+    group = ReviewGroup.create!(
+      name: params[:name],
+      base_domain: params[:base_domain],
+      endpoint: endpoint
+    )
+    render json: group
+  end
+
+  def show
+    group = ReviewGroup.find_by!(name: params[:id])
+    authorize_resource group
+    render json: group
+  end
+
+  def index
+    groups = ReviewGroup.all
+    render json: groups
+  end
+
+  def destroy
+    group = ReviewGroup.find_by!(name: params[:id])
+    authorize_resource group
+    group.destroy!
+
+    head 204
+  end
+end

--- a/app/jobs/cleanup_review_app_job.rb
+++ b/app/jobs/cleanup_review_app_job.rb
@@ -2,6 +2,6 @@ class CleanupReviewAppJob < ActiveJob::Base
   queue_as :default
 
   def perform(reviewapp)
-    reviewapp.destroy
+    reviewapp.destroy if reviewapp.expired?
   end
 end

--- a/app/jobs/cleanup_review_app_job.rb
+++ b/app/jobs/cleanup_review_app_job.rb
@@ -1,0 +1,7 @@
+class CleanupReviewAppJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(reviewapp)
+    reviewapp.destroy
+  end
+end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -117,6 +117,7 @@ class Endpoint < ActiveRecord::Base
   belongs_to :district, inverse_of: :endpoints
   has_many :listeners, inverse_of: :endpoint
   has_many :services, through: :listeners
+  has_many :review_groups, dependent: :destroy
 
   validates :name,
             presence: true,
@@ -148,7 +149,7 @@ class Endpoint < ActiveRecord::Base
   end
 
   def dns_name
-    cf_executor.outputs["DNSName"]
+    cf_executor.outputs&.dig("DNSName")
   end
 
   def to_param

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -149,7 +149,7 @@ class Endpoint < ActiveRecord::Base
   end
 
   def dns_name
-    cf_executor.outputs&.dig("DNSName")
+    cf_executor.outputs["DNSName"]
   end
 
   def to_param

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -132,44 +132,46 @@ class Heritage < ActiveRecord::Base
         ]
       end
 
-      add_resource("AWS::IAM::Role", "TaskRole") do |j|
-        j.AssumeRolePolicyDocument do |j|
-          j.Version "2012-10-17"
-          j.Statement [
+      unless heritage.review?
+        add_resource("AWS::IAM::Role", "TaskRole") do |j|
+          j.AssumeRolePolicyDocument do |j|
+            j.Version "2012-10-17"
+            j.Statement [
+              {
+                "Effect" => "Allow",
+                "Principal" => {
+                  "Service" => ["ecs-tasks.amazonaws.com"]
+                },
+                "Action" => ["sts:AssumeRole"]
+              }
+            ]
+          end
+          j.Path "/"
+          j.Policies [
             {
-              "Effect" => "Allow",
-              "Principal" => {
-                "Service" => ["ecs-tasks.amazonaws.com"]
-              },
-              "Action" => ["sts:AssumeRole"]
+              "PolicyName" => "barcelona-ecs-task-role-#{heritage.name}",
+              "PolicyDocument" => {
+                "Version" => "2012-10-17",
+                "Statement" => [
+                  {
+                    "Effect" => "Allow",
+                    "Action" => ["logs:CreateLogStream",
+                                 "logs:PutLogEvents"],
+                    "Resource" => ["*"]
+                  },
+                  {
+                    "Effect" => "Allow",
+                    "Action" => ["s3:GetObject"],
+                    "Resource" => [
+                      "arn:aws:s3:::#{heritage.district.s3_bucket_name}/heritages/#{heritage.name}/*",
+                      "arn:aws:s3:::#{heritage.district.s3_bucket_name}/certs/*",
+                    ]
+                  }
+                ]
+              }
             }
           ]
         end
-        j.Path "/"
-        j.Policies [
-          {
-            "PolicyName" => "barcelona-ecs-task-role-#{heritage.name}",
-            "PolicyDocument" => {
-              "Version" => "2012-10-17",
-              "Statement" => [
-                {
-                  "Effect" => "Allow",
-                  "Action" => ["logs:CreateLogStream",
-                               "logs:PutLogEvents"],
-                  "Resource" => ["*"]
-                },
-                {
-                  "Effect" => "Allow",
-                  "Action" => ["s3:GetObject"],
-                  "Resource" => [
-                    "arn:aws:s3:::#{heritage.district.s3_bucket_name}/heritages/#{heritage.name}/*",
-                    "arn:aws:s3:::#{heritage.district.s3_bucket_name}/certs/*",
-                  ]
-                }
-              ]
-            }
-          }
-        ]
       end
     end
 
@@ -200,6 +202,7 @@ class Heritage < ActiveRecord::Base
   has_many :environments
   has_many :oneoffs, dependent: :destroy
   has_many :releases, -> { order 'version DESC' }, dependent: :destroy, inverse_of: :heritage
+  has_one :review_app, dependent: :destroy, autosave: false
   belongs_to :district, inverse_of: :heritages
 
   validates :name,
@@ -243,11 +246,15 @@ class Heritage < ActiveRecord::Base
     "#{image_name}:#{tag}"
   end
 
-  def save_and_deploy!(without_before_deploy: false, description: "")
-    save!
+  def deploy!(without_before_deploy: false, description: "")
     release = releases.create!(description: description)
     update_services(release, without_before_deploy)
     release
+  end
+
+  def save_and_deploy!(without_before_deploy: false, description: "")
+    save!
+    deploy!(without_before_deploy: without_before_deploy, description: description)
   end
 
   def regenerate_token
@@ -285,7 +292,11 @@ class Heritage < ActiveRecord::Base
   end
 
   def task_role_id
-    cf_executor&.resource_ids["TaskRole"]
+    if review?
+      review_app.review_group.task_role_id
+    else
+      cf_executor&.resource_ids["TaskRole"]
+    end
   end
 
   def task_execution_role_id
@@ -308,6 +319,10 @@ class Heritage < ActiveRecord::Base
 
   def legacy_secrets
     env_vars.where(secret: true).where.not(key: environments.secrets.pluck(:name))
+  end
+
+  def review?
+    review_app.present?
   end
 
   private

--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -11,7 +11,7 @@ class ReviewApp < ApplicationRecord
 
   def build_heritage
     params = {
-      name: "review-#{unique_slug}",
+      name: "review-#{slug_digest}",
       image_name: image_name,
       image_tag: image_tag,
       before_deploy: before_deploy,
@@ -44,12 +44,15 @@ class ReviewApp < ApplicationRecord
   end
 
   def rule_priority_from_subject
-    digest = Digest::SHA256.hexdigest(subject)
-    (digest[0..5].to_i(16) % 50000) + 1
+    (slug_digest.to_i(16) % 50000) + 1
   end
 
-  def unique_slug
-    Digest::SHA256.hexdigest(review_group.name + "---" + subject)[0...8]
+  def slug
+    review_group.name + "---" + subject
+  end
+
+  def slug_digest
+    Digest::SHA256.hexdigest(slug)[0...8]
   end
 
   def to_param

--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -1,0 +1,57 @@
+class ReviewApp < ApplicationRecord
+  belongs_to :heritage, dependent: :destroy, autosave: true
+  belongs_to :review_group
+
+  attr_accessor :image_name, :image_tag, :retention_hours, :service_params, :before_deploy, :environment
+  validates :subject, :image_name, :image_tag, :retention_hours, :service_params, presence: true
+  validates :subject, format: {with: /\A[a-z0-9][a-z0-9-]*[a-z0-9]\z/}
+
+  before_validation :build_heritage
+  after_save :deploy
+
+  def build_heritage
+    params = {
+      name: "review-#{unique_slug}",
+      image_name: image_name,
+      image_tag: image_tag,
+      before_deploy: before_deploy,
+      environment: environment,
+      services: [
+        service_params.merge(
+          name: "review",
+          listeners: [
+            {
+              endpoint: review_group.endpoint.name,
+              rule_priority: rule_priority_from_subject,
+              rule_conditions: [{type: "host-header", value: domain}]
+            }
+          ]
+        )
+      ]
+    }
+
+    self.heritage = BuildHeritage.new(params, district: review_group.district).execute
+  end
+
+  def deploy
+    self.heritage.deploy!(description: "ReviewApp for #{subject}")
+    CleanupReviewAppJob.set(wait: retention_hours.hours).perform_later(self)
+  end
+
+  def domain
+    "#{subject}.#{review_group.base_domain}"
+  end
+
+  def rule_priority_from_subject
+    digest = Digest::SHA256.hexdigest(subject)
+    (digest[0..5].to_i(16) % 50000) + 1
+  end
+
+  def unique_slug
+    Digest::SHA256.hexdigest(review_group.name + "---" + subject)[0...8]
+  end
+
+  def to_param
+    subject
+  end
+end

--- a/app/models/review_group.rb
+++ b/app/models/review_group.rb
@@ -1,0 +1,99 @@
+class ReviewGroup < ApplicationRecord
+  class Builder < CloudFormation::Builder
+    def build_resources
+      add_resource("AWS::IAM::Role", "TaskRole") do |j|
+        j.AssumeRolePolicyDocument do |j|
+          j.Version "2012-10-17"
+          j.Statement [
+            {
+              "Effect" => "Allow",
+              "Principal" => {
+                "Service" => ["ecs-tasks.amazonaws.com"]
+              },
+              "Action" => ["sts:AssumeRole"]
+            }
+          ]
+        end
+        j.Path "/"
+        j.Policies [
+          {
+            "PolicyName" => "barcelona-ecs-task-role-reviewgroup-#{group.name}",
+            "PolicyDocument" => {
+              "Version" => "2012-10-17",
+              "Statement" => [
+                {
+                  "Effect" => "Allow",
+                  "Action" => ["logs:CreateLogStream",
+                               "logs:PutLogEvents"],
+                  "Resource" => ["*"]
+                }
+              ]
+            }
+          }
+        ]
+      end
+    end
+
+    def group
+      options[:group]
+    end
+  end
+
+  class Stack < CloudFormation::Stack
+    def initialize(group)
+      stack_name = "#{group.district.name}-reviewapp-group-#{group.name}"
+      super(stack_name, group: group)
+    end
+
+    def build
+      super do |builder|
+        builder.add_builder Builder.new(self, options)
+      end
+    end
+  end
+
+  belongs_to :endpoint
+  has_many :review_apps, dependent: :destroy
+
+  validates :token, :base_domain, :name, presence: true
+  validates :name, format: { with: /\A[a-z0-9_-]+\z/ }
+  validates :base_domain, format: { with: /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?)?\z/ }
+
+  before_validation do
+    regenerate_token if self.token.blank?
+  end
+
+  after_save :apply_stack
+  after_destroy :delete_stack
+
+  delegate :district, to: :endpoint
+
+  def regenerate_token
+    self.token = SecureRandom.uuid
+  end
+
+  def task_role_id
+    stack_resources["TaskRole"]
+  end
+
+  def cf_executor
+    @cf_executor ||= begin
+                       stack = Stack.new(self)
+                       CloudFormation::Executor.new(stack, district.aws.cloudformation)
+                     end
+  end
+
+  private
+
+  def apply_stack
+    cf_executor.create_or_update
+  end
+
+  def delete_stack
+    cf_executor.delete
+  end
+
+  def stack_resources
+    @stack_resources ||= cf_executor.resource_ids
+  end
+end

--- a/app/models/review_group.rb
+++ b/app/models/review_group.rb
@@ -41,7 +41,7 @@ class ReviewGroup < ApplicationRecord
 
   class Stack < CloudFormation::Stack
     def initialize(group)
-      stack_name = "#{group.district.name}-reviewapp-group-#{group.name}"
+      stack_name = "#{group.district.name}-reviewgroup-#{group.name}"
       super(stack_name, group: group)
     end
 

--- a/app/policies/review_app_policy.rb
+++ b/app/policies/review_app_policy.rb
@@ -1,0 +1,21 @@
+class ReviewAppPolicy < ApplicationPolicy
+  def create?
+    user.developer?
+  end
+
+  def trigger?
+    true
+  end
+
+  def destroy?
+    user.developer?
+  end
+
+  def index?
+    user.developer?
+  end
+
+  def show?
+    user.developer?
+  end
+end

--- a/app/policies/review_app_policy.rb
+++ b/app/policies/review_app_policy.rb
@@ -3,7 +3,11 @@ class ReviewAppPolicy < ApplicationPolicy
     user.developer?
   end
 
-  def trigger?
+  def ci_create?
+    true
+  end
+
+  def ci_delete?
     true
   end
 

--- a/app/policies/review_group_policy.rb
+++ b/app/policies/review_group_policy.rb
@@ -1,0 +1,21 @@
+class ReviewGroupPolicy < ApplicationPolicy
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+
+  def destroy?
+    user.admin?
+  end
+
+  def index?
+    user.developer?
+  end
+
+  def show?
+    user.developer?
+  end
+end

--- a/app/serializers/review_app_serializer.rb
+++ b/app/serializers/review_app_serializer.rb
@@ -1,0 +1,6 @@
+class ReviewAppSerializer < ActiveModel::Serializer
+  attributes :domain, :subject
+
+  belongs_to :review_group
+  belongs_to :heritage
+end

--- a/app/serializers/review_group_serializer.rb
+++ b/app/serializers/review_group_serializer.rb
@@ -1,0 +1,6 @@
+class ReviewGroupSerializer < ActiveModel::Serializer
+  attributes :name, :base_domain, :token
+
+  has_many :review_apps
+  has_one :endpoint
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
     end
 
     resources :users, only: [:index, :show, :update]
+    resources :review_groups do
+      resources :review_apps, path: "/apps"
+    end
 
     post "/login", to: "users#login"
     patch "/user", to: "users#update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show, :update]
     resources :review_groups do
       resources :review_apps, path: "/apps"
+      post "/apps/trigger/:token", to: "review_apps#trigger"
     end
 
     post "/login", to: "users#login"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,8 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show, :update]
     resources :review_groups do
       resources :review_apps, path: "/apps"
-      post "/apps/trigger/:token", to: "review_apps#trigger"
+      post   "/ci/apps/:token", to: "review_apps#ci_create"
+      delete "/ci/apps/:token/:id", to: "review_apps#ci_delete"
     end
 
     post "/login", to: "users#login"

--- a/db/migrate/20190223160920_create_review_groups.rb
+++ b/db/migrate/20190223160920_create_review_groups.rb
@@ -1,0 +1,15 @@
+class CreateReviewGroups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :review_groups do |t|
+      t.references :endpoint, foreign_key: true, null: false
+      t.string :name, null: false
+      t.string :base_domain, null: false
+      t.string :token, null: false
+
+      t.timestamps
+    end
+
+    add_index :review_groups, :name, unique: true
+    add_index :review_groups, :token, unique: true
+  end
+end

--- a/db/migrate/20190223161003_create_review_apps.rb
+++ b/db/migrate/20190223161003_create_review_apps.rb
@@ -4,6 +4,7 @@ class CreateReviewApps < ActiveRecord::Migration[5.1]
       t.references :heritage, foreign_key: true, index: {unique: true}, null: false
       t.references :review_group, foreign_key: true, null: false
       t.string :subject, null: false
+      t.integer :retention_hours, null: false
 
       t.timestamps
     end

--- a/db/migrate/20190223161003_create_review_apps.rb
+++ b/db/migrate/20190223161003_create_review_apps.rb
@@ -1,0 +1,11 @@
+class CreateReviewApps < ActiveRecord::Migration[5.1]
+  def change
+    create_table :review_apps do |t|
+      t.references :heritage, foreign_key: true, index: {unique: true}, null: false
+      t.references :review_group, foreign_key: true, null: false
+      t.string :subject, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190223161003_create_review_apps.rb
+++ b/db/migrate/20190223161003_create_review_apps.rb
@@ -4,7 +4,7 @@ class CreateReviewApps < ActiveRecord::Migration[5.1]
       t.references :heritage, foreign_key: true, index: {unique: true}, null: false
       t.references :review_group, foreign_key: true, null: false
       t.string :subject, null: false
-      t.integer :retention_hours, null: false
+      t.integer :retention, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_23_124754) do
+ActiveRecord::Schema.define(version: 2019_02_23_161003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -159,6 +159,28 @@ ActiveRecord::Schema.define(version: 2019_02_23_124754) do
     t.index ["heritage_id"], name: "index_releases_on_heritage_id"
   end
 
+  create_table "review_apps", force: :cascade do |t|
+    t.bigint "heritage_id", null: false
+    t.bigint "review_group_id", null: false
+    t.string "subject", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["heritage_id"], name: "index_review_apps_on_heritage_id", unique: true
+    t.index ["review_group_id"], name: "index_review_apps_on_review_group_id"
+  end
+
+  create_table "review_groups", force: :cascade do |t|
+    t.bigint "endpoint_id", null: false
+    t.string "name", null: false
+    t.string "base_domain", null: false
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["endpoint_id"], name: "index_review_groups_on_endpoint_id"
+    t.index ["name"], name: "index_review_groups_on_name", unique: true
+    t.index ["token"], name: "index_review_groups_on_token", unique: true
+  end
+
   create_table "services", force: :cascade do |t|
     t.string "name", null: false
     t.integer "cpu"
@@ -208,6 +230,9 @@ ActiveRecord::Schema.define(version: 2019_02_23_124754) do
   add_foreign_key "plugins", "districts"
   add_foreign_key "port_mappings", "services"
   add_foreign_key "releases", "heritages"
+  add_foreign_key "review_apps", "heritages"
+  add_foreign_key "review_apps", "review_groups"
+  add_foreign_key "review_groups", "endpoints"
   add_foreign_key "services", "heritages"
   add_foreign_key "users_districts", "districts"
   add_foreign_key "users_districts", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define(version: 2019_02_23_161003) do
     t.bigint "heritage_id", null: false
     t.bigint "review_group_id", null: false
     t.string "subject", null: false
+    t.integer "retention_hours", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["heritage_id"], name: "index_review_apps_on_heritage_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,7 +163,7 @@ ActiveRecord::Schema.define(version: 2019_02_23_161003) do
     t.bigint "heritage_id", null: false
     t.bigint "review_group_id", null: false
     t.string "subject", null: false
-    t.integer "retention_hours", null: false
+    t.integer "retention", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["heritage_id"], name: "index_review_apps_on_heritage_id", unique: true

--- a/examples/rails-app/barcelona.yml
+++ b/examples/rails-app/barcelona.yml
@@ -2,9 +2,6 @@ environments:
   production:
     name: rails-app
     image_name: k2nr/rails-docker-sample
-    scheduled_tasks:
-      - schedule: rate(10 minutes)
-        command: echo hello hello
     services:
       - name: web
         service_type: web
@@ -19,3 +16,18 @@ environments:
             rule_conditions:
               - type: path-pattern
                 value: '*'
+review:
+  group: test
+  image_name: quay.io/k2nr/bcn-reviewapp-example
+  environment:
+    - name: RAILS_ENV
+      value: staging
+    - name: DATABASE_URL
+      value_from: komoju_staging/database_url
+  service:
+    service_type: web
+    cpu: 10
+    memory: 128
+    command: nginx -g "daemon off;"
+
+# bcn review deploy branch-name --tag branch-name

--- a/examples/rails-app/barcelona.yml
+++ b/examples/rails-app/barcelona.yml
@@ -23,7 +23,7 @@ review:
     - name: RAILS_ENV
       value: staging
     - name: DATABASE_URL
-      value_from: komoju_staging/database_url
+      ssm_path: komoju_staging/database_url
   service:
     service_type: web
     cpu: 10

--- a/examples/rails-app/barcelona.yml
+++ b/examples/rails-app/barcelona.yml
@@ -24,10 +24,11 @@ review:
       value: staging
     - name: DATABASE_URL
       ssm_path: komoju_staging/database_url
-  service:
-    service_type: web
-    cpu: 10
-    memory: 128
-    command: nginx -g "daemon off;"
+  services:
+    - name: web
+      service_type: web
+      cpu: 10
+      memory: 128
+      command: nginx -g "daemon off;"
 
 # bcn review deploy branch-name --tag branch-name

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -72,7 +72,9 @@ module CloudFormation
     end
 
     def outputs
-      Hash[*describe.outputs.map{ |o| [o.output_key, o.output_value] }.flatten]
+      if describe
+        Hash[*describe.outputs.map{ |o| [o.output_key, o.output_value] }.flatten]
+      end
     end
 
     def delete

--- a/spec/factories/review_apps.rb
+++ b/spec/factories/review_apps.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :review_app do
+    sequence(:subject) { |n| "subject-#{n}" }
+    retention_hours { 24 }
+    image_name { "quay.io/degica/image" }
+    image_tag { "v2" }
+    before_deploy { "before_deploy_command" }
+    environment { [] }
+    service_params {
+      {
+        service_type: "web",
+        cpu: 128,
+        memory: 256,
+        command: "nginx",
+      }
+    }
+
+    association :review_group
+  end
+end

--- a/spec/factories/review_apps.rb
+++ b/spec/factories/review_apps.rb
@@ -1,18 +1,19 @@
 FactoryBot.define do
   factory :review_app do
     sequence(:subject) { |n| "subject-#{n}" }
-    retention_hours { 24 }
+    retention { 24 * 3600 }
     image_name { "quay.io/degica/image" }
     image_tag { "v2" }
     before_deploy { "before_deploy_command" }
     environment { [] }
-    service_params {
-      {
+    services {
+      [{
+        name: "web",
         service_type: "web",
         cpu: 128,
         memory: 256,
         command: "nginx",
-      }
+      }]
     }
 
     association :review_group

--- a/spec/factories/review_groups.rb
+++ b/spec/factories/review_groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :review_group do
+    name { "review" }
+    base_domain { "review.basedomain.com"}
+    association :endpoint
+  end
+end

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -23,7 +23,7 @@ describe ReviewApp do
       expect{review_app.save!}.to_not raise_error
 
       expect(review_app.heritage).to be_present
-      expect(review_app.heritage.name).to eq "review-#{review_app.unique_slug}"
+      expect(review_app.heritage.name).to eq "review-#{review_app.slug_digest}"
       expect(review_app.heritage.services[0].listeners[0].endpoint).to eq group.endpoint
       expect(review_app.heritage.services[0].listeners[0].rule_priority).to eq review_app.rule_priority_from_subject
       expect(review_app.heritage.services[0].listeners[0].rule_conditions[0]["type"]).to eq "host-header"

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe ReviewApp do
+  let(:group) { create :review_group }
+
+  describe "create" do
+    let(:review_app) {
+      group.review_apps.new(
+        subject: "subject",
+        image_name: "image",
+        image_tag: "tag",
+        retention_hours: 12,
+        before_deploy: "true",
+        environment: [],
+        service_params: {
+          command: "true",
+          service_type: "web",
+        }
+      )
+    }
+
+    it "creates a heritage" do
+      expect{review_app.save!}.to_not raise_error
+
+      expect(review_app.heritage).to be_present
+      expect(review_app.heritage.name).to eq "review-#{review_app.unique_slug}"
+      expect(review_app.heritage.services[0].listeners[0].endpoint).to eq group.endpoint
+      expect(review_app.heritage.services[0].listeners[0].rule_priority).to eq review_app.rule_priority_from_subject
+      expect(review_app.heritage.services[0].listeners[0].rule_conditions[0]["type"]).to eq "host-header"
+      expect(review_app.heritage.services[0].listeners[0].rule_conditions[0]["value"]).to eq review_app.domain
+    end
+
+    it "deploys the heritage" do
+      expect_any_instance_of(Heritage).to receive(:deploy!)
+      review_app.save!
+    end
+  end
+end

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -9,13 +9,14 @@ describe ReviewApp do
         subject: "subject",
         image_name: "image",
         image_tag: "tag",
-        retention_hours: 12,
+        retention: 12 * 3600,
         before_deploy: "true",
         environment: [],
-        service_params: {
+        services: [{
+          name: "review",
           command: "true",
           service_type: "web",
-        }
+        }]
       )
     }
 

--- a/spec/models/review_group_spec.rb
+++ b/spec/models/review_group_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe ReviewGroup do
+  let(:endpoint) { create :endpoint }
+
+  describe "#save" do
+    it "works" do
+      group = ReviewGroup.new(endpoint: endpoint, name: "group-name", base_domain: "reviewapps.degica.com")
+      expect(group.cf_executor).to receive(:create_or_update)
+      expect{group.save!}.to_not raise_error
+    end
+  end
+
+  describe "#destroy" do
+    it "works" do
+      group = ReviewGroup.create!(endpoint: endpoint, name: "group-name", base_domain: "reviewapps.degica.com")
+      expect(group.cf_executor).to receive(:delete)
+      expect{group.destroy!}.to_not raise_error
+    end
+  end
+end
+
+describe ReviewGroup::Stack do
+  let(:review_group) { build :review_group }
+  let(:stack) { described_class.new(review_group) }
+
+  describe "#target!" do
+    it "generates a correct stack template" do
+      generated = JSON.load stack.target!
+      expect(generated["Resources"]["TaskRole"]).to be_present
+    end
+  end
+end

--- a/spec/requests/create_review_app_spec.rb
+++ b/spec/requests/create_review_app_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe "POST /v1/:review_group/apps", type: :request do
+  let(:user) { create :user }
+  let(:district) { create :district }
+  let(:endpoint) { create :endpoint, district: district }
+  let(:review_group) { create(:review_group) }
+  let(:params) do
+    {
+      group: review_group.name,
+      subject: "branch-name",
+      image_name: "nginx",
+      image_tag: "v2",
+      before_deploy: "before_deploy_command",
+      environment: [
+        {name: "ENV", value: "value"},
+        {name: "SECRET", value_from: "/secret/env"}
+      ],
+      service: {
+        service_type: "web",
+        cpu: 128,
+        memory: 256,
+        command: "nginx",
+      }
+    }
+  end
+
+  it "creates a heritage" do
+    allow(DeployRunnerJob).to receive(:perform_later)
+    api_request(:post, "/v1/review_groups/#{review_group.name}/apps", params)
+    expect(response.status).to eq 200
+    review_app = JSON.load(response.body)["review_app"]
+    expect(review_app["domain"]).to eq "branch-name.review.basedomain.com"
+    expect(review_app["subject"]).to eq "branch-name"
+    expect(review_app["heritage"]["image_name"]).to eq params[:image_name]
+    expect(review_app["heritage"]["image_tag"]).to eq params[:image_tag]
+    expect(review_app["heritage"]["before_deploy"]).to eq "before_deploy_command"
+    expect(review_app["heritage"]["environment"].count).to eq 2
+    expect(review_app["heritage"]["environment"][0]["name"]).to eq "ENV"
+    expect(review_app["heritage"]["environment"][0]["value"]).to eq "value"
+    expect(review_app["heritage"]["environment"][1]["name"]).to eq "SECRET"
+    expect(review_app["heritage"]["environment"][1]["value_from"]).to eq "/secret/env"
+    expect(review_app["heritage"]["token"]).to be_a String
+    expect(review_app["heritage"]["scheduled_tasks"]).to be_empty
+  end
+
+  context "trigger API" do
+    it "creates a heritage" do
+      allow(DeployRunnerJob).to receive(:perform_later)
+      api_request(:post, "/v1/review_groups/#{review_group.name}/apps/trigger/#{review_group.token}", params, {"X-Barcelona-Token" => nil})
+      expect(response.status).to eq 200
+    end
+
+    context "with wrong token" do
+      it "creates a heritage" do
+        allow(DeployRunnerJob).to receive(:perform_later)
+        api_request(:post, "/v1/review_groups/#{review_group.name}/apps/trigger/wrong-token", params, {"X-Barcelona-Token" => nil})
+        expect(response.status).to eq 404
+      end
+    end
+  end
+
+  context "when the API is called twice" do
+    it "updates an existing heritage" do
+      allow(DeployRunnerJob).to receive(:perform_later)
+
+      api_request(:post, "/v1/review_groups/#{review_group.name}/apps", params)
+      expect(response.status).to eq 200
+
+      second_params = params.merge(
+        image_tag: "next_version",
+        environment: [
+          {name: "ENV", value: "value1"},
+          {name: "ENV2", value: "value2"},
+          {name: "SECRET", value_from: "/secret/env"}
+        ],
+      )
+
+      api_request(:post, "/v1/review_groups/#{review_group.name}/apps", second_params)
+      expect(response.status).to eq 200
+
+      expect(ReviewApp.count).to eq 1
+      expect(Heritage.count).to eq 1
+      review_app = JSON.load(response.body)["review_app"]
+      expect(review_app["domain"]).to eq "branch-name.review.basedomain.com"
+      expect(review_app["subject"]).to eq "branch-name"
+      expect(review_app["heritage"]["image_name"]).to eq params[:image_name]
+      expect(review_app["heritage"]["image_tag"]).to eq "next_version"
+      expect(review_app["heritage"]["before_deploy"]).to eq "before_deploy_command"
+      expect(review_app["heritage"]["environment"].count).to eq 3
+      expect(review_app["heritage"]["environment"][0]["name"]).to eq "ENV"
+      expect(review_app["heritage"]["environment"][0]["value"]).to eq "value1"
+      expect(review_app["heritage"]["environment"][1]["name"]).to eq "ENV2"
+      expect(review_app["heritage"]["environment"][1]["value"]).to eq "value2"
+      expect(review_app["heritage"]["environment"][2]["name"]).to eq "SECRET"
+      expect(review_app["heritage"]["environment"][2]["value_from"]).to eq "/secret/env"
+      expect(review_app["heritage"]["token"]).to be_a String
+      expect(review_app["heritage"]["scheduled_tasks"]).to be_empty
+    end
+  end
+end

--- a/spec/requests/create_review_app_spec.rb
+++ b/spec/requests/create_review_app_spec.rb
@@ -16,12 +16,13 @@ describe "POST /v1/:review_group/apps", type: :request do
         {name: "ENV", value: "value"},
         {name: "SECRET", value_from: "/secret/env"}
       ],
-      service: {
+      services: [{
+        name: "web",
         service_type: "web",
         cpu: 128,
         memory: 256,
         command: "nginx",
-      }
+      }]
     }
   end
 

--- a/spec/requests/create_review_app_spec.rb
+++ b/spec/requests/create_review_app_spec.rb
@@ -44,17 +44,17 @@ describe "POST /v1/:review_group/apps", type: :request do
     expect(review_app["heritage"]["scheduled_tasks"]).to be_empty
   end
 
-  context "trigger API" do
+  context "ci API" do
     it "creates a heritage" do
       allow(DeployRunnerJob).to receive(:perform_later)
-      api_request(:post, "/v1/review_groups/#{review_group.name}/apps/trigger/#{review_group.token}", params, {"X-Barcelona-Token" => nil})
+      api_request(:post, "/v1/review_groups/#{review_group.name}/ci/apps/#{review_group.token}", params, {"X-Barcelona-Token" => nil})
       expect(response.status).to eq 200
     end
 
     context "with wrong token" do
       it "creates a heritage" do
         allow(DeployRunnerJob).to receive(:perform_later)
-        api_request(:post, "/v1/review_groups/#{review_group.name}/apps/trigger/wrong-token", params, {"X-Barcelona-Token" => nil})
+        api_request(:post, "/v1/review_groups/#{review_group.name}/ci/apps/wrong-token", params, {"X-Barcelona-Token" => nil})
         expect(response.status).to eq 404
       end
     end

--- a/spec/requests/create_review_group_spec.rb
+++ b/spec/requests/create_review_group_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "POST /v1/review_groups", type: :request do
+  let(:user) { create :user, roles: roles }
+  let(:endpoint) { create :endpoint }
+  let(:params) do
+    {
+      name: "example",
+      base_domain: "reviewapps.degica.com",
+      endpoint: endpoint.name
+    }
+  end
+
+  context "when developer user" do
+    let(:roles) { ["developer"] }
+
+    it "creates a review group" do
+      api_request(:post, "/v1/review_groups", params)
+      expect(response.status).to eq 403
+    end
+  end
+
+  context "when admin user" do
+    let(:roles) { ["admin"] }
+
+    it "creates a review group" do
+      api_request(:post, "/v1/review_groups", params)
+      expect(response.status).to eq 200
+      group = JSON.load(response.body)["review_group"]
+      expect(group["name"]).to eq "example"
+      expect(group["base_domain"]).to eq "reviewapps.degica.com"
+      expect(group["endpoint"]["name"]).to eq endpoint.name
+    end
+  end
+end

--- a/spec/requests/create_review_group_spec.rb
+++ b/spec/requests/create_review_group_spec.rb
@@ -24,6 +24,10 @@ describe "POST /v1/review_groups", type: :request do
     let(:roles) { ["admin"] }
 
     it "creates a review group" do
+      allow_any_instance_of(CloudFormation::Executor).to receive(:outputs) {
+        {"DNSName" => "dns.name"}
+      }
+
       api_request(:post, "/v1/review_groups", params)
       expect(response.status).to eq 200
       group = JSON.load(response.body)["review_group"]

--- a/spec/requests/delete_review_app_spec.rb
+++ b/spec/requests/delete_review_app_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe "DELETE /v1/:review_group/apps/:review_app", type: :request do
+  let(:user) { create :user }
+  let(:review_group) { create(:review_group) }
+  let(:review_app) { create(:review_app, review_group: review_group) }
+
+  it "creates a heritage" do
+    allow(DeployRunnerJob).to receive(:perform_later)
+    api_request(:delete, "/v1/review_groups/#{review_group.name}/apps/#{review_app.subject}")
+    expect(response.status).to eq 204
+  end
+end

--- a/spec/requests/delete_review_app_spec.rb
+++ b/spec/requests/delete_review_app_spec.rb
@@ -11,3 +11,15 @@ describe "DELETE /v1/:review_group/apps/:review_app", type: :request do
     expect(response.status).to eq 204
   end
 end
+
+describe "DELETE /v1/:review_group/ci/apps/:token/:review_app", type: :request do
+  let(:user) { create :user }
+  let(:review_group) { create(:review_group) }
+  let(:review_app) { create(:review_app, review_group: review_group) }
+
+  it "creates a heritage" do
+    allow(DeployRunnerJob).to receive(:perform_later)
+    api_request(:delete, "/v1/review_groups/#{review_group.name}/ci/apps/#{review_group.token}/#{review_app.subject}", {}, {"X-Barcelona-Token" => nil})
+    expect(response.status).to eq 204
+  end
+end

--- a/spec/requests/delete_review_group_spec.rb
+++ b/spec/requests/delete_review_group_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe "DELETE /v1/review_groups/:review_group", type: :request do
+  let(:user) { create :user, roles: roles }
+  let(:review_group) { create :review_group }
+
+  context "when developer uer" do
+    let(:roles) { ["developer"] }
+
+    it "fails" do
+      api_request(:delete, "/v1/review_groups/#{review_group.name}")
+      expect(response.status).to eq 403
+    end
+  end
+
+  context "when admin uer" do
+    let(:roles) { ["admin"] }
+
+    it "deletes a review group" do
+      api_request(:delete, "/v1/review_groups/#{review_group.name}")
+      expect(response.status).to eq 204
+    end
+  end
+end


### PR DESCRIPTION
**Note: This PR is based on #501 and should be merged after #501**

Client changes https://github.com/degica/barcelona-cli/pull/6

## Usage

### barcelona.yml

Now you can set a top-level `review` section in your `barcelona.yml`

```yaml
review:
  group: test # group name
  image_name: quay.io/degica/awesome-rails-app
  environment:
    - name: RAILS_ENV
      value: staging
    - name: DATABASE_URL
      value_from: komoju_staging/database_url # secret environment variable
  services:
    - name: web
      service_type: web
      cpu: 128
      memory: 256
      command: nginx -g "daemon off;"
```


### Review Group

Review group has the following resources which are shared with review apps that belong to this group.

- TaskRole
- BaseDomain
  - review apps domains are subdmain of its group's base domain
  - e.g. base domain `reviews.degica.com` then review app will be `branch-name.reviews.degica.com`
- Endpoint
  - All review apps that belong to a review group use the same endpoint
  - Barcelona admins need to setup DNS record so that all subdomains of group's base domain are pointed to the endpoint

```
$ bcn review group create review-group-name --endpoint endpoint-name --base-domain reviews.degica.com
```

### Review app

```
$ bcn review deploy branch-name --tag docker-image-tag
```

Once you execute the above command, your docker container will be available at `https://branch-name.reviews.degica.com`

### bcn run

```
$ bcn review list --group group-name
  SUBJECT |          DOMAIN          |                  
+---------+--------------------------+-----------------+
  v2      | v2.reviewapps.degica.com | review-7066c768  
```

`review-7066c768` is the name you want to `bcn run` into. So,

```
$ bcn run -H review-7066c768 sh
Waiting for the process to start
Connecting to the process
/ # 
```

Yay :tada: 