### PR TITLE
Allow ScheduleHandlerRole to PassRole

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -86,6 +86,13 @@ class Heritage < ActiveRecord::Base
                       "logs:PutLogEvents",
                     ],
                     "Resource" => ["*"]
+                  },
+                  {
+                    "Effect" => "Allow",
+                    "Action" => [
+                      "iam:PassRole"
+                    ],
+                    "Resource" => [get_attr("TaskExecutionRole", "Arn")]
                   }
                 ]
               }


### PR DESCRIPTION
Found a bug where ScheduleHandler can't call `RunTask`. I added "TaskExecutionRole" to task definition so now exectuion of task is done in context of TaskExecutionRole.

I tested that this fixes the problem. You can see that now scheduled tasks are running correctly in "test-district" in our test AWS account 