### PR TITLE
Change newrelic repo for amazon linux2

### DIFF
--- a/lib/barcelona/plugins/newrelic_plugin.rb
+++ b/lib/barcelona/plugins/newrelic_plugin.rb
@@ -12,8 +12,8 @@ module Barcelona
         user_data.add_file("/etc/yum.repos.d/newrelic-infra.repo", "root:root", "644", <<~EOS)
           [newrelic-infra]
           name=New Relic Infrastructure
-          baseurl=http://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64
-          gpgkey=http://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
+          baseurl=https://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64
+          gpgkey=https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
           gpgcheck=1
           repo_gpgcheck=1
         EOS

--- a/lib/barcelona/plugins/newrelic_plugin.rb
+++ b/lib/barcelona/plugins/newrelic_plugin.rb
@@ -12,7 +12,7 @@ module Barcelona
         user_data.add_file("/etc/yum.repos.d/newrelic-infra.repo", "root:root", "644", <<~EOS)
           [newrelic-infra]
           name=New Relic Infrastructure
-          baseurl=http://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64
+          baseurl=http://download.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64
           gpgkey=http://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
           gpgcheck=1
           repo_gpgcheck=1


### PR DESCRIPTION
This PR changes the repository for newrelic agent.

- [Install Infrastructure for Linux \| New Relic Documentation](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux)

I confirmed it by replacing it and re-installing the package on an existing amazon linux2 host.
