### PR TITLE
Preserve reviewapp listener config

### DIFF
--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -15,13 +15,11 @@ class ReviewApp < ApplicationRecord
 
   def build_heritage
     web_service = services.find{ |s| s[:service_type].to_s == "web" }
-    web_service[:listeners] = [
-      {
-        endpoint: review_group.endpoint.name,
-        rule_priority: rule_priority_from_subject,
-        rule_conditions: [{type: "host-header", value: domain}]
-      }
-    ]
+    web_service[:listeners] = [{}] if web_service[:listeners].blank?
+    web_service[:listeners][0][:endpoint] = review_group.endpoint.name
+    web_service[:listeners][0][:rule_priority] = rule_priority_from_subject
+    web_service[:listeners][0][:rule_conditions] ||= []
+    web_service[:listeners][0][:rule_conditions] << {type: "host-header", value: domain}
 
     params = {
       name: "review-#{slug_digest}",

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -35,5 +35,38 @@ describe ReviewApp do
       expect_any_instance_of(Heritage).to receive(:deploy!)
       review_app.save!
     end
+
+    context "when a service def has listeners" do
+      let(:review_app) {
+        group.review_apps.new(
+          subject: "subject",
+          image_name: "image",
+          image_tag: "tag",
+          retention: 12 * 3600,
+          before_deploy: "true",
+          environment: [],
+          services: [{
+            name: "review",
+            command: "true",
+            service_type: "web",
+            listeners: [{
+              health_check_path: "/healthcheck",
+              health_check_interval: 300
+            }]
+          }])}
+
+      it "preserves configurations" do
+        expect{review_app.save!}.to_not raise_error
+
+        expect(review_app.heritage).to be_present
+        expect(review_app.heritage.name).to eq "review-#{review_app.slug_digest}"
+        expect(review_app.heritage.services[0].listeners[0].endpoint).to eq group.endpoint
+        expect(review_app.heritage.services[0].listeners[0].rule_priority).to eq review_app.rule_priority_from_subject
+        expect(review_app.heritage.services[0].listeners[0].rule_conditions[0]["type"]).to eq "host-header"
+        expect(review_app.heritage.services[0].listeners[0].rule_conditions[0]["value"]).to eq review_app.domain
+        expect(review_app.heritage.services[0].listeners[0].health_check_interval).to eq 300
+        expect(review_app.heritage.services[0].listeners[0].health_check_path).to eq "/healthcheck"
+      end
+    end
   end
 end


### PR DESCRIPTION
Instead of entirely overriding `listeners`, Barcelona now add/update only necessary fields. With this change, the below config should work

```yaml
review:
  services:
    - name: web
      service_type: web
      # ...
      listeners:
        - health_check_path: /health_check
```
