### PR TITLE
Update ECS optimized AMI to 2018.03.t

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-095775a2445cb7ff7",
-        "us-east-2"      => "ami-0b485bb5e24e0fa19",
-        "us-west-1"      => "ami-09ebebeb27420060d",
-        "us-west-2"      => "ami-072ca073fa9b8b128",
-        "eu-west-1"      => "ami-02a2ea2b210628cc5",
-        "eu-west-2"      => "ami-03ae4df38be5818e7",
-        "eu-west-3"      => "ami-0210474827954ae61",
-        "eu-central-1"      => "ami-0d3777b4505b5fe15",
-        "ap-northeast-1"      => "ami-0cfa84956cde58703",
-        "ap-northeast-2"      => "ami-0467ca4c0f6ab904a",
-        "ap-southeast-1"      => "ami-004a3d8e79a88f9fe",
-        "ap-southeast-2"      => "ami-0a96da37cfa9923a4",
-        "ca-central-1"      => "ami-0d774ad11778bc75e",
-        "ap-south-1"      => "ami-0d95ea0e61c0cf5ec",
-        "sa-east-1"      => "ami-06b53bdc7efc4fb83",
+        "us-east-1"      => "ami-0dde61416371df99a",
+        "us-east-2"      => "ami-068a784e5da70c400",
+        "us-west-1"      => "ami-01b403cf431fecff5",
+        "us-west-2"      => "ami-050274527f8727b52",
+        "eu-west-1"      => "ami-0f43fe59461776205",
+        "eu-west-2"      => "ami-0294bb049c608a183",
+        "eu-west-3"      => "ami-065d86bd1f3350c52",
+        "eu-central-1"      => "ami-075703041f2f591b9",
+        "ap-northeast-1"      => "ami-088d9a38123ee2d21",
+        "ap-northeast-2"      => "ami-009ef65c02eb7db10",
+        "ap-southeast-1"      => "ami-0c8ef5b3cf8888930",
+        "ap-southeast-2"      => "ami-096d467b43b2344ba",
+        "ca-central-1"      => "ami-079442f710b115509",
+        "ap-south-1"      => "ami-03f59e90c8855694e",
+        "sa-east-1"      => "ami-024b28d14f975baf4",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -1,24 +1,24 @@
 module Barcelona
   module Network
     class BastionBuilder < CloudFormation::Builder
-      # https://aws.amazon.com/amazon-linux-ami/
+      # https://aws.amazon.com/amazon-linux-2/release-notes/
       # Amazon Linux 2 AMI
       AMI_IDS = {
-        "us-east-1"      => "ami-02da3a138888ced85",
-        "us-east-2"      => "ami-0de7daa7385332688",
-        "us-west-1"      => "ami-09bfcadb25ee95bec",
-        "us-west-2"      => "ami-095cd038eef3e5074",
-        "eu-west-1"      => "ami-02a39bdb8e8ee056a",
-        "eu-west-2"      => "ami-07a5200f3fa9c33d3",
-        "eu-west-3"      => "ami-0e9073d7ac75f4491",
-        "eu-central-1"      => "ami-07f1fbbff759e24dd",
-        "ap-northeast-1"      => "ami-097473abce069b8e9",
-        "ap-northeast-2"      => "ami-045e355a6004a67c4",
-        "ap-southeast-1"      => "ami-00158b185c8cc09dc",
-        "ap-southeast-2"      => "ami-0c3228fd049cdb151",
-        "ca-central-1"      => "ami-05f9d71283317f5c9",
-        "ap-south-1"      => "ami-03103e7ded4c02ef8",
-        "sa-east-1"      => "ami-095a33e72f6bb89c3",
+        "us-east-1"      => "ami-0c6b1d09930fac512",
+        "us-east-2"      => "ami-0ebbf2179e615c338",
+        "us-west-1"      => "ami-015954d5e5548d13b",
+        "us-west-2"      => "ami-0cb72367e98845d43",
+        "eu-west-1"      => "ami-030dbca661d402413",
+        "eu-west-2"      => "ami-0009a33f033d8b7b6",
+        "eu-west-3"      => "ami-0ebb3a801d5fb8b9b",
+        "eu-central-1"      => "ami-0ebe657bc328d4e82",
+        "ap-northeast-1"      => "ami-00d101850e971728d",
+        "ap-northeast-2"      => "ami-08ab3f7e72215fe91",
+        "ap-southeast-1"      => "ami-0b5a47f8865280111",
+        "ap-southeast-2"      => "ami-0fb7513bcdc525c3b",
+        "ca-central-1"      => "ami-08a9b721ecc5b0a53",
+        "ap-south-1"      => "ami-00e782930f1c3dbc7",
+        "sa-east-1"      => "ami-058141e091292ecf0",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances and bastion instances as following page.

- [Amazon Linux 2 Release Note](https://aws.amazon.com/amazon-linux-2/release-notes/)
- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)