### PR TITLE
Update nodejs runtime to nodejs8.10

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -50,7 +50,7 @@ class Heritage < ActiveRecord::Base
         add_resource("AWS::Lambda::Function", "ScheduleHandler") do |j|
           j.Handler "index.handler"
           j.Role get_attr("ScheduleHandlerRole", "Arn")
-          j.Runtime "nodejs6.10"
+          j.Runtime "nodejs8.10"
           j.Timeout 60
           j.Code do |j|
             j.ZipFile schedule_handler_code

--- a/app/models/notification_stack.rb
+++ b/app/models/notification_stack.rb
@@ -64,7 +64,7 @@ class NotificationStack < CloudFormation::Stack
                 j.DISTRICT stack.district.name
               end
             end
-            j.Runtime "nodejs6.10"
+            j.Runtime "nodejs8.10"
             j.Code do |j|
               j.ZipFile slack_notification_code
             end


### PR DESCRIPTION
`nodejs6.10` has been deprecated and that version can no longer be created or updated. In this PR I updated the version to `nodejs8.10` 

Note: The current latest runtime is `nodejs10.x` but CloudFormation still does not support 10.x with `ZipFile` option https://forums.aws.amazon.com/thread.jspa?messageID=908801

:heavy_check_mark: Tested on the test district on AWS