### PR TITLE
Specify debian version to runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Gemfile.lock $APP_HOME/
 
 RUN bundle install -j=4 --without development test
 
-FROM ruby:2.6.1-slim
+FROM ruby:2.6.5-slim-buster
 
 ENV APP_HOME=/app
 ENV PATH=$APP_HOME/bin:$PATH


### PR DESCRIPTION
This fixes incompatibility between build env and runtime.

`ruby:2.6.1` is stretch while `degica/rails-buildpack:2.6` is buster now. So some gems can't be loaded on runtime.

```
$ bcn run -H barcelona2 bash                                                                                                          1164ms 
Waiting for the process to start
Connecting to the process
app@b914d7ece8ad:/app$ bin/rails c
Traceback (most recent call last):
...
/usr/local/bundle/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in `require': /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /usr/local/bundle/gems/nokogiri-1.10.2/lib/nokogiri/nokogiri.so) - /usr/local/bundle/gems/nokogiri-1.10.2/lib/nokogiri/nokogiri.so (LoadError)
```