### PR TITLE
Use libcurl3-gnutls instead of libcurl3 for buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
       libsqlite3-0 \
       libxslt1.1 \
       libxml2 \
-      libcurl3 \
+      libcurl3-gnutls \
       openssh-client \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
buster doesn't have `libcurl3` package and [the build failed on Quay](https://quay.io/repository/degica/barcelona/build/a8047d64-d450-4266-9df9-72214b41cd7f).

This fixes the build.