### PR TITLE
Update ECS optimized AMI to latest

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0f846c06eb372f19a",
-        "us-east-2"      => "ami-00017101cbd0aceef",
-        "us-west-1"      => "ami-0576e257e74a2ed6a",
-        "us-west-2"      => "ami-0077174c1f13f8f04",
-        "eu-west-1"      => "ami-0963349a5568210b8",
-        "eu-west-2"      => "ami-096dcbb5122eba98f",
-        "eu-west-3"      => "ami-0bf526dd84e58dee1",
-        "eu-central-1"      => "ami-084ab95c0cbe247e5",
-        "ap-northeast-1"      => "ami-057631c6a4834e06d",
-        "ap-northeast-2"      => "ami-024fbf9337a64471d",
-        "ap-southeast-1"      => "ami-0dfd0f227eabe017b",
-        "ap-southeast-2"      => "ami-0ccdac544dce31397",
-        "ca-central-1"      => "ami-0ab7a7298717e548d",
-        "ap-south-1"      => "ami-0dae45b322e48a882",
-        "sa-east-1"      => "ami-089e78b2a3db5de22",
+        "us-east-1"      => "ami-08fa2eb77f5afe360",
+        "us-east-2"      => "ami-073b44c7c2e03e3d3",
+        "us-west-1"      => "ami-02960ab220404c9a6",
+        "us-west-2"      => "ami-04240723d51aeeb2d",
+        "eu-west-1"      => "ami-05c0240426c25004c",
+        "eu-west-2"      => "ami-0e4e5c424778d57b1",
+        "eu-west-3"      => "ami-084782c5b95d70e09",
+        "eu-central-1"      => "ami-008fc232afbf08234",
+        "ap-northeast-1"      => "ami-06c98c6fe6f20c437",
+        "ap-northeast-2"      => "ami-077c3aea18b1effa7",
+        "ap-southeast-1"      => "ami-0d01c8832e8b0915b",
+        "ap-southeast-2"      => "ami-0020ff5d19a60c0e5",
+        "ca-central-1"      => "ami-07243ebddb8e654ee",
+        "ap-south-1"      => "ami-00c9ea0fa19811160",
+        "sa-east-1"      => "ami-037d92649e2a676ab",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # https://aws.amazon.com/amazon-linux-2/release-notes/
       # Amazon Linux 2 AMI
       AMI_IDS = {
-        "us-east-1"      => "ami-0cc96feef8c6bbff3",
-        "us-east-2"      => "ami-00c79db59589996b9",
-        "us-west-1"      => "ami-0ce5ae170b49e3870",
-        "us-west-2"      => "ami-07669fc90e6e6cc47",
-        "eu-west-1"      => "ami-01f3682deed220c2a",
-        "eu-west-2"      => "ami-08afc3105ef372053",
-        "eu-west-3"      => "ami-07d80b16fe4b2de61",
-        "eu-central-1"      => "ami-0cd855c8009cb26ef",
-        "ap-northeast-1"      => "ami-084040f99a74ce8c3",
-        "ap-northeast-2"      => "ami-0c28c81fda53dcb86",
-        "ap-southeast-1"      => "ami-0602ae7e6b9191aea",
-        "ap-southeast-2"      => "ami-0c1d8842b9bfc767c",
-        "ca-central-1"      => "ami-0827e3df5a5cdb6a6",
-        "ap-south-1"      => "ami-0b3046001e1ba9a99",
-        "sa-east-1"      => "ami-083cd84588c53dffa",
+        "us-east-1"      => "ami-00dc79254d0461090",
+        "us-east-2"      => "ami-00bf61217e296b409",
+        "us-west-1"      => "ami-024c80694b5b3e51a",
+        "us-west-2"      => "ami-0a85857bfc5345c38",
+        "eu-west-1"      => "ami-040ba9174949f6de4",
+        "eu-west-2"      => "ami-00e8b55a2e841be44",
+        "eu-west-3"      => "ami-05a51ff00c1d77571",
+        "eu-central-1"      => "ami-0f3a43fbf2d3899f7",
+        "ap-northeast-1"      => "ami-0064e711cbc7a825e",
+        "ap-northeast-2"      => "ami-02b3330196502d247",
+        "ap-southeast-1"      => "ami-00942d7cd4f3ca5c0",
+        "ap-southeast-2"      => "ami-08a74056dfd30c986",
+        "ca-central-1"      => "ami-007dbcbce3118978b",
+        "ap-south-1"      => "ami-040c7ad0a93be494e",
+        "sa-east-1"      => "ami-053f8b6627112b46e",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

It also update the AMIs for bastion to the latest Amazon Linux2.
