### PR TITLE
Add ssm_path to whitelist

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -117,7 +117,8 @@ class HeritagesController < ApplicationController
       environment: [
         :name,
         :value,
-        :value_from
+        :value_from,
+        :ssm_path
       ]
     ]).tap do |whitelisted|
       if params[:services].present?

--- a/spec/requests/update_heritage_spec.rb
+++ b/spec/requests/update_heritage_spec.rb
@@ -44,7 +44,8 @@ describe "updating a heritage" do
         before_deploy: nil,
         environment: [
           {name: "ENV2", value: "my value 2"},
-          {name: "SECRET", value_from: "arn"}
+          {name: "SECRET", value_from: "arn"},
+          {name: "VALUE_HIDDEN_IN_SSM", ssm_path: "heritage1/key1"}
         ],
         services: [
           {
@@ -67,13 +68,16 @@ describe "updating a heritage" do
       expect(heritage["image_name"]).to eq "nginx"
       expect(heritage["image_tag"]).to eq "v3"
       expect(heritage["before_deploy"]).to eq nil
-      expect(heritage["environment"].count).to eq 2
+      expect(heritage["environment"].count).to eq 3
       expect(heritage["environment"][0]["name"]).to eq "ENV2"
       expect(heritage["environment"][0]["value"]).to eq "my value 2"
       expect(heritage["environment"][0]["value_from"]).to eq nil
       expect(heritage["environment"][1]["name"]).to eq "SECRET"
       expect(heritage["environment"][1]["value"]).to eq nil
       expect(heritage["environment"][1]["value_from"]).to eq "arn"
+      expect(heritage["environment"][2]["name"]).to eq "VALUE_HIDDEN_IN_SSM"
+      expect(heritage["environment"][2]["value"]).to eq nil
+      expect(heritage["environment"][2]["value_from"]).to eq "/barcelona/#{district.name}/heritage1/key1"
       web_service = heritage["services"].find { |s| s["name"] == "web" }
       expect(web_service["public"]).to eq true
       expect(web_service["cpu"]).to eq 128


### PR DESCRIPTION
Currently, Barcelona doesn't accept environment variables with `ssm_path`. 

When I post a `barcelona.yml` containing `ssm_path`, it fails with following message.

```
ActiveRecord::RecordInvalid: Validation failed: Environments value can't be blank, Environments value from can't be blank
```

This PR adds `ssm_path` to the whitelist for heritage requests.
