### PR TITLE
Set keepalive timeout to 75s

### DIFF
--- a/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/alb_server.conf.erb
@@ -18,8 +18,6 @@ server {
   }
   <% end %>
 
-  keepalive_timeout 5;
-
   location / {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";

--- a/dockerfiles/reverse-proxy/templates/nginx.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/nginx.conf.erb
@@ -33,7 +33,7 @@ http {
   gzip_vary on;
   gzip_disable "MSIE [1-6].(?!.*SV1)";
 
-  keepalive_timeout  5;
+  keepalive_timeout  75;
   server_tokens off;
 
   upstream <%= upstream_name %> {

--- a/dockerfiles/reverse-proxy/templates/server.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/server.conf.erb
@@ -33,8 +33,6 @@ server {
   real_ip_header proxy_protocol;
   <% end %>
 
-  keepalive_timeout 5;
-
   location / {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This PR changes nginx reverse proxy's `keepalive_timeout` to 75 seconds, which is [the default value](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)

The reason why this is needed is that nginx keepalive timeout should be longer than ALB's keepalive timeout, which is by default 60 seconds and we do not change it.
More detailed why is well explained here https://stackoverflow.com/a/50174356