### PR TITLE
Upgrade runtime for Draining Function

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -112,7 +112,7 @@ module Barcelona
           end
 
           j.Handler "index.lambda_handler"
-          j.Runtime "python2.7"
+          j.Runtime "python3.7"
           j.Timeout "15"
           j.Role get_attr("ASGDrainingFunctionRole", "Arn")
           j.Environment do |j|

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -214,7 +214,7 @@ describe Barcelona::Network::NetworkStack do
             "ZipFile" => kind_of(String)
           },
           "Handler" => "index.lambda_handler",
-          "Runtime" => "python2.7",
+          "Runtime" => "python3.7",
           "Timeout" => "15",
           "Role" => {"Fn::GetAtt" => ["ASGDrainingFunctionRole", "Arn"]},
           "Environment" => {


### PR DESCRIPTION
python2 was deprecated and AWS says that we can't use it since December 31, 2020.

So I tested the draining function just modifying Runtime to  pyhon3.8. 

Here's my tests with Barclona runing on my machine.

1.  Create a district
2. Create and deploy a heritage with [barcelona\-tutorial/](https://github.com/essa/barcelona-tutorial/tree/master/step1)
3. Start three instances
4. Reduce number of instances to two
5. Reduce number of instances to one

The second instances had two tasks and they were migrated to the last successfully.

And I also tested that I can modify runtime with Web Console to python2.7.
