### PR TITLE
Update development docker files

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,12 +1,14 @@
 FROM degica/rails-buildpack:2.6
 
 ARG UID=1000
-ARG APP_HOME=/app
-
-WORKDIR $APP_HOME
+ARG APP_HOME
 
 RUN useradd --uid $UID --user-group --create-home app
 RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
 RUN apt-get install -y openssh-client --no-install-recommends
+
+WORKDIR /app
+RUN rm -rf $APP_HOME && ln -s /app $APP_HOME
+ENV PATH=/app/bin:$PATH
 
 USER app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
      - vault
     volumes:
       - bundle:/usr/local/bundle
-      - .:${PWD}
+      - .:/app
     environment: &env_base
       PORT: 3333
       DATABASE_URL: postgres://postgres:@db:5432


### PR DESCRIPTION
The current docker files for development didn't work because excutable path resolution failed. I fixed the files so docker-compose work again

Previously `${PWD}` was the instance and `/app` was a symlink to $PWD. I reversed that and added `/app/bin` to `$PATH`