### PR TITLE
Use ChangeSet for district update

### DIFF
--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -100,10 +100,6 @@ class ApplyDistrict
     aws.ecs.create_cluster(cluster_name: district.name)
   end
 
-  def create_or_update_network_stack
-    district.stack_executor.create_or_update
-  end
-
   def create_district_role(access_key_id, secret_access_key)
     task_role_arn = ecs_task_credentials&.dig("RoleArn")
     raise RuntimeError.new("Role ARN doesn't exist") if task_role_arn.nil?

--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -34,7 +34,7 @@ class ApplyDistrict
   def apply
     district.save!
     update_ecs_config
-    district.stack_executor.update
+    district.stack_executor.update(change_set: true)
   end
 
   def destroy!

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -25,14 +25,27 @@ module CloudFormation
       client.create_stack(options)
     end
 
-    def update
-      client.update_stack(stack_options)
+    def update(change_set: false)
+      if change_set
+        create_change_set
+      else
+        client.update_stack(stack_options)
+      end
     rescue Aws::CloudFormation::Errors::ValidationError => e
       if e.message == "No updates are to be performed."
         Rails.logger.warn "No updates are to be performed."
       else
         raise e
       end
+    end
+
+    def create_change_set(type: "UPDATE")
+      dt = Time.current.strftime("%Y-%m-%d-%H%M%S")
+      options = stack_options.merge({
+        change_set_name: "changeset-#{dt}",
+        change_set_type: type,
+      })
+      client.create_change_set(options)
     end
 
     def stack_options

--- a/spec/lib/cloud_formation/executor_spec.rb
+++ b/spec/lib/cloud_formation/executor_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe CloudFormation::Executor do
+  let(:client) { double }
+  let(:stack) { CloudFormation::Stack.new("test") }
+  let(:executor) { CloudFormation::Executor.new(stack, client) }
+
+  describe "#update" do
+    it "creates a change set if true" do
+      expect(client).to receive(:create_change_set)
+      expect(client).to_not receive(:update_stack)
+      executor.update(change_set: true)
+    end
+
+    it "updates the stack directly if false" do
+      expect(client).to_not receive(:create_change_set)
+      expect(client).to receive(:update_stack)
+      executor.update(change_set: false)
+    end
+  end
+end


### PR DESCRIPTION
Closes #404 

With this change, barcelona creates a [change set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html) instead of directly updating the stack.

I've been always worried a case where resources get deleted when we update a stack (`bcn district apply`). That can happen when we merge a wrong change into the master branch and the change contains a bug which deletes a resource unwillingly.

With this PR, Barcelona creates a change set so we can review what are going to change before we actually update a stack