### PR TITLE
Make delete-plugin work again

### DIFF
--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -21,7 +21,6 @@ class PluginsController < ApplicationController
 
   def destroy
     @plugin.destroy!
-    render status: 204, nothing: true
     head 204
   end
 

--- a/spec/requests/plugin_spec.rb
+++ b/spec/requests/plugin_spec.rb
@@ -25,5 +25,9 @@ describe "PUT /districts/:district/plugins/:id", type: :request do
     expect(plugin["attributes"]).to eq({"token" => "fghijk"})
 
     expect(district.plugins.pluck(:name)).to eq ["logentries"]
+
+    # delete
+    api_request :delete, "/v1/districts/#{district.name}/plugins/#{name}", params
+    expect(response.status).to eq 204
   end
 end


### PR DESCRIPTION
it's raising 500 error now because rendering nothing is not supported now