### PR TITLE
Allow connecting to external ossec servers

### DIFF
--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -57,14 +57,14 @@ module Barcelona
               "IpProtocol" => "udp",
               "FromPort" => 1514,
               "ToPort" => 1514,
-              "CidrIp" => options[:cidr_block]
+              "CidrIp" => '0.0.0.0/0'
             },
             # OSSEC authd
             {
               "IpProtocol" => "tcp",
               "FromPort" => 1515,
               "ToPort" => 1515,
-              "CidrIp" => options[:cidr_block]
+              "CidrIp" => '0.0.0.0/0'
             },
           ]
           j.Tags [

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -326,11 +326,11 @@ describe Barcelona::Network::NetworkStack do
             {"IpProtocol" => "udp",
              "FromPort" => 1514,
              "ToPort" => 1514,
-             "CidrIp" => district.cidr_block},
+             "CidrIp" => "0.0.0.0/0"},
             {"IpProtocol" => "tcp",
              "FromPort" => 1515,
              "ToPort" => 1515,
-             "CidrIp" => district.cidr_block},
+             "CidrIp" => "0.0.0.0/0"},
           ],
           "Tags" => [{"Key" => "barcelona", "Value" => district.name}]
         }


### PR DESCRIPTION
This PR enables bastion severs to connect to ossec servers located outside of the VPC.
