### PR TITLE
Fix secure instance plugin

### DIFF
--- a/app/models/instance_user_data.rb
+++ b/app/models/instance_user_data.rb
@@ -1,5 +1,5 @@
 class InstanceUserData
-  attr_accessor :files, :boot_commands, :run_commands, :packages, :users
+  attr_accessor :files, :boot_commands, :run_commands, :packages, :users, :cloud_final_modules
 
   def self.load_or_initialize(base64 = nil)
     if base64.nil?
@@ -17,6 +17,7 @@ class InstanceUserData
     instance.run_commands = yml["runcmd"] || []
     instance.packages = yml["packages"] || []
     instance.users = yml["users"] || []
+    instance.cloud_final_modules = yml["cloud_final_modules"] || []
     instance
   end
 
@@ -26,6 +27,7 @@ class InstanceUserData
     @run_commands = []
     @users = []
     @packages = []
+    @cloud_final_modules = []
   end
 
   def build
@@ -34,7 +36,8 @@ class InstanceUserData
       "write_files" => files,
       "bootcmd" => boot_commands,
       "runcmd" => run_commands,
-      "users" => users
+      "users" => users,
+      "cloud_final_modules" => cloud_final_modules
     }.reject{ |_, v| v.blank? }
     raw_user_data = "#cloud-config\n" << YAML.dump(user_data)
     Base64.encode64(raw_user_data)

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -140,6 +140,8 @@ module Barcelona
         ud.run_commands += [
           # awslogs
           "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
+          # There are cases when we must wait for meta-data
+          'while [ "$ec2_id" = "" ]; do sleep 1 ; ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id) ; done',
           'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
           'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
           "systemctl start awslogsd",

--- a/lib/barcelona/plugins/secure_instance_plugin.rb
+++ b/lib/barcelona/plugins/secure_instance_plugin.rb
@@ -28,7 +28,8 @@ module Barcelona
 
       module SecureUserData
         def apply_security_update_on_the_first_boot
-          self.boot_commands += <<~EOS.split("\n")
+          self.cloud_final_modules = [['scripts-user', 'always']] # run runcmd on every boot
+          self.run_commands.unshift *<<~EOS.split("\n")
 
             if [ -f /root/.security_update_applied ]
             then

--- a/spec/lib/barcelona/plugins/secure_instance_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/secure_instance_plugin_spec.rb
@@ -52,8 +52,11 @@ module Barcelona
         it_behaves_like('pcidss tools')
 
         it "applies security update" do
-          expect(user_data["bootcmd"]).to include(/yum update -y --security/)
-          expect(user_data["bootcmd"]).to include(/reboot/)
+          # the first command must be the checking of security update
+          expect(user_data["runcmd"][1]).to eq('if [ -f /root/.security_update_applied ]')
+          expect(user_data["runcmd"]).to include(/yum update -y --security/)
+          expect(user_data["runcmd"]).to include(/reboot/)
+          expect(user_data["cloud_final_modules"]).to eq [['scripts-user', 'always']]
         end
       end
     end

--- a/spec/models/instance_user_data_spec.rb
+++ b/spec/models/instance_user_data_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe InstanceUserData do
+  let(:user) { create :user, public_key: 'abc' }
+  let(:run_commands) { [ "echo abc" ] }
+  let(:packages) { [ "ruby" ] }
+  let(:cloud_final_modules) { [] }
+  describe "#build" do
+    subject do
+      described_class.load_or_initialize.tap do |userdata|
+        userdata.run_commands += run_commands
+        userdata.packages +=  packages
+        userdata.cloud_final_modules = cloud_final_modules
+      end.build
+    end
+
+    it "generates base64 eoncoded yaml string" do
+      yml = YAML.load(Base64.decode64(subject))
+      expect(yml['runcmd']).to eq(run_commands)
+      expect(yml['packages']).to eq(packages)
+    end
+
+    context "with cloud_final_modules" do
+      let(:cloud_final_modules) { [['scripts-user', 'always']] }
+
+      it "generates cloud_final_modules directive" do
+        yml = YAML.load(Base64.decode64(subject))
+        expect(yml['cloud_final_modules']).to eq([['scripts-user', 'always']])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes secure instance plugin.

Rebooting in the `bootcmd` of cloud-init seems to have a flipflop issue. 

I tested it by booting bastion instance in a district only with this plugin several times. Although the launch configuration was not changed, the instance became silent with no message some times.

So I moved the script in the `bootcmd` to the beginning of the `runcmd` and make it run on every boot with `cloud_final_modules: [['scripts-user', 'always']]`.

### Tricky part of this PR

I need to guarantee that rebooting is the first command in the `runcmd` so that any commands will run just one time.

Currently I can only put it to the first of `run_commands` array.
```ruby
self.run_commands.unshift *<<~EOS.split("\n")
...
EOS
```
This works when this plugin is the only plugin which puts commands with `unshift`. I think it's a little bit tricky but adding an interface for it to `InstanceUserData` seemed too much to me.

