### PR TITLE
Permissions framework for barcelona

### DIFF
--- a/Kaiserfile
+++ b/Kaiserfile
@@ -1,4 +1,8 @@
-dockerfile 'Dockerfile'
+require 'fileutils'
+
+File.write('.kaiser.dockerfile', File.read('Dockerfile').sub('--without development test', ''))
+dockerfile '.kaiser.dockerfile'
+FileUtils.rm '.kaiser.dockerfile'
 
 db 'postgres:alpine',
    port: 5432,
@@ -26,11 +30,11 @@ vault_host = ENV['VAULT_HOST'] || "#{vault_app_name}.localhost.labs.degica.com"
 app_params "
   -e DATABASE_URL=postgres://postgres:example@<%= db_container_name %>:5432
   -e ENCRYPTION_KEY=abcdefghijklmn
-  -e GITHUB_ORGANIZATION='degica'
-  -e GITHUB_DEVELOPER_TEAM='developers'
-  -e GITHUB_ADMIN_TEAM='Admin developers'
-  -e VAULT_URL=http://#{vault_host}
-  -e VAULT_PATH_PREFIX=degica
+  -e GITHUB_ORGANIZATION='dojiko'
+  -e GITHUB_DEVELOPER_TEAM='dev'
+  -e GITHUB_ADMIN_TEAM='admin'
+  -e VAULT_URL=https://#{vault_host}
+  -e VAULT_PATH_PREFIX=dojiko
 "
 
 attach_mount '.rspec', '/app/.rspec'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::API
   before_action :authenticate
   before_action :authorize_action
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   attr_accessor :current_user
 
   def authenticate
@@ -32,5 +34,11 @@ class ApplicationController < ActionController::API
                        else
                          GithubAuth.new(request)
                        end
+  end
+
+  private
+
+  def user_not_authorized
+    raise ExceptionHandler::Forbidden.new("You are not allowed to do this")
   end
 end

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -2,6 +2,7 @@ class HeritagesController < ApplicationController
   before_action :load_district, only:   [:index, :create]
   before_action :load_heritage, except: [:index, :create, :trigger]
   skip_before_action :authenticate, only: [:trigger]
+  before_action :authorize_heritage
 
   def index
     render json: @district.heritages

--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -1,6 +1,7 @@
 class OneoffsController < ApplicationController
   before_action :load_heritage, only: [:create]
   before_action :load_oneoff, except: [:index, :create]
+  before_action :authorize_heritage
 
   def show
     render json: @oneoff

--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -1,7 +1,6 @@
 class OneoffsController < ApplicationController
   before_action :load_heritage, only: [:create]
   before_action :load_oneoff, except: [:index, :create]
-  before_action :authorize_heritage
 
   def show
     render json: @oneoff
@@ -37,6 +36,7 @@ class OneoffsController < ApplicationController
 
   def load_heritage
     @heritage = Heritage.find_by!(name: params[:heritage_id])
+    Pundit::authorize current_user, @heritage, :run?
   end
 
   def load_oneoff

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
     user = auth_backend.login
     raise ExceptionHandler::Unauthorized.new("You are not allowed to login") if user.nil?
 
+    user.permissions.create!(key: 'users.edit')
     user.save!
 
     Event.new.notify(message: "#{user.name} has logged in to Barcelona")

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,3 @@
+class Permission < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_many :users_districts
+  has_many :permissions
 
   attr_accessor :token
 
@@ -27,6 +28,13 @@ class User < ActiveRecord::Base
 
   def to_param
     name
+  end
+
+  def allowed_to?(*args)
+    return true if admin?
+    return true if permissions.exists?(key: args.join('.'))
+
+    false
   end
 
   private

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -6,32 +6,30 @@ class ApplicationPolicy
     @record = record
   end
 
-  def index?
-    false
-  end
-
-  def show?
-    scope.where(id: record.id).exists?
-  end
-
   def create?
-    false
+    user.allowed_to?(record.name.downcase, 'create')
   end
 
   def new?
     create?
   end
 
+  def index?
+    user.allowed_to?(record.name.downcase, 'index')
+  end
+
+  def method_missing(method_name, *args, &block)
+    user.allowed_to?(record.class.name.downcase, method_name[0..-2])
+  end
+
+  def respond_to?(method_name, *args)
+    return true if method_name.to_s.end_with?('?')
+
+    false
+  end
+
   def update?
-    false
-  end
-
-  def edit?
-    update?
-  end
-
-  def destroy?
-    false
+    edit?
   end
 
   def scope

--- a/app/policies/district_policy.rb
+++ b/app/policies/district_policy.rb
@@ -3,31 +3,7 @@ class DistrictPolicy < ApplicationPolicy
     user.admin?
   end
 
-  def update?
-    user.admin?
-  end
-
-  def destroy?
-    user.admin?
-  end
-
-  def index?
-    user.developer?
-  end
-
-  def launch_instances?
-    user.developer?
-  end
-
-  def terminate_instance?
-    user.developer?
-  end
-
-  def apply_stack?
-    user.admin?
-  end
-
-  def sign_public_key?
-    user.admin?
+  def method_missing(method_name, *args, &block)
+    user.allowed_to?('district', method_name[0..-2], record.name)
   end
 end

--- a/app/policies/heritage_policy.rb
+++ b/app/policies/heritage_policy.rb
@@ -1,2 +1,5 @@
 class HeritagePolicy < ApplicationPolicy
+  def method_missing(method_name, *args, &block)
+    user.allowed_to?('heritage', method_name[0..-2], record.name)
+  end
 end

--- a/app/policies/heritage_policy.rb
+++ b/app/policies/heritage_policy.rb
@@ -1,0 +1,2 @@
+class HeritagePolicy < ApplicationPolicy
+end

--- a/app/policies/notification_policy.rb
+++ b/app/policies/notification_policy.rb
@@ -1,21 +1,2 @@
 class NotificationPolicy < ApplicationPolicy
-  def create?
-    user.admin?
-  end
-
-  def update?
-    user.admin?
-  end
-
-  def destroy?
-    user.admin?
-  end
-
-  def index?
-    user.developer?
-  end
-
-  def show?
-    user.developer?
-  end
 end

--- a/app/policies/review_app_policy.rb
+++ b/app/policies/review_app_policy.rb
@@ -1,25 +1,9 @@
 class ReviewAppPolicy < ApplicationPolicy
-  def create?
-    user.developer?
-  end
-
   def ci_create?
     true
   end
 
   def ci_delete?
     true
-  end
-
-  def destroy?
-    user.developer?
-  end
-
-  def index?
-    user.developer?
-  end
-
-  def show?
-    user.developer?
   end
 end

--- a/app/policies/review_group_policy.rb
+++ b/app/policies/review_group_policy.rb
@@ -1,21 +1,2 @@
 class ReviewGroupPolicy < ApplicationPolicy
-  def create?
-    user.admin?
-  end
-
-  def update?
-    user.admin?
-  end
-
-  def destroy?
-    user.admin?
-  end
-
-  def index?
-    user.developer?
-  end
-
-  def show?
-    user.developer?
-  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,5 @@
 
 en:
   hello: "Hello world"
+  pundit:
+    default: 'You cannot perform this action.'

--- a/db/migrate/20200212095609_create_permissions.rb
+++ b/db/migrate/20200212095609_create_permissions.rb
@@ -1,0 +1,11 @@
+class CreatePermissions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :permissions do |t|
+      t.references :user, null: false
+      t.string :key, null: false
+
+      t.timestamps
+    end
+    add_index :permissions, [:user_id, :key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_23_161003) do
+ActiveRecord::Schema.define(version: 2020_02_12_095609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,6 +126,15 @@ ActiveRecord::Schema.define(version: 2019_02_23_161003) do
     t.datetime "updated_at", null: false
     t.text "command"
     t.index ["heritage_id"], name: "index_oneoffs_on_heritage_id"
+  end
+
+  create_table "permissions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "key"], name: "index_permissions_on_user_id_and_key", unique: true
+    t.index ["user_id"], name: "index_permissions_on_user_id"
   end
 
   create_table "plugins", force: :cascade do |t|

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :permission do
+    user
+    key { 'district.show' }
+  end
+end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe Permission do
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,25 @@
 require 'rails_helper'
 
 describe User do
+  describe '#allowed_to?' do
+    it 'returns true if the user has that permission' do
+      user = create :user
+      perm = create :permission, user: user, key: 'pokemon.train'
+
+      expect(user.allowed_to?('pokemon', 'train')).to eq true
+    end
+
+    it 'returns true if user has no permission but is admin' do
+      user = create :user
+      allow(user).to receive(:admin?) { true }
+
+      expect(user.allowed_to?('pokemon', 'train')).to eq true
+    end
+
+    it 'returns false if user does not have the permission' do
+      user = create :user
+
+      expect(user.allowed_to?('pokemon', 'train')).to eq false
+    end
+  end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+describe ApplicationPolicy do
+  let(:user) { create :user }
+
+  subject { ApplicationPolicy.new(user, record) }
+
+  describe 'type operation' do
+    let(:record) { instance_double(Class) }
+    let(:record_class_name) { "SomeClass" }
+    before do
+      allow(record).to receive(:name) { record_class_name }
+    end
+
+    describe '#create?' do
+      context 'for admins' do
+        let(:user) { create :user, roles: ["admin"] }
+        it { is_expected.to be_create }
+      end
+
+      context 'for plebs' do
+        it { is_expected.to_not be_create }
+      end
+
+      context 'for developers allowed to do so' do
+        before do
+          create :permission, user: user, key: 'someclass.create'
+        end
+        it { is_expected.to be_create }
+      end
+
+      context 'even if other developers have the permission' do
+        before do
+          create :permission, key: 'someclass.create'
+        end
+        it { is_expected.to_not be_create }
+      end
+    end
+
+    describe '#new?' do
+      context 'when #create? returns true' do
+        before { allow(subject).to receive(:create?) { true } }
+        it { is_expected.to be_new }
+      end
+
+      context 'when #create? returns false' do
+        before { allow(subject).to receive(:create?) { false } }
+        it { is_expected.to_not be_new }
+      end
+    end
+
+    describe '#index?' do
+      context 'for admins' do
+        let(:user) { create :user, roles: ["admin"] }
+        it { is_expected.to be_index }
+      end
+
+      context 'for ordinary users' do
+        it { is_expected.to_not be_index }
+      end
+
+      context 'for developers allowed to do so' do
+        before do
+          create :permission, user: user, key: 'someclass.index'
+        end
+        it { is_expected.to be_index }
+      end
+    end
+  end
+
+  describe 'instance operation' do
+    let(:record) { instance_double(Object) }
+    let(:record_class_name) { "SomeClass" }
+    before do
+      class_object = instance_double(Class)
+      allow(class_object).to receive(:name) { record_class_name }
+      allow(record).to receive(:class) { class_object }
+    end
+
+    describe '#meow?' do
+      context 'for admins' do
+        let(:user) { create :user, roles: ["admin"] }
+        it { is_expected.to be_meow }
+      end
+
+      context 'for ordinary users' do
+        it { is_expected.to_not be_meow }
+      end
+
+      context 'for developers allowed to do so' do
+        before do
+          create :permission, user: user, key: 'someclass.meow'
+        end
+        it { is_expected.to be_meow }
+      end
+    end
+
+    describe '#update?' do
+      context 'when #edit? returns true' do
+        before { allow(subject).to receive(:edit?) { true } }
+        it { is_expected.to be_update }
+      end
+
+      context 'when #edit? returns false' do
+        before { allow(subject).to receive(:edit?) { false } }
+        it { is_expected.to_not be_update }
+      end
+    end
+  end
+end

--- a/spec/policies/district_policy_spec.rb
+++ b/spec/policies/district_policy_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe DistrictPolicy do
+  let(:user) { create :user }
+  let(:record) { create :district, name: 'sagrada' }
+
+  subject { DistrictPolicy.new(user, record) }
+
+  describe '#meow?' do
+    context 'for admins' do
+      let(:user) { create :user, roles: ["admin"] }
+      it { is_expected.to be_meow }
+    end
+
+    context 'for developers allowed to meow on sagrada' do
+      before do
+        create :permission, user: user, key: 'district.meow.sagrada'
+      end
+      it { is_expected.to be_meow }
+    end
+
+    context 'for developers allowed to woof on sagrada' do
+      before do
+        create :permission, user: user, key: 'district.woof.sagrada'
+      end
+      it { is_expected.to_not be_meow }
+    end
+
+    context 'for developers allowed to meow on centro' do
+      before do
+        create :permission, user: user, key: 'district.meow.centro'
+      end
+      it { is_expected.to_not be_meow }
+    end
+
+    context 'even if other developers have the permission' do
+      before do
+        create :permission, key: 'district.meow.sagrada'
+      end
+      it { is_expected.to_not be_meow }
+    end
+  end
+end

--- a/spec/policies/review_app_policy_spec.rb
+++ b/spec/policies/review_app_policy_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ReviewAppPolicy do
+  let(:user) { create :user }
+  let(:record) { create :review_app }
+
+  subject { ReviewAppPolicy.new(user, record) }
+
+  describe '#ci_create?' do
+    it { is_expected.to be_ci_create }
+  end
+
+  describe '#ci_delete?' do
+    it { is_expected.to be_ci_delete }
+  end
+end

--- a/spec/requests/create_oneoff_spec.rb
+++ b/spec/requests/create_oneoff_spec.rb
@@ -24,7 +24,17 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
     )
   }
 
+  it 'fails to create oneoff task if no permission' do
+    params = {
+      command: "rake db:migrate",
+      memory: 1024
+    }
+    api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
+    expect(response).to_not be_successful
+  end
+
   it "creates a oneoff task" do
+    create :permission, user: user, key: "heritage.run.#{heritage.name}"
     expect_any_instance_of(Aws::ECS::Client).to receive(:run_task) do
       run_task_response_mock
     end
@@ -56,6 +66,7 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
     end
 
     it "creates a interactive oneoff task" do
+      create :permission, user: user, key: "heritage.run.#{heritage.name}"
       expect_any_instance_of(Aws::ECS::Client).to receive(:run_task) do
         run_task_response_mock
       end

--- a/spec/requests/login_spec.rb
+++ b/spec/requests/login_spec.rb
@@ -27,6 +27,11 @@ describe "POST /login", type: :request do
       expect(body["user"]["name"]).to eq user.name
       expect(body["user"]["token"]).to be_present
     end
+
+    it 'sets permissions after logging in' do
+      api_request :post, "/v1/login", {}, gh_auth
+      expect(User.last.allowed_to?('users', 'edit')).to eq true
+    end
   end
 
   context "when user team is not allowed to login" do

--- a/spec/requests/update_user_spec.rb
+++ b/spec/requests/update_user_spec.rb
@@ -36,6 +36,10 @@ describe "PATCH /user", type: :request do
   let(:district) { create :district }
   let(:user) { create :user, roles: ["developer"] }
 
+  before do
+    create :permission, user: user, key: 'users.update'
+  end
+
   it "updates user information" do
     params = {
       "public_key" => "ssh-rsa aaaaaaaa"


### PR DESCRIPTION
# Context

This is a permissions framework that is both detailed and flexible. The relationship between an action and permission is simple. For example if a person wishes to allow developers to create districts then the permission is `district.create`. If a person wishes to allow developers to edit a district called `sagrada` the permission is `district.edit.sagrada`.

This opens up the possibility of giving/removing wide ranging permissions by simply iterating through all things. To give permissions to a developer `alice` to edit all districts we simply iterate through all districts to create the `Permission.create(user: alice, key: "district.edit.#{district.name}")` for example. Vice versa to remove all.

Users only have one permission by default at the beginning `users.edit` which can also be revoked, leaving the user unable to change his own ssh keys.

Admins have full permissions regardless of what permissions they were given before.

fixes #546 

This PR really is just here to implement the minimum viable product for permissions. There are other desirable features that can be added to it over time.

## What it does not have right now
- API for admins/those with permission to add permissions
- Wildcard permissions?
- API to add/remove ranges of permissions (allow all developers to create endpoints will iterate through all the developers and give them the permission `endpoint.create` for example)
- Endpoints permissions
- Not sure how to `bcn run`

# How to test
1. Login as a github user (non-admin)
2. Attempt to perform `bcn district list`
3. Observe that it fails
4. Use `rails c` to create a permission `Permission.create(user: User.last, key: 'district.list')`
5. Attempt `bcn district list`
6. Observe that it succeeds
