### PR TITLE
Update AMIs for ecs instances and bastion instances to 2.0.20200205

### DIFF
--- a/app/models/container_instance.rb
+++ b/app/models/container_instance.rb
@@ -40,9 +40,6 @@ class ContainerInstance
       'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
       "systemctl start awslogsd",
 
-      # Install SSM agent
-      "yum install -y https://amazon-ssm-#{district.region}.s3.amazonaws.com/latest/linux_amd64/amazon-ssm-agent.rpm",
-
       # Install AWS Inspector agent
       "curl https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install | bash"
     ]

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0f81924348bcd01a1",
-        "us-east-2"      => "ami-025e529ec693faba6",
-        "us-west-1"      => "ami-0c4f775d282076047",
-        "us-west-2"      => "ami-01262e56d9a240227",
-        "eu-west-1"      => "ami-04c29bb1e9988c803",
-        "eu-west-2"      => "ami-037af9c254c6dc46c",
-        "eu-west-3"      => "ami-00c2374f0b16417ab",
-        "eu-central-1"      => "ami-02171c9c6dfc9dd1a",
-        "ap-northeast-1"      => "ami-0633805928291a0db",
-        "ap-northeast-2"      => "ami-0bd857d087df070e6",
-        "ap-southeast-1"      => "ami-0dfacf29e68ba0347",
-        "ap-southeast-2"      => "ami-02a1d998121cea625",
-        "ca-central-1"      => "ami-06a21d76fa509c0e8",
-        "ap-south-1"      => "ami-005136f1190a5c6b7",
-        "sa-east-1"      => "ami-0c16a6e54a2f933f0",
+        "us-east-1"      => "ami-056807e883f197989",
+        "us-east-2"      => "ami-0b421c31dd21d6534",
+        "us-west-1"      => "ami-06cc2443be89d1439",
+        "us-west-2"      => "ami-05a2f3dd8f21fa9f7",
+        "eu-west-1"      => "ami-09270d80acf4d09ca",
+        "eu-west-2"      => "ami-0d44f4b892bde0a73",
+        "eu-west-3"      => "ami-031576df8aaa03c17",
+        "eu-central-1"      => "ami-0bfdae54e0eda93f2",
+        "ap-northeast-1"      => "ami-09ab4b51b72020b66",
+        "ap-northeast-2"      => "ami-0d93e3afc32b4e41a",
+        "ap-southeast-1"      => "ami-04f3eb384ebc387b3",
+        "ap-southeast-2"      => "ami-05c621ca32de56e7a",
+        "ca-central-1"      => "ami-033fdf08e595bc7c8",
+        "ap-south-1"      => "ami-0484b39dd56f70080",
+        "sa-east-1"      => "ami-0eafc21e33e768494",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -3,22 +3,24 @@ module Barcelona
     class BastionBuilder < CloudFormation::Builder
       # https://aws.amazon.com/amazon-linux-2/release-notes/
       # Amazon Linux 2 AMI
+      # You can see the latest version stored in public SSM parameter store
+      # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-00dc79254d0461090",
-        "us-east-2"      => "ami-00bf61217e296b409",
-        "us-west-1"      => "ami-024c80694b5b3e51a",
-        "us-west-2"      => "ami-0a85857bfc5345c38",
-        "eu-west-1"      => "ami-040ba9174949f6de4",
-        "eu-west-2"      => "ami-00e8b55a2e841be44",
-        "eu-west-3"      => "ami-05a51ff00c1d77571",
-        "eu-central-1"      => "ami-0f3a43fbf2d3899f7",
-        "ap-northeast-1"      => "ami-0064e711cbc7a825e",
-        "ap-northeast-2"      => "ami-02b3330196502d247",
-        "ap-southeast-1"      => "ami-00942d7cd4f3ca5c0",
-        "ap-southeast-2"      => "ami-08a74056dfd30c986",
-        "ca-central-1"      => "ami-007dbcbce3118978b",
-        "ap-south-1"      => "ami-040c7ad0a93be494e",
-        "sa-east-1"      => "ami-053f8b6627112b46e",
+        "us-east-1"      => "ami-0a887e401f7654935",
+        "us-east-2"      => "ami-0e38b48473ea57778",
+        "us-west-1"      => "ami-01c94064639c71719",
+        "us-west-2"      => "ami-0e8c04af2729ff1bb",
+        "eu-west-1"      => "ami-099a8245f5daa82bf",
+        "eu-west-2"      => "ami-0389b2a3c4948b1a0",
+        "eu-west-3"      => "ami-0fd9bce3a3384b635",
+        "eu-central-1"      => "ami-0df0e7600ad0913a9",
+        "ap-northeast-1"      => "ami-0af1df87db7b650f4",
+        "ap-northeast-2"      => "ami-0a93a08544874b3b7",
+        "ap-southeast-1"      => "ami-0f02b24005e4aec36",
+        "ap-southeast-2"      => "ami-0f767afb799f45102",
+        "ca-central-1"      => "ami-00db12b46ef5ebc36",
+        "ap-south-1"      => "ami-0d9462a653c34dab7",
+        "sa-east-1"      => "ami-080a223be3de0c3b8",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

It also updates the AMIs for bastion to the latest Amazon Linux2 stored in SSM public parameter store.

- [AWS Systems Manager \- Parameter Store](https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1)