### PR TITLE
Make it possible for ALB to accept PortMappings in barcelona.yml

### DIFF
--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -13,7 +13,8 @@ class HeritageTaskDefinition
         force_ssl: service.force_ssl,
         hosts: service.hosts,
         reverse_proxy_image: service.reverse_proxy_image,
-        mode: (service.listeners.present?) ? :alb : :tcp
+        mode: (service.listeners.present?) ? :alb : :tcp,
+        web_container_port: service.web_container_port
        )
   end
 
@@ -73,7 +74,7 @@ class HeritageTaskDefinition
     end
   end
 
-  def initialize(heritage:, family_name:, user: nil, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil)
+  def initialize(heritage:, family_name:, user: nil, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil, web_container_port: 3000)
     @heritage = heritage
     @family_name = family_name
     @user = user
@@ -87,6 +88,7 @@ class HeritageTaskDefinition
     @reverse_proxy_image = reverse_proxy_image
     @app_container_labels = app_container_labels
     @mode = mode
+    @web_container_port = web_container_port
   end
 
   def web_service?
@@ -94,7 +96,7 @@ class HeritageTaskDefinition
   end
 
   def web_container_port
-    3000
+    @web_container_port
   end
 
   def container_definition

--- a/app/models/port_mapping.rb
+++ b/app/models/port_mapping.rb
@@ -22,6 +22,7 @@ class PortMapping < ActiveRecord::Base
   scope :lb_registerable, -> { where.not(protocol: "udp") }
   scope :tcp, -> { where(protocol: "tcp") }
   scope :udp, -> { where(protocol: "udp") }
+  scope :http, -> { where(protocol: "http") }
 
   def self.to_task_definition
     self.all.map { |pm|

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -93,10 +93,14 @@ class Service < ActiveRecord::Base
 
   def create_port_mappings
     return unless web?
-    return if self.port_mappings.count.nonzero? # No need to create these if already specified
 
-    self.port_mappings.create!(container_port: web_container_port, protocol: 'http')
-    self.port_mappings.create!(container_port: web_container_port, protocol: 'https')
+    if http_port_mapping.blank?
+      self.port_mappings.create!(container_port: web_container_port, protocol: 'http')
+    end
+
+    if https_port_mapping.blank?
+      self.port_mappings.create!(container_port: web_container_port, protocol: 'https')
+    end
   end
 
   def backend

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -63,7 +63,9 @@ class Service < ActiveRecord::Base
   end
 
   def web_container_port
-    3000
+    return 3000 unless http_port_mapping.present?
+
+    http_port_mapping.container_port
   end
 
   def http_port_mapping
@@ -91,6 +93,7 @@ class Service < ActiveRecord::Base
 
   def create_port_mappings
     return unless web?
+    return if self.port_mappings.count.nonzero? # No need to create these if already specified
 
     self.port_mappings.create!(container_port: web_container_port, protocol: 'http')
     self.port_mappings.create!(container_port: web_container_port, protocol: 'https')

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -5,4 +5,37 @@ describe Service do
   let(:service) { create :web_service, heritage: heritage }
 
   it { expect{service.save}.to_not raise_error }
+
+  describe '#create_port_mappings' do
+    before do
+      service.port_mappings.destroy_all
+    end
+
+    it 'creates http port mappings when they do not exist' do
+      allow(service).to receive(:web?) { true }
+      allow(service).to receive(:http_port_mapping) { nil }
+
+      service.send :create_port_mappings
+
+      expect(service.port_mappings.find_by(protocol: 'http')).to be_present
+    end
+
+    it 'creates https port mappings when they do not exist' do
+      allow(service).to receive(:web?) { true }
+      allow(service).to receive(:https_port_mapping) { nil }
+
+      service.send :create_port_mappings
+
+      expect(service.port_mappings.find_by(protocol: 'https')).to be_present
+    end
+
+    it 'does not create https port mappings when not a web' do
+      allow(service).to receive(:web?) { false }
+      allow(service).to receive(:https_port_mapping) { nil }
+
+      service.send :create_port_mappings
+
+      expect(service.port_mappings.find_by(protocol: 'https')).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
This PR removes the hardcoded port 3000 for the webserver.

Fixes #553 

## How to test
Try the thing in #553 and observe that it reaches the webserver.

Also open the AWS console and observe the ports are set to the ones selected in barcelona.yml.