### PR TITLE
Remove CPU defaults for barcelona

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -271,7 +271,6 @@ class Heritage < ActiveRecord::Base
   def base_task_definition(task_name, with_environment: true)
     base = district.base_task_definition.merge(
       name: task_name,
-      cpu: 256,
       memory: 256,
       essential: true,
       image: image_path,

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -118,7 +118,6 @@ class HeritageTaskDefinition
     base[:docker_labels] = @app_container_labels if @app_container_labels.present?
 
     base = base.merge(
-      cpu: cpu,
       memory: memory,
       volumes_from: [
         {
@@ -127,6 +126,7 @@ class HeritageTaskDefinition
         }
       ]
     ).compact
+    base[:cpu] = cpu if cpu.present?
     base[:command] = LaunchCommand.new(heritage, command).to_command if command.present?
     base[:port_mappings] = port_mappings.to_task_definition if port_mappings.present?
     base[:user] = user if user.present?

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,7 +12,7 @@ class Service < ActiveRecord::Base
             presence: true,
             uniqueness: {scope: :heritage_id},
             format: { with: /\A[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]\z/ }
-  validates :cpu, numericality: {greater_than: 0}
+  validates :cpu, numericality: {greater_than: 0}, allow_nil: true
   validates :memory, numericality: {greater_than: 0}
   validates :service_type, inclusion: { in: %w(default web) }
   validates :name, :service_type, :public, immutable: true
@@ -24,7 +24,6 @@ class Service < ActiveRecord::Base
   accepts_nested_attributes_for :listeners, allow_destroy: true
 
   after_initialize do |service|
-    service.cpu ||= 256
     service.memory ||= 512
     service.reverse_proxy_image ||= DEFAULT_REVERSE_PROXY
     service.service_type ||= 'default'

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -81,7 +81,7 @@ describe BuildHeritage do
 
       service2 = heritage.services.second
       expect(service2.name).to eq "worker"
-      expect(service2.cpu).to eq 256
+      expect(service2.cpu).to be_nil
       expect(service2.memory).to eq 512
       expect(service2.command).to eq "rake jobs:work"
       expect(service2.port_mappings.count).to eq 0
@@ -124,7 +124,7 @@ describe BuildHeritage do
 
         service2 = @updated_heritage.services.second
         expect(service2.name).to eq "worker"
-        expect(service2.cpu).to eq 256
+        expect(service2.cpu).to be_nil
         expect(service2.memory).to eq 512
         expect(service2.command).to eq "rake jobs:offwork"
         expect(service2.port_mappings.count).to eq 0
@@ -159,7 +159,7 @@ describe BuildHeritage do
 
         service2 = @updated_heritage.services.second
         expect(service2.name).to eq "worker"
-        expect(service2.cpu).to eq 256
+        expect(service2.cpu).to be_nil
         expect(service2.memory).to eq 512
         expect(service2.command).to eq "rake jobs:offwork"
         expect(service2.port_mappings.count).to eq 0
@@ -217,7 +217,7 @@ describe BuildHeritage do
 
         service2 = @updated_heritage.services.second
         expect(service2.name).to eq "worker"
-        expect(service2.cpu).to eq 256
+        expect(service2.cpu).to be_nil
         expect(service2.memory).to eq 512
         expect(service2.command).to eq "rake jobs:work"
         expect(service2.port_mappings.count).to eq 0


### PR DESCRIPTION
# Context

This removes the default of 256 cpu units when CPU is not specified during the creation of a heritage. The issue linked (#558) describes a value of 512 which was a default that was specified by the barcelona cli. This PR removes the server's default to omit mentioning it if it is not set in b arcelona.yml.

Fixes #558 