### PR TITLE
Fix CPU not defaulting to nil when erasing the member from barcelona.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_script:
 - psql -c 'create database travis_ci_test;' -U postgres
 script:
 - set -e
-- bundle exec rake db:setup spec
+- bundle exec rake db:setup
+- rspec
 - bcnd
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 script:
 - set -e
 - bundle exec rake db:setup
-- rspec
+- bundle exec rspec
 - bcnd
 notifications:
   slack:

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -91,8 +91,8 @@ class BuildHeritage
 
   def execute
     heritage.district = district if district.present?
-    heritage.attributes = prenullify_params
-    heritage.attributes = params
+    heritage.assign_attributes prenullify_params
+    heritage.assign_attributes params
     heritage
   end
 end

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -77,6 +77,9 @@ class BuildHeritage
     [:cpu]
   end
 
+  # This method sets fields defined in #nullables to nil before applying
+  # updates to them, so that any deletions in barcelona.yml are detected
+  # properly.
   def prenullify_params
     nullifiers = []
     heritage.services.each do |service|

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -34,9 +34,10 @@ class BuildHeritage
       new_params[:environments_attributes] = new_params.delete(:environment).map do |e|
         e.slice(:name, :value, :value_from, :ssm_path)
       end
-      new_params[:environments_attributes] = sync_resources(new_params[:environments_attributes], heritage.environments, :name)
+      new_params[:environments_attributes] = sync_resources(
+        new_params[:environments_attributes], heritage.environments, :name
+      )
     end
-
 
     unless heritage.new_record?
       new_params.delete :name
@@ -57,22 +58,40 @@ class BuildHeritage
     new_params
   end
 
-  def sync_resources(attributes, resources, key_key)
-    resource_map = resources.pluck(key_key, :id).to_h
+  def sync_resources(attributes, curr_attributes, resource_key)
+    attr_map = curr_attributes.pluck(resource_key, :id).to_h
     attributes ||= []
+
     attributes.each do |attr|
-      attr[:id] = resource_map[attr[key_key]] if resource_map[attr[key_key]].present?
+      attr[:id] = attr_map[attr[resource_key]] if attr_map[attr[resource_key]].present?
     end
 
-    resources_to_delete = resource_map.keys - attributes.map { |attr| attr[key_key] }
+    resources_to_delete = attr_map.keys - attributes.map { |attr| attr[resource_key] }
     resources_to_delete.each do |k|
-      attributes << {id: resource_map[k], _destroy: '1'}
+      attributes << {id: attr_map[k], _destroy: '1'}
     end
     attributes
   end
 
+  def nullables
+    [:cpu]
+  end
+
+  def prenullify_params
+    nullifiers = []
+    heritage.services.each do |service|
+      nuller_hash = {}
+      nullables.each do |nullable|
+        nuller_hash[nullable] = nil
+      end
+      nullifiers << { id: service.id, **nuller_hash }
+    end
+    {"services_attributes" => nullifiers}
+  end
+
   def execute
     heritage.district = district if district.present?
+    heritage.attributes = prenullify_params
     heritage.attributes = params
     heritage
   end

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -231,7 +231,7 @@ describe BuildHeritage do
     context "changing endpoints" do
       let(:endpoint2) { district.endpoints.create!(name: "load-balancer2") }
       before do
-        new_params = params.dup
+        new_params = params.deep_dup
         new_params[:services][0][:listeners][0] = {endpoint: endpoint2.name}
         @updated_heritage = BuildHeritage.new(new_params).execute
         @updated_heritage.save!

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -237,7 +237,7 @@ describe BuildHeritage do
         @updated_heritage.save!
       end
 
-      it "updates listners" do
+      it "updates listeners" do
         service1 = @updated_heritage.services.first
         expect(service1).to be_present
         expect(service1.listeners.count).to eq 1

--- a/spec/services/build_heritage_spec.rb
+++ b/spec/services/build_heritage_spec.rb
@@ -204,23 +204,21 @@ describe BuildHeritage do
       it "adds a service" do
         expect(@updated_heritage.services.count).to eq 3
 
-        service1 = @updated_heritage.services.first
-        expect(service1.id).to be_present
-        expect(service1.name).to eq "web"
-        expect(service1.cpu).to eq 128
-        expect(service1.memory).to eq 128
-        expect(service1.command).to eq "rails s"
-        expect(service1.public).to eq true
-        expect(service1.port_mappings.count).to eq 1
-        expect(service1.port_mappings.first.lb_port).to eq 80
-        expect(service1.port_mappings.first.container_port).to eq 3000
+        webservice = @updated_heritage.services.find_by(name: 'web')
+        expect(webservice.id).to be_present
+        expect(webservice.cpu).to eq 128
+        expect(webservice.memory).to eq 128
+        expect(webservice.command).to eq "rails s"
+        expect(webservice.public).to eq true
+        expect(webservice.port_mappings.count).to eq 1
+        expect(webservice.port_mappings.first.lb_port).to eq 80
+        expect(webservice.port_mappings.first.container_port).to eq 3000
 
-        service2 = @updated_heritage.services.second
-        expect(service2.name).to eq "worker"
-        expect(service2.cpu).to be_nil
-        expect(service2.memory).to eq 512
-        expect(service2.command).to eq "rake jobs:work"
-        expect(service2.port_mappings.count).to eq 0
+        workerservice = @updated_heritage.services.find_by(name: 'worker')
+        expect(workerservice.cpu).to be_nil
+        expect(workerservice.memory).to eq 512
+        expect(workerservice.command).to eq "rake jobs:work"
+        expect(workerservice.port_mappings.count).to eq 0
 
         service3 = @updated_heritage.services.third
         expect(service3.name).to eq "another-service"
@@ -231,19 +229,19 @@ describe BuildHeritage do
     context "changing endpoints" do
       let(:endpoint2) { district.endpoints.create!(name: "load-balancer2") }
       before do
-        new_params = params.deep_dup
+        new_params = params.dup
         new_params[:services][0][:listeners][0] = {endpoint: endpoint2.name}
         @updated_heritage = BuildHeritage.new(new_params).execute
         @updated_heritage.save!
       end
 
       it "updates listeners" do
-        service1 = @updated_heritage.services.first
-        expect(service1).to be_present
-        expect(service1.listeners.count).to eq 1
-        expect(service1.listeners.first.health_check_interval).to eq 10
-        expect(service1.listeners.first.health_check_path).to eq "/"
-        expect(service1.listeners.first.endpoint.name).to eq endpoint2.name
+        webservice = @updated_heritage.services.find_by(name: 'web')
+        expect(webservice).to be_present
+        expect(webservice.listeners.count).to eq 1
+        expect(webservice.listeners.first.health_check_interval).to eq 10
+        expect(webservice.listeners.first.health_check_path).to eq "/"
+        expect(webservice.listeners.first.endpoint.name).to eq endpoint2.name
       end
     end
 


### PR DESCRIPTION
# Context

As in the ticket, this PR fixes CPU not being set to nil when removed from `barcelona.yml`.

Fixes #563 

This change may be controversial as the original specs mandated that a PATCH only changes attributes that were mentioned. This change breaks that behavior for the `service.cpu` attribute specifically by setting it to `nil` when it is not mentioned.

This is possibly a case of use-case does not match specification. The current normal use-case is to have a `barcelona.yml` read in by `barcelona-cli` and sent to `barcelona` using a PATCH method.

This way of fixing this is admittedly hacky. An alternate solution, that I just thought of while writing this post was to make it so we have a `replace` action that maps to the PUT method that basically always takes a fully-formed definition instead of a partial one  that we illustrate in our tests.