### PR TITLE
Make all one-off tasks set lang to UTF8

### DIFF
--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -34,7 +34,7 @@ class Oneoff < ActiveRecord::Base
             # Ideally Barcelona should not override LANG but because all official docker images
             # doesn't set LANG as UTF8 we can't use multi byte characters in
             # the interactive session without this override
-            environment: interactive ? [{name: "LANG", value: "C.UTF-8"}] : []
+            environment: [{name: "LANG", value: "C.UTF-8"}]
           }
         ]
       }


### PR DESCRIPTION
# Context

This PR makes it so `LANG=C.UTF-8` is set for all one-off tasks, not just `interactive: true`. I'm not actually sure if this is safe, I think it is, but please let me know if you are depending on LANG not being set.

Fixes #568 