### PR TITLE
Add params to add env vars to oneoff tasks

### DIFF
--- a/app/controllers/oneoffs_controller.rb
+++ b/app/controllers/oneoffs_controller.rb
@@ -9,7 +9,10 @@ class OneoffsController < ApplicationController
   def create
     interactive = !!params[:interactive]
     @oneoff = @heritage.oneoffs.create!(create_params)
-    @oneoff.run!(sync: !!params[:sync], interactive: interactive, started_by: "barcelona/#{current_user.name}")
+    @oneoff.run!(sync: !!params[:sync],
+                 interactive: interactive,
+                 started_by: "barcelona/#{current_user.name}",
+                 env_vars: env_var_params)
     json = if interactive
              certificate = @heritage.district.ca_sign_public_key(
                current_user,
@@ -32,6 +35,23 @@ class OneoffsController < ApplicationController
       :memory,
       :user
     )
+  end
+
+  def env_var_params
+    return {} if params[:env_vars].nil?
+
+    raise ExceptionHandler::BadRequest.new("env_vars should be a hash") unless params[:env_vars].is_a? ActionController::Parameters
+
+    params[:env_vars].each do |key, value|
+      if !key.is_a? String
+        raise ExceptionHandler::BadRequest.new("Keys in env_vars should be strings")
+      end
+      if !value.is_a? String
+        raise ExceptionHandler::BadRequest.new("Values in env_vars should be strings")
+      end
+    end
+
+    params[:env_vars].permit(params[:env_vars].keys)
   end
 
   def load_heritage

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -27,8 +27,7 @@ class Oneoff < ActiveRecord::Base
     definition = HeritageTaskDefinition.oneoff_definition(self)
     aws.ecs.register_task_definition(definition.to_task_definition)
 
-    vars = {}
-    vars = { "LANG" => "C.UTF-8" } if interactive
+    vars = { "LANG" => "C.UTF-8" }
     vars = vars.merge(env_vars)
 
     resp = aws.ecs.run_task(

--- a/app/models/oneoff.rb
+++ b/app/models/oneoff.rb
@@ -16,12 +16,21 @@ class Oneoff < ActiveRecord::Base
   class ECSResourceError < RuntimeError
   end
 
-  def run(sync: false, interactive: false, started_by: "barcelona")
+  def env_var_arrayize(env_vars)
+    env_vars.map { |k, v| {name: k, value: v} }
+  end
+
+  def run(sync: false, interactive: false, started_by: "barcelona", env_vars: {})
     raise ArgumentError if sync && interactive
 
     self.session_token = SecureRandom.uuid if interactive
     definition = HeritageTaskDefinition.oneoff_definition(self)
     aws.ecs.register_task_definition(definition.to_task_definition)
+
+    vars = {}
+    vars = { "LANG" => "C.UTF-8" } if interactive
+    vars = vars.merge(env_vars)
+
     resp = aws.ecs.run_task(
       cluster: district.name,
       task_definition: definition.family_name,
@@ -34,7 +43,7 @@ class Oneoff < ActiveRecord::Base
             # Ideally Barcelona should not override LANG but because all official docker images
             # doesn't set LANG as UTF8 we can't use multi byte characters in
             # the interactive session without this override
-            environment: [{name: "LANG", value: "C.UTF-8"}]
+            environment: env_var_arrayize(vars)
           }
         ]
       }

--- a/spec/models/oneoff_spec.rb
+++ b/spec/models/oneoff_spec.rb
@@ -93,5 +93,29 @@ describe Oneoff do
                             ).and_return(describe_tasks_response_mock)
       oneoff.run(interactive: false)
     end
+
+    it 'uses env_var_arrayize to define environment' do
+      allow(oneoff).to receive(:env_var_arrayize) { [{name: 'BAR', value: 'foo' }] }
+      expect(ecs_mock).to receive(:run_task).with(hash_including(
+        overrides: hash_including(
+          container_overrides: [
+            hash_including(environment: [{name: 'BAR', value: 'foo' }])
+          ]
+        )
+      )).and_return(describe_tasks_response_mock)
+      oneoff.run
+    end
+  end
+
+  describe '#env_var_arrayize' do
+    it 'arrayizes a hash' do
+      result = oneoff.env_var_arrayize( "FOO" => "bar" )
+      expect(result).to eq [{ name: 'FOO', value: 'bar' }]
+    end
+
+    it 'arrayizes a hash with multiple entries' do
+      result = oneoff.env_var_arrayize( "FOO" => "bar", 'HELLO' => 'meow' )
+      expect(result).to eq [{ name: 'FOO', value: 'bar' }, { name: 'HELLO', value: 'meow' }]
+    end
   end
 end

--- a/spec/requests/create_oneoff_spec.rb
+++ b/spec/requests/create_oneoff_spec.rb
@@ -53,13 +53,10 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
 
     before do
       allow_any_instance_of(District).to receive(:get_ca_key) { ca_key_pair.to_pem }
+      allow_any_instance_of(Aws::ECS::Client).to receive(:run_task) { run_task_response_mock }
     end
 
     it "creates a interactive oneoff task" do
-      expect_any_instance_of(Aws::ECS::Client).to receive(:run_task) do
-        run_task_response_mock
-      end
-
       params = {
         interactive: true,
         command: "rake db:migrate"
@@ -74,6 +71,58 @@ describe "POST /heritages/:heritage/oneoffs", type: :request do
       expect(resp["oneoff"]["command"]).to eq "rake db:migrate"
       expect(resp["oneoff"]["interactive_run_command"]).to be_a String
       expect(resp["certificate"]).to be_a String
+    end
+
+    context ':env_vars param' do
+      it 'creates a task if the env_vars param is a proper hash' do
+        params = {
+          interactive: true,
+          command: "rake db:migrate",
+          env_vars: {
+            "FOO" => "bar"
+          }
+        }
+
+        api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
+        expect(response).to be_successful
+      end
+
+      it 'throws a 400 if the env_vars param is not a hash' do
+        params = {
+          interactive: true,
+          command: "rake db:migrate",
+          env_vars: "invalidness"
+        }
+
+        api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
+        expect(response).to be_a_bad_request
+      end
+
+      it 'throws a 400 if the env_vars param is a hash that contains hashes' do
+        params = {
+          interactive: true,
+          command: "rake db:migrate",
+          env_vars: {
+            "FOO": {
+              "bar" => "baz"
+            }
+          }
+        }
+
+        api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
+        expect(response).to be_a_bad_request
+      end
+
+      it 'throws a 400 if the env_var param is weird' do
+        params = {
+          interactive: true,
+          command: "rake db:migrate",
+          env_vars: 1231
+        }
+
+        api_request :post, "/v1/heritages/#{heritage.name}/oneoffs", params
+        expect(response).to be_a_bad_request
+      end
     end
   end
 end


### PR DESCRIPTION
# Context

This PR adds a parameter to the one-off tasks endpoint to allow running one-off tasks with specific environment variables.

Fixes https://github.com/degica/barcelona-cli/issues/14

You need the new barcelona cli available here: https://github.com/degica/barcelona-cli/releases/tag/0.9.3

# How to test
<version of bcn cli>

1. Pull https://github.com/degica/barcelona-hello
2. Deploy the heritage
3. Try and run `bcn run -e hello -E FOO=bz bash`
4. Run `echo $FOO` and observe that it outputs `bz`