### PR TITLE
update datadog plugin

### DIFF
--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -12,20 +12,25 @@ module Barcelona
       private
 
       def agent_command
-        ["docker", "run", "-d",
-         "--name", "dd-agent",
+        ["DOCKER_CONTENT_TRUST=1",
+         "docker", "run", "-d",
+         "--name", "datadog-agent",
          "-h", "`hostname`",
-         "-v", "/var/run/docker.sock:/var/run/docker.sock",
+         "-v", "/var/run/docker.sock:/var/run/docker.sock:ro",
          "-v", "/proc/:/host/proc/:ro",
          "-v", "/cgroup/:/host/sys/fs/cgroup:ro",
+         "-v", "/opt/datadog-agent/run:/opt/datadog-agent/run:rw",
          "-e", "API_KEY=#{api_key}",
-         tags,
-         "datadog/docker-dd-agent:latest"
+         "-e", "DD_LOGS_ENABLED=true",
+         "-e", "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true",
+         "-e", "DD_AC_EXCLUDE=name:datadog-agent",
+         *tags,
+         "datadog/agent:latest"
         ].flatten.compact.join(" ")
       end
 
       def tags
-        "-e TAGS=\"barcelona,barcelona-dd-agent,district:#{district.name}\""
+        ["-e", %Q{TAGS="barcelona,barcelona-dd-agent,district:#{district.name}"}]
       end
 
       def api_key

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -20,7 +20,7 @@ module Barcelona
          "-v", "/proc/:/host/proc/:ro",
          "-v", "/cgroup/:/host/sys/fs/cgroup:ro",
          "-v", "/opt/datadog-agent/run:/opt/datadog-agent/run:rw",
-         "-e", "API_KEY=#{api_key}",
+         "-e", "DD_API_KEY=#{api_key}",
          "-e", "DD_LOGS_ENABLED=true",
          "-e", "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true",
          "-e", "DD_AC_EXCLUDE=name:datadog-agent",

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -30,7 +30,7 @@ module Barcelona
       end
 
       def tags
-        ["-e", %Q{TAGS="barcelona,barcelona-dd-agent,district:#{district.name}"}]
+        ["-e", %Q{DD_TAGS="barcelona,barcelona-dd-agent,district:#{district.name}"}]
       end
 
       def api_key

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -18,7 +18,7 @@ module Barcelona
         it "gets hooked with container_instance_user_data trigger" do
           ci = ContainerInstance.new(district)
           user_data = YAML.load(Base64.decode64(ci.user_data.build))
-          expect(user_data["runcmd"].last).to eq "docker run -d --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e API_KEY=abcdef -e TAGS=\"barcelona,barcelona-dd-agent,district:#{district.name}\" datadog/docker-dd-agent:latest"
+          expect(user_data["runcmd"].last).to eq "DOCKER_CONTENT_TRUST=1 docker run -d --name datadog-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -e DD_API_KEY=abcdef -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e DD_AC_EXCLUDE=name:datadog-agent -e TAGS=\"barcelona,barcelona-dd-agent,district:district8\" datadog/agent:latest"
         end
       end
     end

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -18,7 +18,7 @@ module Barcelona
         it "gets hooked with container_instance_user_data trigger" do
           ci = ContainerInstance.new(district)
           user_data = YAML.load(Base64.decode64(ci.user_data.build))
-          expect(user_data["runcmd"].last).to eq "DOCKER_CONTENT_TRUST=1 docker run -d --name datadog-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -e DD_API_KEY=abcdef -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e DD_AC_EXCLUDE=name:datadog-agent -e TAGS=\"barcelona,barcelona-dd-agent,district:district8\" datadog/agent:latest"
+          expect(user_data["runcmd"].last).to eq "DOCKER_CONTENT_TRUST=1 docker run -d --name datadog-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -e DD_API_KEY=abcdef -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e DD_AC_EXCLUDE=name:datadog-agent -e DD_TAGS=\"barcelona,barcelona-dd-agent,district:district8\" datadog/agent:latest"
         end
       end
     end


### PR DESCRIPTION
## Context

This PR fixes up the datadog agent to make it compatible with the latest version of its agent.

Fixes #571 

## How to test
You can create a free trial account with datadog to test this. They will provide you with an API key when you select the docker integration
1. Start up a barcelona district, or if you already have a test one just use that
2. Run `bcn district put-plugin --apply -a api_key=<apikey> <districtname> datadog`
3. Go to aws to your district and apply the changeset that was created (see #572 )
4. Apply the changeset
5. Go to datadog after 5 mins and check that metrics of your containers are coming in