### PR TITLE
Upgrade postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,11 @@ services:
       - bundle:/usr/local/bundle
       - .:${PWD}
   db:
-    image: postgres:9.5
+    image: postgres:11
     environment:
       PGDATA: /data
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
     healthcheck:
       test: echo "\\l" | psql -U postgres
     volumes:


### PR DESCRIPTION
This upgrades PostgreSQL on development environment .

PostgreSQL11 requires `POSTGRES_HOST_AUTH_METHOD: trust` for password less connection.

If you want to upgrade local development db, run the following commands.

In postgresql9.4
```
$ docker-compose run --rm web bash
$ apt-get update && apt-get install -y postgresql-client
$ pg_dumb -h db -U postgres bcn_development -f bcn_development.sql
```

In postgresql11
```
$ docker volume rm barcelona_bundle barcelona_pgdata
$ make setup
$ docker-compose run --rm web bash
$ psql -h db -U postgres bcn_development -f bcn_development.sql
$ exit
$ make up
$ bcn district list # check it running
$ bcn api get /districts
```


