### PR TITLE
Update AMIs for ecs instances and bastion instances to 2.0.20200402

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-056807e883f197989",
-        "us-east-2"      => "ami-0b421c31dd21d6534",
-        "us-west-1"      => "ami-06cc2443be89d1439",
-        "us-west-2"      => "ami-05a2f3dd8f21fa9f7",
-        "eu-west-1"      => "ami-09270d80acf4d09ca",
-        "eu-west-2"      => "ami-0d44f4b892bde0a73",
-        "eu-west-3"      => "ami-031576df8aaa03c17",
-        "eu-central-1"      => "ami-0bfdae54e0eda93f2",
-        "ap-northeast-1"      => "ami-09ab4b51b72020b66",
-        "ap-northeast-2"      => "ami-0d93e3afc32b4e41a",
-        "ap-southeast-1"      => "ami-04f3eb384ebc387b3",
-        "ap-southeast-2"      => "ami-05c621ca32de56e7a",
-        "ca-central-1"      => "ami-033fdf08e595bc7c8",
-        "ap-south-1"      => "ami-0484b39dd56f70080",
-        "sa-east-1"      => "ami-0eafc21e33e768494",
+        "us-east-1"      => "ami-09edd32d9b0990d49",
+        "us-east-2"      => "ami-008c5ba1857e0fdec",
+        "us-west-1"      => "ami-02649d71054b25d22",
+        "us-west-2"      => "ami-023578bcb54b36edf",
+        "eu-west-1"      => "ami-09266271a2521d06f",
+        "eu-west-2"      => "ami-066f0ae194916c572",
+        "eu-west-3"      => "ami-02840369a939ae502",
+        "eu-central-1"      => "ami-0e9347664c1c5ed65",
+        "ap-northeast-1"      => "ami-032b1a02e6610214e",
+        "ap-northeast-2"      => "ami-062022418ff822030",
+        "ap-southeast-1"      => "ami-0fa00d20cc2fa3c81",
+        "ap-southeast-2"      => "ami-064db566f79006111",
+        "ca-central-1"      => "ami-05e77f4fec44e91f3",
+        "ap-south-1"      => "ami-0d0e74761b4cc8a53",
+        "sa-east-1"      => "ami-0cbe40dd412e5ef32",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0a887e401f7654935",
-        "us-east-2"      => "ami-0e38b48473ea57778",
-        "us-west-1"      => "ami-01c94064639c71719",
-        "us-west-2"      => "ami-0e8c04af2729ff1bb",
-        "eu-west-1"      => "ami-099a8245f5daa82bf",
-        "eu-west-2"      => "ami-0389b2a3c4948b1a0",
-        "eu-west-3"      => "ami-0fd9bce3a3384b635",
-        "eu-central-1"      => "ami-0df0e7600ad0913a9",
-        "ap-northeast-1"      => "ami-0af1df87db7b650f4",
-        "ap-northeast-2"      => "ami-0a93a08544874b3b7",
-        "ap-southeast-1"      => "ami-0f02b24005e4aec36",
-        "ap-southeast-2"      => "ami-0f767afb799f45102",
-        "ca-central-1"      => "ami-00db12b46ef5ebc36",
-        "ap-south-1"      => "ami-0d9462a653c34dab7",
-        "sa-east-1"      => "ami-080a223be3de0c3b8",
+        "us-east-1"      => "ami-0323c3dd2da7fb37d",
+        "us-east-2"      => "ami-0f7919c33c90f5b58",
+        "us-west-1"      => "ami-06fcc1f0bc2c8943f",
+        "us-west-2"      => "ami-0d6621c01e8c2de2c",
+        "eu-west-1"      => "ami-06ce3edf0cff21f07",
+        "eu-west-2"      => "ami-01a6e31ac994bbc09",
+        "eu-west-3"      => "ami-00077e3fed5089981",
+        "eu-central-1"      => "ami-076431be05aaf8080",
+        "ap-northeast-1"      => "ami-0f310fced6141e627",
+        "ap-northeast-2"      => "ami-01288945bd24ed49a",
+        "ap-southeast-1"      => "ami-0ec225b5e01ccb706",
+        "ap-southeast-2"      => "ami-0970010f37c4f9c8d",
+        "ca-central-1"      => "ami-054362537f5132ce2",
+        "ap-south-1"      => "ami-0470e33cd681b2476",
+        "sa-east-1"      => "ami-003449ffb2605a74c",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
