### PR TITLE
Rsyslog datadog

### DIFF
--- a/lib/barcelona/plugins/datadog_logs_plugin.rb
+++ b/lib/barcelona/plugins/datadog_logs_plugin.rb
@@ -1,0 +1,73 @@
+module Barcelona
+  module Plugins
+    class DatadogLogsPlugin < Base
+      LOCAL_LOGGER_PORT = 514
+      SYSTEM_PACKAGES = %w[rsyslog-gnutls ca-certificates]
+      RUN_COMMANDS = [
+        "service rsyslog restart"
+      ]
+
+      def on_container_instance_user_data(_instance, user_data)
+        update_user_data(user_data, "ci") # ci stands for Container Instance
+        user_data
+      end
+
+      def on_heritage_task_definition(_heritage, task_definition)
+        task_definition.merge(
+          log_configuration: {
+            log_driver: "syslog",
+            options: {
+              "syslog-address" => "tcp://127.0.0.1:#{LOCAL_LOGGER_PORT}",
+              "tag" => task_definition[:name]
+            }
+          }
+        )
+      end
+
+      def on_network_stack_template(_stack, template)
+        bastion_lc = template["BastionLaunchConfiguration"]
+        return template if bastion_lc.nil?
+
+        user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
+        update_user_data(user_data, "bastion")
+        bastion_lc["Properties"]["UserData"] = user_data.build
+        template
+      end
+
+      private
+
+      def rsyslog_conf(role)
+        <<~CONF
+          $ModLoad imtcp
+          $InputTCPServerRun #{LOCAL_LOGGER_PORT}
+
+          ## Set the Datadog Format to send the logs
+          $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+
+          ## Define the destination for the logs
+
+          $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
+          $ActionSendStreamDriver gtls
+          $ActionSendStreamDriverMode 1
+          $ActionSendStreamDriverAuthMode x509/name
+          $ActionSendStreamDriverPermittedPeer *.logs.datadoghq.com
+          *.* @@intake.logs.datadoghq.com:10516;DatadogFormat
+
+          ## Keep connections alive
+          $ModLoad immark
+          $MarkMessagePeriod 20
+        CONF
+      end
+
+      def update_user_data(user_data, role)
+        user_data.packages += SYSTEM_PACKAGES
+        user_data.add_file("/etc/rsyslog.d/datadog.conf", "root:root", "644", rsyslog_conf(role))
+        user_data.run_commands += RUN_COMMANDS
+      end
+
+      def token
+        model.plugin_attributes["token"]
+      end
+    end
+  end
+end

--- a/lib/barcelona/plugins/datadog_logs_plugin.rb
+++ b/lib/barcelona/plugins/datadog_logs_plugin.rb
@@ -42,11 +42,11 @@ module Barcelona
           $InputTCPServerRun #{LOCAL_LOGGER_PORT}
 
           ## Set the Datadog Format to send the logs
-          $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\"<MY_SOURCE_NAME>\" ddtags=\"env:dev,<KEY:VALUE>\"] %msg%\n"
+          $template DatadogFormat,"#{api_key} <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\\"host\\" ddtags=\\"barcelona,barcelona-dd-agent,district:#{district.name},barcelona:#{district.name}\\"] %msg%\\n"
 
           ## Define the destination for the logs
 
-          $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-certificates.crt
+          $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-bundle.crt
           $ActionSendStreamDriver gtls
           $ActionSendStreamDriverMode 1
           $ActionSendStreamDriverAuthMode x509/name
@@ -67,6 +67,10 @@ module Barcelona
 
       def token
         model.plugin_attributes["token"]
+      end
+
+      def api_key
+        attributes["api_key"]
       end
     end
   end

--- a/lib/barcelona/plugins/datadog_logs_plugin.rb
+++ b/lib/barcelona/plugins/datadog_logs_plugin.rb
@@ -4,6 +4,7 @@ module Barcelona
       LOCAL_LOGGER_PORT = 514
       SYSTEM_PACKAGES = %w[rsyslog-gnutls ca-certificates]
       RUN_COMMANDS = [
+        'sed "s/%HOSTNAME%/`curl http://169.254.169.254/latest/meta-data/instance-id`/g" /etc/rsyslog.d/datadog.conf',
         "service rsyslog restart"
       ]
 
@@ -42,7 +43,7 @@ module Barcelona
           $InputTCPServerRun #{LOCAL_LOGGER_PORT}
 
           ## Set the Datadog Format to send the logs
-          $template DatadogFormat,"#{api_key} <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\\"host\\" ddtags=\\"barcelona,barcelona-dd-agent,district:#{district.name},barcelona:#{district.name}\\"] %msg%\\n"
+          $template DatadogFormat,"#{api_key} <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - [metas ddsource=\\"rsyslog\\" ddtags=\\"barcelona,barcelona-dd-agent,district:#{district.name},barcelona:#{district.name}\\"] %msg%\\n"
 
           ## Define the destination for the logs
 

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -22,8 +22,7 @@ module Barcelona
          "-v", "/opt/datadog-agent/run:/opt/datadog-agent/run:rw",
          "-e", "DD_API_KEY=#{api_key}",
          "-e", "DD_LOGS_ENABLED=true",
-         "-e", "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true",
-         "-e", "DD_AC_EXCLUDE=name:datadog-agent",
+         "-e", "DD_AC_INCLUDE='name:ecs-agent name:datadog-agent'",
          *tags,
          "datadog/agent:latest"
         ].flatten.compact.join(" ")

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -43,7 +43,7 @@ module Barcelona
             - barcelona:#{district.name}
             - barcelona-dd-agent
             - district:#{district.name}
-            - role:#{district.name}
+            - role:app
         DATADOG_YAML
 
         user_data.add_file("/etc/datadog-agent/conf.d/docker.d/docker_daemon.yaml", "root:root", "000755", <<~YAML)

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -2,6 +2,7 @@ module Barcelona
   module Plugins
     class DatadogPlugin < Base
       def on_container_instance_user_data(_instance, user_data)
+        add_files!(user_data)
         user_data.run_commands += [
           agent_command
         ]
@@ -12,28 +13,50 @@ module Barcelona
       private
 
       def agent_command
-        ["DOCKER_CONTENT_TRUST=1",
-         "docker", "run", "-d",
-         "--name", "datadog-agent",
-         "-h", "`hostname`",
-         "-v", "/var/run/docker.sock:/var/run/docker.sock:ro",
-         "-v", "/proc/:/host/proc/:ro",
-         "-v", "/cgroup/:/host/sys/fs/cgroup:ro",
-         "-v", "/opt/datadog-agent/run:/opt/datadog-agent/run:rw",
-         "-e", "DD_API_KEY=#{api_key}",
-         "-e", "DD_LOGS_ENABLED=true",
-         "-e", "DD_AC_INCLUDE='name:ecs-agent name:datadog-agent'",
-         *tags,
-         "datadog/agent:latest"
+        [
+          "DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=#{api_key} bash -c",
+          '"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)" &&',
+          'usermod -a -G docker dd-agent &&',
+          'usermod -a -G systemd-journal dd-agent &&',
+          'systemctl restart datadog-agent'
         ].flatten.compact.join(" ")
-      end
-
-      def tags
-        ["-e", %Q{DD_TAGS="barcelona,barcelona-dd-agent,district:#{district.name}"}]
       end
 
       def api_key
         attributes["api_key"]
+      end
+
+      def add_files!(user_data)
+        user_data.add_file("/etc/datadog-agent/datadog.yaml", "root:root", "000755", <<~DATADOG_YAML)
+          api_key: #{api_key}
+          logs_enabled: true
+          listeners:
+            - name: docker
+          config_providers:
+            - name: docker
+              polling: true
+          logs_config:
+            container_collect_all: true
+          process_config:
+            enabled: 'true'
+          tags:
+            - barcelona:#{district.name}
+            - barcelona-dd-agent
+            - district:#{district.name}
+            - role:#{district.name}
+        DATADOG_YAML
+
+        user_data.add_file("/etc/datadog-agent/conf.d/docker.d/docker_daemon.yaml", "root:root", "000755", <<~YAML)
+          init_config:
+          instances:
+            - url: "unix://var/run/docker.sock"
+              new_tag_names: true
+        YAML
+
+        user_data.add_file("/etc/datadog-agent/conf.d/journal.d/conf.yaml", "root:root", "000755", <<~YAML)
+          logs:
+            - type: journald
+        YAML
       end
     end
   end

--- a/lib/barcelona/plugins/logentries_plugin.rb
+++ b/lib/barcelona/plugins/logentries_plugin.rb
@@ -8,7 +8,7 @@ module Barcelona
       ]
 
       def on_container_instance_user_data(_instance, user_data)
-        update_user_data(user_data, "ci") # ci stands for Container Instance
+        update_user_data(user_data, "app")
         user_data
       end
 
@@ -18,7 +18,7 @@ module Barcelona
             log_driver: "syslog",
             options: {
               "syslog-address" => "tcp://127.0.0.1:#{LOCAL_LOGGER_PORT}",
-              "tag" => task_definition[:name]
+              "tag" => "{{.FullID}}_#{task_definition[:name]}"
             }
           }
         )

--- a/lib/barcelona/plugins/logentries_plugin.rb
+++ b/lib/barcelona/plugins/logentries_plugin.rb
@@ -37,19 +37,19 @@ module Barcelona
       private
 
       def rsyslog_conf(role)
-        <<EOS
-$ModLoad imtcp
-$InputTCPServerRun #{LOCAL_LOGGER_PORT}
+        <<~EOS
+          $ModLoad imtcp
+          $InputTCPServerRun #{LOCAL_LOGGER_PORT}
 
-$DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-bundle.crt
-$ActionSendStreamDriver gtls
-$ActionSendStreamDriverMode 1
-$ActionSendStreamDriverAuthMode x509/name
-$ActionSendStreamDriverPermittedPeer *.logentries.com
+          $DefaultNetstreamDriverCAFile /etc/ssl/certs/ca-bundle.crt
+          $ActionSendStreamDriver gtls
+          $ActionSendStreamDriverMode 1
+          $ActionSendStreamDriverAuthMode x509/name
+          $ActionSendStreamDriverPermittedPeer *.logentries.com
 
-$template LogentriesTemplate,"#{token} %syslogtag% role=#{role} hostname=%hostname% %msg:1:1024%\\n"
-*.* @@data.logentries.com:443;LogentriesTemplate
-EOS
+          $template LogentriesTemplate,"#{token} %syslogtag% role=#{role} hostname=%hostname% %msg:1:1024%\\n"
+          *.* @@data.logentries.com:443;LogentriesTemplate
+        EOS
       end
 
       def update_user_data(user_data, role)

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -18,7 +18,7 @@ module Barcelona
         it "gets hooked with container_instance_user_data trigger" do
           ci = ContainerInstance.new(district)
           user_data = YAML.load(Base64.decode64(ci.user_data.build))
-          expect(user_data["runcmd"].last).to eq "DOCKER_CONTENT_TRUST=1 docker run -d --name datadog-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /cgroup/:/host/sys/fs/cgroup:ro -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw -e DD_API_KEY=abcdef -e DD_LOGS_ENABLED=true -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true -e DD_AC_EXCLUDE=name:datadog-agent -e DD_TAGS=\"barcelona,barcelona-dd-agent,district:district8\" datadog/agent:latest"
+          expect(user_data["runcmd"].last).to eq "DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" && usermod -a -G docker dd-agent && usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
         end
       end
     end

--- a/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/logentries_plugin_spec.rb
@@ -25,7 +25,7 @@ module Barcelona
         expect(definition[:log_configuration]).to eq(log_driver: "syslog",
                                                      options: {
                                                        "syslog-address" => "tcp://127.0.0.1:514",
-                                                       "tag" => "heritage"
+                                                       "tag" => "{{.FullID}}_heritage"
                                                      })
       end
 


### PR DESCRIPTION
This PR introduces the datadog_logs plugin that is compatible with the logentries plugin, while keeping all the functionality of a datadog agent for log collection.

It also changes the datadog plugin to be a host-installed plugin, allowing it to take docker metrics and logs from the host.

In order to update your stack you must re-add all your existing plugins to your stack and re-deploy your application. No deletion neccessary.

## How to test
1. Deploy your district `bcn district create test`
2. Add the plugins
  - `bcn district put-plugin -a api_key=<apikey> test datadog_logs`
  - `bcn district put-plugin -a api_key=<apikey> test datadog`
  - `bcn district apply test`
3. Apply your changeset
4. Deploy or create your heritage `bcn create -e hello -d test`