### PR TITLE
Make web_container_port configurable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,4 +41,5 @@ group :test do
   gem 'stub_env'
   gem 'webmock'
   gem 'rack-test'
+  gem 'rspec-collection_matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,8 @@ GEM
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
+    rspec-collection_matchers (1.2.0)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -278,6 +280,7 @@ DEPENDENCIES
   pundit
   rack-test
   rails (~> 5.2)
+  rspec-collection_matchers
   rspec-its
   rspec-rails
   spring

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -85,6 +85,7 @@ class HeritagesController < ApplicationController
         :public,
         :service_type,
         :force_ssl,
+        :web_container_port,
         {
           port_mappings: [
             :lb_port,

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -13,7 +13,8 @@ class HeritageTaskDefinition
         force_ssl: service.force_ssl,
         hosts: service.hosts,
         reverse_proxy_image: service.reverse_proxy_image,
-        mode: (service.listeners.present?) ? :alb : :tcp
+        mode: (service.listeners.present?) ? :alb : :tcp,
+        web_container_port: service.web_container_port
        )
   end
 
@@ -73,7 +74,7 @@ class HeritageTaskDefinition
     end
   end
 
-  def initialize(heritage:, family_name:, user: nil, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil)
+  def initialize(heritage:, family_name:, user: nil, cpu:, memory:, command: nil, port_mappings: nil, is_web_service: false, force_ssl: false, hosts: [], app_container_labels: {}, reverse_proxy_image: nil, mode: nil, web_container_port: 3000)
     @heritage = heritage
     @family_name = family_name
     @user = user
@@ -87,6 +88,7 @@ class HeritageTaskDefinition
     @reverse_proxy_image = reverse_proxy_image
     @app_container_labels = app_container_labels
     @mode = mode
+    @web_container_port = web_container_port
   end
 
   def web_service?
@@ -94,7 +96,7 @@ class HeritageTaskDefinition
   end
 
   def web_container_port
-    3000
+    @web_container_port
   end
 
   def container_definition
@@ -118,6 +120,7 @@ class HeritageTaskDefinition
     base[:docker_labels] = @app_container_labels if @app_container_labels.present?
 
     base = base.merge(
+      cpu: cpu,
       memory: memory,
       volumes_from: [
         {
@@ -126,7 +129,6 @@ class HeritageTaskDefinition
         }
       ]
     ).compact
-    base[:cpu] = cpu if cpu.present?
     base[:command] = LaunchCommand.new(heritage, command).to_command if command.present?
     base[:port_mappings] = port_mappings.to_task_definition if port_mappings.present?
     base[:user] = user if user.present?

--- a/db/migrate/20200506082137_add_web_container_port_to_service.rb
+++ b/db/migrate/20200506082137_add_web_container_port_to_service.rb
@@ -1,0 +1,5 @@
+class AddWebContainerPortToService < ActiveRecord::Migration[5.2]
+  def change
+    add_column :services, :web_container_port, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_23_161003) do
+ActiveRecord::Schema.define(version: 2020_05_06_082137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(version: 2019_02_23_161003) do
     t.boolean "force_ssl"
     t.text "hosts"
     t.text "health_check"
+    t.integer "web_container_port"
     t.index ["heritage_id"], name: "index_services_on_heritage_id"
   end
 

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -150,6 +150,98 @@ describe HeritageTaskDefinition do
                               })
       end
     end
+    context "when a service is web service with non-default port" do
+      let(:service) { create :web_service, heritage: heritage, web_container_port: 6000 }
+      it "returns a task definition for the service" do
+        expect(subject).to eq({
+                                family: service.service_name,
+                                task_role_arn: "task-role",
+                                execution_role_arn: "task-execution-role",
+                                container_definitions: [
+                                  {
+                                    environment: [
+                                      {
+                                        name: "HOST_PORT_HTTP_6000",
+                                        value: service.http_port_mapping.host_port.to_s
+                                      },
+                                      {
+                                        name: "HOST_PORT_HTTPS_6000",
+                                        value: service.https_port_mapping.host_port.to_s
+                                      },
+                                      {
+                                        name: "PORT",
+                                        value: "6000"
+                                      }
+                                    ],
+                                    name: service.service_name,
+                                    cpu: service.cpu,
+                                    memory: service.memory,
+                                    essential: true,
+                                    image: heritage.image_path,
+                                    command: LaunchCommand.new(heritage, service.command).to_command,
+                                    volumes_from: [
+                                      {
+                                        source_container: "runpack",
+                                        read_only: true
+                                      }
+                                    ],
+                                    port_mappings: [
+                                      {container_port: 6000, protocol: "tcp"}
+                                    ],
+                                    log_configuration: expected_log_configuration
+                                  },
+                                  {
+                                    name: "runpack",
+                                    cpu: 1,
+                                    memory: 16,
+                                    essential: false,
+                                    image: "quay.io/degica/barcelona-run-pack",
+                                    environment: [],
+                                    log_configuration: expected_log_configuration
+                                  },
+                                  {
+                                    name: "#{service.service_name}-revpro",
+                                    cpu: 128,
+                                    memory: 128,
+                                    essential: true,
+                                    image: service.reverse_proxy_image,
+                                    links: ["#{service.service_name}:backend"],
+                                    environment: [
+                                      {
+                                        name: "AWS_REGION",
+                                        value: district.region,
+                                      },
+                                      {
+                                        name: "UPSTREAM_NAME",
+                                        value: "backend"
+                                      },
+                                      {
+                                        name: "UPSTREAM_PORT",
+                                        value: "6000"
+                                      },
+                                      {
+                                        name: "FORCE_SSL",
+                                        value: "false"
+                                      }
+                                    ],
+                                    port_mappings: [
+                                      {
+                                        container_port: 80,
+                                        host_port: service.http_port_mapping.host_port,
+                                        protocol: "tcp"
+                                      },
+                                      {
+                                        container_port: 443,
+                                        host_port: service.https_port_mapping.host_port,
+                                        protocol: "tcp"
+                                      }
+                                    ],
+                                    log_configuration: expected_log_configuration
+                                  }
+                                ]
+                              })
+      end
+    end
   end
 
   describe ".oneonff_definition" do

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -5,4 +5,62 @@ describe Service do
   let(:service) { create :web_service, heritage: heritage }
 
   it { expect{service.save}.to_not raise_error }
+
+  describe 'handling port mappings' do
+    context 'created with default port' do
+      before { service.save }
+      it 'should create http and https port mappings' do
+        expect(service.port_mappings).to have(2).items
+        http_mapping = service.port_mappings.find_by_lb_port(80)
+        expect(http_mapping.container_port).to eq(Service::WEB_CONTAINER_PORT_DEFAULT)
+        https_mapping = service.port_mappings.find_by_lb_port(443)
+        expect(https_mapping.container_port).to eq(Service::WEB_CONTAINER_PORT_DEFAULT)
+      end
+    end
+
+    context 'created with specified port' do
+      before { service.save }
+      let(:service) { create :web_service, heritage: heritage, web_container_port: 6000 }
+      it 'should create http and https port mappings with the specifed port' do
+        expect(service.port_mappings).to have(2).items
+        http_mapping = service.port_mappings.find_by_lb_port(80)
+        expect(http_mapping.container_port).to eq(6000)
+        https_mapping = service.port_mappings.find_by_lb_port(443)
+        expect(https_mapping.container_port).to eq(6000)
+      end
+    end
+
+    context 'update specified port' do
+      before do
+        service.save
+        service.web_container_port = 6000
+        service.save
+      end
+
+      it 'should create http and https port mappings with the specifed port' do
+        expect(service.port_mappings).to have(2).items
+        http_mapping = service.port_mappings.find_by_lb_port(80)
+        expect(http_mapping.container_port).to eq(6000)
+        https_mapping = service.port_mappings.find_by_lb_port(443)
+        expect(https_mapping.container_port).to eq(6000)
+      end
+    end
+
+    context 'created with specified port and extra mapping' do
+      before { service.save }
+      let(:udp_mapping) { PortMapping.new(container_port: 3333, protocol: "udp", lb_port: 3333) }
+      let(:service) do
+        create :web_service, heritage: heritage, web_container_port: 6000, port_mappings: [udp_mapping]
+      end
+      it 'should create http and https port mappings with the specifed port' do
+        expect(service.port_mappings).to have(3).items
+        http_mapping = service.port_mappings.find_by_lb_port(80)
+        expect(http_mapping.container_port).to eq(6000)
+        https_mapping = service.port_mappings.find_by_lb_port(443)
+        expect(https_mapping.container_port).to eq(6000)
+        udp_mapping = service.port_mappings.find_by_lb_port(3333)
+        expect(udp_mapping.container_port).to eq(3333)
+      end
+    end
+  end
 end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -66,18 +66,27 @@ describe "POST /districts/:district/heritages", type: :request do
       expect(heritage["services"][0]["command"]).to eq "nginx"
       expect(heritage["services"][0]["force_ssl"]).to eq true
       expect(heritage["services"][0]["reverse_proxy_image"]).to eq "org/custom_revpro:v1.2"
-      expect(heritage["services"][0]["port_mappings"][0]["lb_port"]).to eq 3333
-      expect(heritage["services"][0]["port_mappings"][0]["container_port"]).to eq 3333
-      expect(heritage["services"][0]["port_mappings"][0]["host_port"]).to be_a Integer
-      expect(heritage["services"][0]["port_mappings"][0]["protocol"]).to eq "udp"
-      expect(heritage["services"][0]["port_mappings"][1]["lb_port"]).to eq 80
-      expect(heritage["services"][0]["port_mappings"][1]["container_port"]).to eq 3000
-      expect(heritage["services"][0]["port_mappings"][1]["host_port"]).to be_a Integer
-      expect(heritage["services"][0]["port_mappings"][1]["protocol"]).to eq "http"
-      expect(heritage["services"][0]["port_mappings"][2]["lb_port"]).to eq 443
-      expect(heritage["services"][0]["port_mappings"][2]["container_port"]).to eq 3000
-      expect(heritage["services"][0]["port_mappings"][2]["host_port"]).to be_a Integer
-      expect(heritage["services"][0]["port_mappings"][2]["protocol"]).to eq "https"
+
+      udp_mapping = heritage["services"][0]["port_mappings"].find do |port_mapping|
+        port_mapping["lb_port"]  == 3333
+      end
+      expect(udp_mapping["host_port"]).to be_a Integer
+      expect(udp_mapping["protocol"]).to eq "udp"
+
+      http_mapping = heritage["services"][0]["port_mappings"].find do |port_mapping|
+        port_mapping["lb_port"]  == 80
+      end
+      expect(http_mapping["container_port"]).to eq 3000
+      expect(http_mapping["host_port"]).to be_a Integer
+      expect(http_mapping["protocol"]).to eq "http"
+
+      https_mapping = heritage["services"][0]["port_mappings"].find do |port_mapping|
+        port_mapping["lb_port"]  == 443
+      end
+      expect(https_mapping["container_port"]).to eq 3000
+      expect(https_mapping["host_port"]).to be_a Integer
+      expect(https_mapping["protocol"]).to eq "https"
+
       expect(heritage["services"][0]["health_check"]["protocol"]).to eq "tcp"
       expect(heritage["services"][0]["health_check"]["port"]).to eq 1111
       expect(heritage["services"][0]["hosts"][0]["hostname"]).to eq "awesome-app.degica.com"


### PR DESCRIPTION
Resolves #553 with https://github.com/degica/barcelona-cli/pull/27.

I tested this with following barcelona.yml

```yaml
environments:
  production:
    name: hello
    image_name: docker.io/essa/barcelona-sample-hello
    services:
      - name: web
        service_type: web
        public: true
        cpu: 128
        memory: 256
        command: ruby hello.rb -p 8001 # Specify port for application to bind
        web_container_port: 8001 #  Specify port for connecting by reverse proxy
        listeners:
          - endpoint: essa-hello
            health_check_interval: 10
            health_check_path: /
            rule_conditions:
              - type: path-pattern
                value: '*'
```

`web_container_port` is used for `container_port` in port_mappings. So you can use it any application with fixed bind port.

