### PR TITLE
Deploy barcelona from master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,15 @@ jobs:
         bundle exec rake db:create
         bundle exec rake db:setup
         bundle exec rspec
+    - name: deploy
+      if: ${{ github.ref == 'refs/heads/master' }}
+      env:
+        BARCELONA_ENDPOINT: https://barcelona.degica.com
+        MAINLINE_HERITAGE_TOKEN: ${{ secrets.MAINLINE_HERITAGE_TOKEN }}
+        QUAY_REPOSITORY: degica/barcelona
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      run: |-
+        bcnd
     services:
       postgres:
         # Docker Hub image


### PR DESCRIPTION
The last #581 PR did not add deployment from github actions. This PR adds that back.

Will need to set up the settings for barcelona for our main servers. 

Please do not merge this. I will merge it after the env vars have been set up