### PR TITLE
Install bcnd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         QUAY_REPOSITORY: degica/barcelona
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
       run: |-
+        gem install bcnd --no-ri --no-rdoc
         bcnd
     services:
       postgres:


### PR DESCRIPTION
It turns out the deployment PR was not complete because bcnd failed. https://github.com/degica/barcelona/actions/runs/107903526

This PR installs bcnd so it can be called