### PR TITLE
Update AMIs for ecs instances and bastion instances to 2.0.20200603

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0aee8ced190c05726",
-        "us-east-2"      => "ami-0d9ef3d936a8fa1c6",
-        "us-west-1"      => "ami-0fc0ce1549e302a52",
-        "us-west-2"      => "ami-088bb4cd2f62fc0e1",
-        "eu-west-1"      => "ami-0a74b180a0c97ecd1",
-        "eu-west-2"      => "ami-04967dd60612d3b49",
-        "eu-west-3"      => "ami-032a9f3e531acca53",
-        "eu-central-1"      => "ami-0d2e4df42e13655e0",
-        "ap-northeast-1"      => "ami-03179588b2f59f257",
-        "ap-northeast-2"      => "ami-00ec0bddfbdd6e1c1",
-        "ap-southeast-1"      => "ami-0fd3e3d7875748187",
-        "ap-southeast-2"      => "ami-029bf83e14803c25f",
-        "ca-central-1"      => "ami-0c54fd41f64065620",
-        "ap-south-1"      => "ami-0b9d66ddb2a9f47d1",
-        "sa-east-1"      => "ami-0d6ac368fff49ff2d",
+        "us-east-1"      => "ami-0b22c910bce7178b6",
+        "us-east-2"      => "ami-0b29e28ad09b4e536",
+        "us-west-1"      => "ami-0560993025898e8e8",
+        "us-west-2"      => "ami-0633e2a3c7135c18a",
+        "eu-west-1"      => "ami-0cf112c4c967e0437",
+        "eu-west-2"      => "ami-038863f4c20d2d63d",
+        "eu-west-3"      => "ami-00a12748018f55f56",
+        "eu-central-1"      => "ami-08c4be469fbdca0fa",
+        "ap-northeast-1"      => "ami-0471ea40c46b4325d",
+        "ap-northeast-2"      => "ami-0a42b1e2c5f22035c",
+        "ap-southeast-1"      => "ami-00100469ca2a34fa3",
+        "ap-southeast-2"      => "ami-02446908683d78c79",
+        "ca-central-1"      => "ami-01a7c134a00678ad6",
+        "ap-south-1"      => "ami-0c20a67db6e1c7258",
+        "sa-east-1"      => "ami-0e720f8542a11d10b",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0323c3dd2da7fb37d",
-        "us-east-2"      => "ami-0f7919c33c90f5b58",
-        "us-west-1"      => "ami-06fcc1f0bc2c8943f",
-        "us-west-2"      => "ami-0d6621c01e8c2de2c",
-        "eu-west-1"      => "ami-06ce3edf0cff21f07",
-        "eu-west-2"      => "ami-01a6e31ac994bbc09",
-        "eu-west-3"      => "ami-00077e3fed5089981",
-        "eu-central-1"      => "ami-076431be05aaf8080",
-        "ap-northeast-1"      => "ami-0f310fced6141e627",
-        "ap-northeast-2"      => "ami-01288945bd24ed49a",
-        "ap-southeast-1"      => "ami-0ec225b5e01ccb706",
-        "ap-southeast-2"      => "ami-0970010f37c4f9c8d",
-        "ca-central-1"      => "ami-054362537f5132ce2",
-        "ap-south-1"      => "ami-0470e33cd681b2476",
-        "sa-east-1"      => "ami-003449ffb2605a74c",
+        "us-east-1"      => "ami-09d95fab7fff3776c",
+        "us-east-2"      => "ami-026dea5602e368e96",
+        "us-west-1"      => "ami-04e59c05167ea7bd5",
+        "us-west-2"      => "ami-0e34e7b9ca0ace12d",
+        "eu-west-1"      => "ami-0ea3405d2d2522162",
+        "eu-west-2"      => "ami-032598fcc7e9d1c7a",
+        "eu-west-3"      => "ami-01c72e187b357583b",
+        "eu-central-1"      => "ami-0a02ee601d742e89f",
+        "ap-northeast-1"      => "ami-0a1c2ec61571737db",
+        "ap-northeast-2"      => "ami-01af223aa7f274198",
+        "ap-southeast-1"      => "ami-0615132a0f36d24f4",
+        "ap-southeast-2"      => "ami-088ff0e3bde7b3fdf",
+        "ca-central-1"      => "ami-0f75c2980c6a5851d",
+        "ap-south-1"      => "ami-0447a12f28fddb066",
+        "sa-east-1"      => "ami-0477a95397a9154b3",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
