### PR TITLE
Update AMIs for ecs instances and bastion instance to 2.0.20200623

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0b22c910bce7178b6",
-        "us-east-2"      => "ami-0b29e28ad09b4e536",
-        "us-west-1"      => "ami-0560993025898e8e8",
-        "us-west-2"      => "ami-0633e2a3c7135c18a",
-        "eu-west-1"      => "ami-0cf112c4c967e0437",
-        "eu-west-2"      => "ami-038863f4c20d2d63d",
-        "eu-west-3"      => "ami-00a12748018f55f56",
-        "eu-central-1"      => "ami-08c4be469fbdca0fa",
-        "ap-northeast-1"      => "ami-0471ea40c46b4325d",
-        "ap-northeast-2"      => "ami-0a42b1e2c5f22035c",
-        "ap-southeast-1"      => "ami-00100469ca2a34fa3",
-        "ap-southeast-2"      => "ami-02446908683d78c79",
-        "ca-central-1"      => "ami-01a7c134a00678ad6",
-        "ap-south-1"      => "ami-0c20a67db6e1c7258",
-        "sa-east-1"      => "ami-0e720f8542a11d10b",
+        "us-east-1"      => "ami-00c7c1cf5bdc913ed",
+        "us-east-2"      => "ami-0466acdbae3d9cc42",
+        "us-west-1"      => "ami-0cd16f68edb958c92",
+        "us-west-2"      => "ami-0dffcb5ca115099f3",
+        "eu-west-1"      => "ami-060fdc00b63abc251",
+        "eu-west-2"      => "ami-04fca4396558d03bf",
+        "eu-west-3"      => "ami-023bf90632e1c95cc",
+        "eu-central-1"      => "ami-0b34f371a12d673de",
+        "ap-northeast-1"      => "ami-08d175f1b493f205f",
+        "ap-northeast-2"      => "ami-0fc5958377fe875c0",
+        "ap-southeast-1"      => "ami-0562e27aac95dcf60",
+        "ap-southeast-2"      => "ami-0abf1b04f846837ea",
+        "ca-central-1"      => "ami-02e1c36d5a022e870",
+        "ap-south-1"      => "ami-0e26e067030ec6083",
+        "sa-east-1"      => "ami-0191bdb48aa7141d7",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-09d95fab7fff3776c",
-        "us-east-2"      => "ami-026dea5602e368e96",
-        "us-west-1"      => "ami-04e59c05167ea7bd5",
-        "us-west-2"      => "ami-0e34e7b9ca0ace12d",
-        "eu-west-1"      => "ami-0ea3405d2d2522162",
-        "eu-west-2"      => "ami-032598fcc7e9d1c7a",
-        "eu-west-3"      => "ami-01c72e187b357583b",
-        "eu-central-1"      => "ami-0a02ee601d742e89f",
-        "ap-northeast-1"      => "ami-0a1c2ec61571737db",
-        "ap-northeast-2"      => "ami-01af223aa7f274198",
-        "ap-southeast-1"      => "ami-0615132a0f36d24f4",
-        "ap-southeast-2"      => "ami-088ff0e3bde7b3fdf",
-        "ca-central-1"      => "ami-0f75c2980c6a5851d",
-        "ap-south-1"      => "ami-0447a12f28fddb066",
-        "sa-east-1"      => "ami-0477a95397a9154b3",
+        "us-east-1"      => "ami-08f3d892de259504d",
+        "us-east-2"      => "ami-016b213e65284e9c9",
+        "us-west-1"      => "ami-01311df3780ebd33e",
+        "us-west-2"      => "ami-0b1e2eeb33ce3d66f",
+        "eu-west-1"      => "ami-0c3e74fa87d2a4227",
+        "eu-west-2"      => "ami-04122be15033aa7ec",
+        "eu-west-3"      => "ami-0bfddfb1ccc3a6993",
+        "eu-central-1"      => "ami-00edb93a4d68784e3",
+        "ap-northeast-1"      => "ami-06ad9296e6cf1e3cf",
+        "ap-northeast-2"      => "ami-0e92198843e11ccee",
+        "ap-southeast-1"      => "ami-0adbe59da7d24a349",
+        "ap-southeast-2"      => "ami-0a58e22c727337c51",
+        "ca-central-1"      => "ami-05de9e98f3bef5e8a",
+        "ap-south-1"      => "ami-0732b62d310b80e97",
+        "sa-east-1"      => "ami-081a078e835a9f751",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
