### PR TITLE
Allow underscores to be passed in as review app subject

### DIFF
--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -4,7 +4,7 @@ class ReviewApp < ApplicationRecord
 
   attr_accessor :image_name, :image_tag, :services, :before_deploy, :environment
   validates :subject, :image_name, :image_tag, :retention, :services, presence: true
-  validates :subject, format: {with: /\A[a-z0-9][a-z0-9-]*[a-z0-9]\z/}
+  validates :subject, format: {with: /\A[a-z0-9][a-z0-9(-|_)]*[a-z0-9]\z/}
   validates :retention, numericality: {greater_than: 0, less_than: 24 * 3600 * 30}
 
   before_validation :build_heritage
@@ -40,7 +40,7 @@ class ReviewApp < ApplicationRecord
   end
 
   def domain
-    "#{subject}.#{review_group.base_domain}"
+    "#{sanitized_subject}.#{review_group.base_domain}"
   end
 
   def rule_priority_from_subject
@@ -48,7 +48,7 @@ class ReviewApp < ApplicationRecord
   end
 
   def slug
-    review_group.name + "---" + subject
+    review_group.name + "---" + sanitized_subject
   end
 
   def slug_digest
@@ -56,7 +56,7 @@ class ReviewApp < ApplicationRecord
   end
 
   def to_param
-    subject
+    sanitized_subject
   end
 
   def expired?(now=Time.current)
@@ -67,5 +67,10 @@ class ReviewApp < ApplicationRecord
     environment + [
       {name: "BARCELONA_REVIEWAPP_DOMAIN", value: domain}
     ]
+  end
+
+  # replace underscores if present - not valid as subdomain
+  def sanitized_subject
+    subject.gsub('_', '-')
   end
 end

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -36,6 +36,34 @@ describe ReviewApp do
       review_app.save!
     end
 
+    context 'when a subject includes underscores' do
+      let(:review_app) {
+        group.review_apps.new(
+          subject: "subject_with_underscores",
+          image_name: "image",
+          image_tag: "tag",
+          retention: 12 * 3600,
+          before_deploy: "true",
+          environment: [],
+          services: [{
+            name: "review",
+            command: "true",
+            service_type: "web",
+          }]
+        )
+      }
+
+      it 'passes validation' do
+        expect{review_app.save!}.to_not raise_error
+      end
+
+      it "converts the underscores to hyphens" do
+        expect(review_app.to_param).to eq('subject-with-underscores')
+        expect(review_app.slug).to eq('review---subject-with-underscores')
+      end
+
+    end
+
     context "when a service def has listeners" do
       let(:review_app) {
         group.review_apps.new(


### PR DESCRIPTION
This is kind of a selfish PR, but I tend to use snake_case naming scheme for git branch names which does not pass the review app subject validation.

Underscores aren't legal characters in subdomains, so in this PR we check the subject for them and convert to hyphens if necessary.

Feel free to reject if handling underscores is deemed unnecessary