### PR TITLE
Expose status of deployment to the api

### DIFF
--- a/app/serializers/heritage_serializer.rb
+++ b/app/serializers/heritage_serializer.rb
@@ -1,6 +1,6 @@
 class HeritageSerializer < ActiveModel::Serializer
   attributes :name, :image_name, :image_tag, :env_vars, :before_deploy,
-             :token, :version, :scheduled_tasks, :environment
+             :token, :version, :scheduled_tasks, :environment, :deployed
 
   has_many :services
   belongs_to :district
@@ -15,5 +15,9 @@ class HeritageSerializer < ActiveModel::Serializer
     object.environments.
       map { |e| e.slice(:name, :value, :value_from) }.
       sort_by { |e| e[:name] }
+  end
+
+  def deployed
+    object.services.map { |s| s.deployment_finished?(nil) }.all?
   end
 end

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,5 +1,5 @@
 class ServiceSerializer < ActiveModel::Serializer
-  attributes :name, :public, :command, :cpu, :memory, :endpoint, :status,
+  attributes :name, :public, :command, :cpu, :memory, :endpoint, :status, :deployed,
              :port_mappings, :running_count, :pending_count, :desired_count,
              :reverse_proxy_image, :hosts, :service_type, :force_ssl, :health_check
 
@@ -14,5 +14,9 @@ class ServiceSerializer < ActiveModel::Serializer
         protocol: pm.protocol
       }
     end
+  end
+
+  def deployed
+    object.deployment_finished?(nil)
   end
 end

--- a/spec/requests/show_heritage_spec.rb
+++ b/spec/requests/show_heritage_spec.rb
@@ -36,8 +36,10 @@ describe "GET /heritages/:heritage", type: :request do
     expect(heritage["name"]).to eq "nginx"
     expect(heritage["image_name"]).to eq "nginx"
     expect(heritage["image_tag"]).to eq "latest"
+    expect(heritage["deployed"]).to eq true
     expect(heritage["before_deploy"]).to eq "echo hello"
     expect(heritage["services"][0]["name"]).to eq "web"
+    expect(heritage["services"][0]["deployed"]).to eq true
     expect(heritage["services"][0]["public"]).to eq true
     expect(heritage["services"][0]["cpu"]).to eq 128
     expect(heritage["services"][0]["memory"]).to eq 256


### PR DESCRIPTION
# Context

Before it was not possible to use the API to find out if a deployment was done yet. This PR fixes this. It adds a `deployed` key to the heritage output and each of its services.

# How to test

1. Deploy a heritage (lets call it `hello`)
2. `bcn api get /heritages/hello`
3. Look for a `deployed` key in the output JSON.

<img width="400" alt="スクリーンショット 2020-08-05 17 52 31" src="https://user-images.githubusercontent.com/874280/89392393-7215ca00-d744-11ea-8637-0b3c1d73c6da.png">

4. Wait for the deployment to finish
5. Run the command again and expect true to be returned this time.
