### PR TITLE
Add option to drop query params from logs

### DIFF
--- a/dockerfiles/reverse-proxy/README.md
+++ b/dockerfiles/reverse-proxy/README.md
@@ -1,0 +1,13 @@
+# reverse-proxy
+
+The reverse-proxy Dockerfile is the Barcelona supported reverse proxy (based on nginx) that is configured to cleanly integrate with the other Barcelona images.
+
+## Testing
+
+To test the reverse-proxy image in isolation you can use the `docker-compose.test.yml` file:
+```bash
+$ docker-compose -f docker-compose.test.yml build
+$ docker-compose -f docker-compose.test.yml up
+```
+
+This will start a simple webserver on port `50132`, which can be used for testing that the nginx config is working as intended. The Nginx logs are being directed to stdout so you should see any logs appearing in the docker-compose session, or if you started it in detached mode you can run `docker-compose -f docker-compose.test.yml logs` to see the nginx log output.

--- a/dockerfiles/reverse-proxy/docker-compose.test.yml
+++ b/dockerfiles/reverse-proxy/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+    revpro:
+        build: .
+        ports:
+            - "50132:80"
+        links:
+            - web
+        environment:
+            UPSTREAM_NAME: web
+            UPSTREAM_PORT: 80
+            FORCE_SSL: "false"
+            DISABLE_PROXY_PROTOCOL: "true"
+            FILTER_LOGS: "true"
+    web:
+        image: yeasy/simple-web
+

--- a/dockerfiles/reverse-proxy/docker-compose.test.yml
+++ b/dockerfiles/reverse-proxy/docker-compose.test.yml
@@ -11,7 +11,7 @@ services:
             UPSTREAM_PORT: 80
             FORCE_SSL: "false"
             DISABLE_PROXY_PROTOCOL: "true"
-            FILTER_LOGS: "true"
+            REMOVE_PARAMS_FROM_LOGS: "true"
     web:
         image: yeasy/simple-web
 

--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -63,9 +63,30 @@ def server_conf_template_path
   end
 end
 
+def default_log_format
+  <<~LOG_FORMAT
+    '$proxy_protocol_addr - [$time_local] '
+    '"$request" $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent"'
+  LOG_FORMAT
+end
+
+def no_query_params_log_format
+  <<~LOG_FORMAT
+    '$proxy_protocol_addr - [$time_local] '
+    '"$request_method $uri $server_protocol" $status $body_bytes_sent '
+    '"$http_referer" "$http_user_agent"'
+  LOG_FORMAT
+end
+
+def log_format
+  ENV['REMOVE_PARAMS_FROM_LOGS'] == 'true' ? no_query_params_log_format : default_log_format
+end
+
 render_template('/templates/nginx.conf.erb', '/etc/nginx/nginx.conf',
   upstream_name: ENV['UPSTREAM_NAME'],
-  upstream_port: ENV['UPSTREAM_PORT']
+  upstream_port: ENV['UPSTREAM_PORT'],
+  log_format: log_format,
 )
 
 hosts = (ENV['HTTP_HOSTS'] || "").split(',')

--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -75,7 +75,7 @@ def no_query_params_log_format
   <<~LOG_FORMAT
     '$proxy_protocol_addr - [$time_local] '
     '"$request_method $uri $server_protocol" $status $body_bytes_sent '
-    '"$http_referer" "$http_user_agent"'
+    '"$http_user_agent"'
   LOG_FORMAT
 end
 

--- a/dockerfiles/reverse-proxy/templates/nginx.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/nginx.conf.erb
@@ -12,9 +12,7 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  log_format main '$proxy_protocol_addr - [$time_local] '
-                  '"$request" $status $body_bytes_sent '
-                  '"$http_referer" "$http_user_agent"';
+  log_format main <%= log_format %>;
   access_log    /var/log/nginx/access.log main;
 
   sendfile on;


### PR DESCRIPTION
Because we have GDPR requirements to be able to delete a users personally identifiable information (PII) and some of that information (like email addresses) could be passed into our systems as query parameters, we want the ability to disable Nginx query parameter logging. This is a lot easier than trying to identify all possible instances of PII that come into our systems and filter them out explicitly.

## How to test
**Testing with filtering enabled**
1. Clone the branch
1. `cd barcelona/dockerfiles/reverse-proxy`
1. Run `docker-compose -f docker-compose.test.yml build`
1. Run `docker-compose -f docker-compose.test.yml up`
1. Using the browser (or curl) go to http://localhost:50132/?email=john.smith@smith.com
1. In the nginx logs you shouldn't see any query parameters logged, like the screenshots

**Testing with filtering disabled**
1. Stop the docker containers session if it's still running
1. Change the `REMOVE_PARAMS_FROM_LOGS` param to "false" (or remove it entirely)
1. Run `docker-compose -f docker-compose.test.yml build`
1. Run `docker-compose -f docker-compose.test.yml up`
1. Using the browser (or curl) go to http://localhost:50132/?email=john.smith@smith.com
1. In the nginx logs you should see `email=john.smith@smith.com`

## Screenshot
**with `REMOVE_PARAMS_FROM_LOGS=true`**
![image](https://user-images.githubusercontent.com/12392541/89487331-7f849000-d7e8-11ea-9b9a-0f4b76aad7b6.png)

** with `REMOVE_PARAMS_FROM_LOGS=false`**
![image](https://user-images.githubusercontent.com/12392541/89487513-06d20380-d7e9-11ea-8bba-6f48b6105dd6.png)


