### PR TITLE
Update AMI to 2.0.20200805

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-08b26b905b0d17561",
-        "us-east-2"      => "ami-0fca7970ac53c18de",
-        "us-west-1"      => "ami-04e6f97d4c34650be",
-        "us-west-2"      => "ami-0126b48562dbe238a",
-        "eu-west-1"      => "ami-07ba39552b1744428",
-        "eu-west-2"      => "ami-03b5c056f589c6b94",
-        "eu-west-3"      => "ami-05bc8c2cb89370c49",
-        "eu-central-1"      => "ami-00b639818e857a757",
-        "ap-northeast-1"      => "ami-03003e0e2f7489bfa",
-        "ap-northeast-2"      => "ami-01622871b8eb5d0e5",
-        "ap-southeast-1"      => "ami-0eead268449ccefc1",
-        "ap-southeast-2"      => "ami-01132d29dd53937bf",
-        "ca-central-1"      => "ami-019e9fe8ee6a50d36",
-        "ap-south-1"      => "ami-0fdf0d779a4359dbd",
-        "sa-east-1"      => "ami-084dceb1f742bc5e1",
+        "us-east-1"      => "ami-05250bd90f5750ed7",
+        "us-east-2"      => "ami-078d79190068a1b35",
+        "us-west-1"      => "ami-0667a9cc6a93f50fe",
+        "us-west-2"      => "ami-06cb61a83c506fe88",
+        "eu-west-1"      => "ami-0c4b9f15bc61a5ba8",
+        "eu-west-2"      => "ami-0e2ab4ec1609a6006",
+        "eu-west-3"      => "ami-0dfde27e692f68456",
+        "eu-central-1"      => "ami-00364a85f9634c4f3",
+        "ap-northeast-1"      => "ami-0ca6d4eb36c5aae78",
+        "ap-northeast-2"      => "ami-0f611947480a24c88",
+        "ap-southeast-1"      => "ami-0167e83338bdf98c2",
+        "ap-southeast-2"      => "ami-095016ddc8e84b54e",
+        "ca-central-1"      => "ami-0761de529c3d697c5",
+        "ap-south-1"      => "ami-0cd2ebd86e9e44cec",
+        "sa-east-1"      => "ami-03e8fe2917f457857",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-08f3d892de259504d",
-        "us-east-2"      => "ami-016b213e65284e9c9",
-        "us-west-1"      => "ami-01311df3780ebd33e",
-        "us-west-2"      => "ami-0b1e2eeb33ce3d66f",
-        "eu-west-1"      => "ami-0c3e74fa87d2a4227",
-        "eu-west-2"      => "ami-04122be15033aa7ec",
-        "eu-west-3"      => "ami-0bfddfb1ccc3a6993",
-        "eu-central-1"      => "ami-00edb93a4d68784e3",
-        "ap-northeast-1"      => "ami-06ad9296e6cf1e3cf",
-        "ap-northeast-2"      => "ami-0e92198843e11ccee",
-        "ap-southeast-1"      => "ami-0adbe59da7d24a349",
-        "ap-southeast-2"      => "ami-0a58e22c727337c51",
-        "ca-central-1"      => "ami-05de9e98f3bef5e8a",
-        "ap-south-1"      => "ami-0732b62d310b80e97",
-        "sa-east-1"      => "ami-081a078e835a9f751",
+        "us-east-1"      => "ami-02354e95b39ca8dec",
+        "us-east-2"      => "ami-07c8bc5c1ce9598c3",
+        "us-west-1"      => "ami-05655c267c89566dd",
+        "us-west-2"      => "ami-0873b46c45c11058d",
+        "eu-west-1"      => "ami-07d9160fa81ccffb5",
+        "eu-west-2"      => "ami-0a13d44dccf1f5cf6",
+        "eu-west-3"      => "ami-093fa4c538885becf",
+        "eu-central-1"      => "ami-0c115dbd34c69a004",
+        "ap-northeast-1"      => "ami-0cc75a8978fbbc969",
+        "ap-northeast-2"      => "ami-0bd7691bf6470fe9c",
+        "ap-southeast-1"      => "ami-0cd31be676780afa7",
+        "ap-southeast-2"      => "ami-0ded330691a314693",
+        "ca-central-1"      => "ami-013d1df4bcea6ba95",
+        "ap-south-1"      => "ami-0ebc1ac48dfd14136",
+        "sa-east-1"      => "ami-018ccfb6b4745882a",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
