### PR TITLE
Vault fixes

### DIFF
--- a/app/auth/auth.rb
+++ b/app/auth/auth.rb
@@ -2,7 +2,7 @@ class Auth
   attr_accessor :request, :current_user
 
   def initialize(request)
-    unless enabled?
+    unless self.class.enabled?
       raise ExceptionHandler::InternalServerError.new("Auth backend is disabled")
     end
     @request = request

--- a/app/auth/github_auth.rb
+++ b/app/auth/github_auth.rb
@@ -1,5 +1,5 @@
 class GithubAuth < Auth
-  def enabled?
+  def self.enabled?
     ENV['GITHUB_ORGANIZATION'].present?
   end
 

--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -1,5 +1,5 @@
 class VaultAuth < Auth
-  def enabled?
+  def self.enabled?
     ENV['VAULT_URL'].present?
   end
 

--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -47,6 +47,7 @@ class VaultAuth < Auth
     req['X-Vault-Token'] = vault_token
     uri = URI(ENV['VAULT_URL'])
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.scheme == 'https'
     res = http.request(req)
     raise ExceptionHandler::Forbidden.new("Your Vault token does not have a permission for #{req.path}") if res.code.to_i > 299
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,10 +27,13 @@ class ApplicationController < ActionController::API
   end
 
   def auth_backend
-    @_auth_backend ||= if request.headers['HTTP_X_VAULT_TOKEN']
-                         VaultAuth.new(request)
-                       else
-                         GithubAuth.new(request)
-                       end
+    @_auth_backend ||= begin
+      backend_class = if VaultAuth.enabled?
+                        VaultAuth
+                      elsif GithubAuth.enabled?
+                        GithubAuth
+                      end
+      backend_class.new(request)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,18 @@ Rails.application.routes.draw do
         post "/releases/:version/rollback", to: "releases#rollback"
       end
 
+      resources :heritages, except: [:new, :edit] do
+        post   :env_vars, on: :member, to: "heritages#set_env_vars"
+        delete :env_vars, on: :member, to: "heritages#delete_env_vars"
+
+        post "/trigger/:token", to: "heritages#trigger"
+        resources :oneoffs, only: [:show, :create]
+
+        get "/releases", to: "releases#index"
+        get "/releases/:version", to: "releases#show"
+        post "/releases/:version/rollback", to: "releases#rollback"
+      end
+
       resources :endpoints, except: [:new, :edit]
       resources :notifications, except: [:new, :edit]
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,9 @@ services:
       GITHUB_ORGANIZATION: 'degica'
       GITHUB_DEVELOPER_TEAM: 'developers'
       GITHUB_ADMIN_TEAM: 'Admin developers'
-      VAULT_URL: http://vault:8200
-      VAULT_PATH_PREFIX: degica
+      # Uncomment to use vault auth
+      # VAULT_URL: http://vault:8200
+      # VAULT_PATH_PREFIX: degica
   worker:
     <<: *app_base
     ports: []
@@ -45,7 +46,7 @@ services:
     volumes:
       - pgdata:/data
   vault:
-    image: vault:1.4.2
+    image: vault:1.5.2
     ports:
       - "8200:8200"
     environment:

--- a/spec/auth/vault_auth_spec.rb
+++ b/spec/auth/vault_auth_spec.rb
@@ -4,7 +4,7 @@ describe VaultAuth do
   let(:auth) { VaultAuth.new(request) }
   before do
     stub_const('ENV', {
-      'VAULT_URL' => 'http://vault-url',
+      'VAULT_URL' => 'https://vault-url',
       'VAULT_PATH_PREFIX' => ''
     })
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe ApplicationController do
+  describe "#auth_backend" do
+    context "when github auth is enabled" do
+      before do
+        stub_env("GITHUB_ORGANIZATION", "degica")
+      end
+
+      it "returns github" do
+        expect(controller.auth_backend).to be_a GithubAuth
+      end
+    end
+
+    context "when vault auth is enabled" do
+      before do
+        stub_env("VAULT_URL", "https://vault.degica.com")
+      end
+
+      it "returns vault" do
+        expect(controller.auth_backend).to be_a VaultAuth
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,8 +54,6 @@ RSpec.configure do |config|
     Aws.config[:stub_responses] = true
 
     ENV['GITHUB_ORGANIZATION'] = 'degica'
-    ENV['VAULT_URL'] ||= "http://my-vault.com"
-    ENV['VAULT_PATH_PREFIX'] ||= "prefix"
   end
 
   config.before :each do


### PR DESCRIPTION
This PR contains several fixes related to vault backend.

## Set `use_ssl` if the vault URL is https 

https://github.com/degica/barcelona/commit/52e398f9e168c1e561b16edc2b050259f52132cd

it was not set so https url couldn't be used

## Add non-shallow routes

https://github.com/degica/barcelona/pull/614/commits/ba64ac4f3856652d6d531f76dd5462a2893140d8

Currently heritage routes are shallow so district name is not in a path e.g. `/v1/heritages/heritage-name`.
This makes it harder to set vault permissions because it is a typical use case to allow teams to do all operations to a specific district.

I added new non-shallow routes. I didn't remove the shallow routes because it breaks CLI. Once this is merged, we need to update CLI to use the non-shallow routes and then we can remove the shallow routes.

## Improved auth backend selection

https://github.com/degica/barcelona/pull/614/commits/3b124d3cb30a8bc79b78db725dc5649d1c7edeae

Instead of relying on `X-Vault-Token` header, now backend is enabled / disabled by the following environment variables

- if `VAULT_URL` is set, vault auth is enabled
- if `GITHUB_ORGANIZATION` is set, github auth is enabled
- if both are set, vault is chosen