### PR TITLE
Meta endpoint

### DIFF
--- a/app/auth/auth.rb
+++ b/app/auth/auth.rb
@@ -2,7 +2,7 @@ class Auth
   attr_accessor :request, :current_user
 
   def initialize(request)
-    unless enabled?
+    unless self.class.enabled?
       raise ExceptionHandler::InternalServerError.new("Auth backend is disabled")
     end
     @request = request

--- a/app/auth/github_auth.rb
+++ b/app/auth/github_auth.rb
@@ -1,5 +1,5 @@
 class GithubAuth < Auth
-  def enabled?
+  def self.enabled?
     ENV['GITHUB_ORGANIZATION'].present?
   end
 

--- a/app/auth/github_auth.rb
+++ b/app/auth/github_auth.rb
@@ -3,6 +3,10 @@ class GithubAuth < Auth
     ENV['GITHUB_ORGANIZATION'].present?
   end
 
+  def name
+    "github"
+  end
+
   def login
     github_token = request.headers['HTTP_X_GITHUB_TOKEN']
 

--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -7,6 +7,10 @@ class VaultAuth < Auth
     authenticate
   end
 
+  def name
+    "vault"
+  end
+
   def authenticate
     res = lookup
     username = res.dig("data", "meta", "username")
@@ -49,7 +53,7 @@ class VaultAuth < Auth
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
     res = http.request(req)
-    raise ExceptionHandler::Forbidden.new("Your Vault token does not have a permission for #{req.path}") if res.code.to_i > 299
+    raise ExceptionHandler::Forbidden.new("Couldn't get capabilities. the token is invalid or expired") if res.code.to_i > 299
 
     JSON.load(res.body)
   end

--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -1,5 +1,5 @@
 class VaultAuth < Auth
-  def enabled?
+  def self.enabled?
     ENV['VAULT_URL'].present?
   end
 

--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -47,6 +47,7 @@ class VaultAuth < Auth
     req['X-Vault-Token'] = vault_token
     uri = URI(ENV['VAULT_URL'])
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true if uri.scheme == 'https'
     res = http.request(req)
     raise ExceptionHandler::Forbidden.new("Your Vault token does not have a permission for #{req.path}") if res.code.to_i > 299
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,10 +27,13 @@ class ApplicationController < ActionController::API
   end
 
   def auth_backend
-    @_auth_backend ||= if request.headers['HTTP_X_VAULT_TOKEN']
-                         VaultAuth.new(request)
-                       else
-                         GithubAuth.new(request)
-                       end
+    @_auth_backend ||= begin
+      backend_class = if VaultAuth.enabled?
+                        VaultAuth
+                      elsif GithubAuth.enabled?
+                        GithubAuth
+                      end
+      backend_class.new(request)
+    end
   end
 end

--- a/app/controllers/meta_controller.rb
+++ b/app/controllers/meta_controller.rb
@@ -1,0 +1,22 @@
+class MetaController < ApplicationController
+  skip_before_action :authenticate
+  skip_before_action :authorize_action
+
+  def index
+    res = { auth: { backend: auth_backend.name } }
+    case auth_backend.name 
+    when "vault"
+      res[:auth][:vault] = {
+        url: ENV["VAULT_URL"]
+      }
+    when "github"
+      res[:auth][:github] = {
+        organization: ENV["GITHUB_ORGANIZATION"],
+        developer_team: ENV['GITHUB_DEVELOPER_TEAM'],
+        admin_team: ENV['GITHUB_ADMIN_TEAM'],
+      }
+    end
+
+    render json: res
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,18 @@ Rails.application.routes.draw do
         post "/releases/:version/rollback", to: "releases#rollback"
       end
 
+      resources :heritages, except: [:new, :edit] do
+        post   :env_vars, on: :member, to: "heritages#set_env_vars"
+        delete :env_vars, on: :member, to: "heritages#delete_env_vars"
+
+        post "/trigger/:token", to: "heritages#trigger"
+        resources :oneoffs, only: [:show, :create]
+
+        get "/releases", to: "releases#index"
+        get "/releases/:version", to: "releases#show"
+        post "/releases/:version/rollback", to: "releases#rollback"
+      end
+
       resources :endpoints, except: [:new, :edit]
       resources :notifications, except: [:new, :edit]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
     post "/login", to: "users#login"
     patch "/user", to: "users#update"
     get "/user", to: "users#show"
+
+    get "/meta", to: "meta#index"
   end
 
   get "/health_check", to: "health_check#index"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,9 @@ services:
       GITHUB_ORGANIZATION: 'degica'
       GITHUB_DEVELOPER_TEAM: 'developers'
       GITHUB_ADMIN_TEAM: 'Admin developers'
-      VAULT_URL: http://vault:8200
-      VAULT_PATH_PREFIX: degica
+      # Uncomment to use vault auth
+      # VAULT_URL: http://vault:8200
+      # VAULT_PATH_PREFIX: degica
   worker:
     <<: *app_base
     ports: []
@@ -45,7 +46,7 @@ services:
     volumes:
       - pgdata:/data
   vault:
-    image: vault:1.4.2
+    image: vault:1.5.2
     ports:
       - "8200:8200"
     environment:

--- a/spec/auth/vault_auth_spec.rb
+++ b/spec/auth/vault_auth_spec.rb
@@ -4,7 +4,7 @@ describe VaultAuth do
   let(:auth) { VaultAuth.new(request) }
   before do
     stub_const('ENV', {
-      'VAULT_URL' => 'http://vault-url',
+      'VAULT_URL' => 'https://vault-url',
       'VAULT_PATH_PREFIX' => ''
     })
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,8 +54,6 @@ RSpec.configure do |config|
     Aws.config[:stub_responses] = true
 
     ENV['GITHUB_ORGANIZATION'] = 'degica'
-    ENV['VAULT_URL'] ||= "http://my-vault.com"
-    ENV['VAULT_PATH_PREFIX'] ||= "prefix"
   end
 
   config.before :each do

--- a/spec/requests/meta_endpoint_spec.rb
+++ b/spec/requests/meta_endpoint_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe "GET /v1/meta", type: :request do
+  context "when vault auth is on" do
+    before do
+      stub_env("VAULT_URL" => "https://vault.degica.com")
+      stub_env("GITHUB_ORGANIZATION" => nil)
+    end
+
+    it "returns vault info" do
+      get "/v1/meta"
+      body = JSON.load(response.body)
+      expect(body["auth"]["backend"]).to eq "vault"
+      expect(body["auth"]["vault"]["url"]).to eq "https://vault.degica.com"
+    end
+  end
+
+  context "github vault is on" do
+    before do
+      stub_env("GITHUB_ORGANIZATION" => "degica")
+      stub_env("GITHUB_DEVELOPER_TEAM" => "developer")
+      stub_env("GITHUB_ADMIN_TEAM" => "admin")
+      stub_env("VAULT_URL" => nil)
+    end
+
+    it "returns vault info" do
+      get "/v1/meta"
+      body = JSON.load(response.body)
+      expect(body["auth"]["backend"]).to eq "github"
+      expect(body["auth"]["github"]["organization"]).to eq "degica"
+      expect(body["auth"]["github"]["developer_team"]).to eq "developer"
+      expect(body["auth"]["github"]["admin_team"]).to eq "admin"
+    end
+  end
+end


### PR DESCRIPTION
depends on #614 

TBH I'm not 100% sure if we need this API. I just opened this to have a discussion.

The idea is that the bcn cli calls this meta API to get auth backend info and changes login action.
of cousre this can be done as a cli option such as `bcn login --auth vault --vault-url https://...`