### PR TITLE
Update AMIs for ecs instances and bastion instance to 2.0.20200905

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-00a35b04ab99b549a",
-        "us-east-2"      => "ami-00b7bbb0f21c54d1c",
-        "us-west-1"      => "ami-0448eb47430191106",
-        "us-west-2"      => "ami-06dccd44015e57613",
-        "eu-west-1"      => "ami-01f62a207c1d180d2",
-        "eu-west-2"      => "ami-096caa773bb6196d1",
-        "eu-west-3"      => "ami-083a93636360ff754",
-        "eu-central-1"      => "ami-09e7549e8fc2233b9",
-        "ap-northeast-1"      => "ami-084ceb2ac4b523463",
-        "ap-northeast-2"      => "ami-073c48001678780d4",
-        "ap-southeast-1"      => "ami-09aade22702aec219",
-        "ap-southeast-2"      => "ami-08f6acdaa858c5148",
-        "ca-central-1"      => "ami-0dd880c4d5f02a5e7",
-        "ap-south-1"      => "ami-00c556d64c0320b38",
-        "sa-east-1"      => "ami-01e04d76918550d9b",
+        "us-east-1"      => "ami-0878e35d09c75f0a1",
+        "us-east-2"      => "ami-041382ba1d2dcbd27",
+        "us-west-1"      => "ami-056b01efa5c7f8718",
+        "us-west-2"      => "ami-04bb74f3ffa3aa3e2",
+        "eu-west-1"      => "ami-0bf6268a1d7c80226",
+        "eu-west-2"      => "ami-09b1109d40fc89d9e",
+        "eu-west-3"      => "ami-0615654018f871562",
+        "eu-central-1"      => "ami-0a0b9f07d788b7c85",
+        "ap-northeast-1"      => "ami-040a7dcfd701fead5",
+        "ap-northeast-2"      => "ami-0ab5e3afc0773f28e",
+        "ap-southeast-1"      => "ami-01bba7275474fc9af",
+        "ap-southeast-2"      => "ami-0d4f4489017746267",
+        "ca-central-1"      => "ami-0e7767d1cb89be85d",
+        "ap-south-1"      => "ami-04a13379b93d01d0c",
+        "sa-east-1"      => "ami-07bc52d2426c76ed7",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-02354e95b39ca8dec",
-        "us-east-2"      => "ami-07c8bc5c1ce9598c3",
-        "us-west-1"      => "ami-05655c267c89566dd",
-        "us-west-2"      => "ami-0873b46c45c11058d",
-        "eu-west-1"      => "ami-07d9160fa81ccffb5",
-        "eu-west-2"      => "ami-0a13d44dccf1f5cf6",
-        "eu-west-3"      => "ami-093fa4c538885becf",
-        "eu-central-1"      => "ami-0c115dbd34c69a004",
-        "ap-northeast-1"      => "ami-0cc75a8978fbbc969",
-        "ap-northeast-2"      => "ami-0bd7691bf6470fe9c",
-        "ap-southeast-1"      => "ami-0cd31be676780afa7",
-        "ap-southeast-2"      => "ami-0ded330691a314693",
-        "ca-central-1"      => "ami-013d1df4bcea6ba95",
-        "ap-south-1"      => "ami-0ebc1ac48dfd14136",
-        "sa-east-1"      => "ami-018ccfb6b4745882a",
+        "us-east-1"      => "ami-0c94855ba95c71c99",
+        "us-east-2"      => "ami-0603cbe34fd08cb81",
+        "us-west-1"      => "ami-0e65ed16c9bf1abc7",
+        "us-west-2"      => "ami-01ce4793a2f45922e",
+        "eu-west-1"      => "ami-08a2aed6e0a6f9c7d",
+        "eu-west-2"      => "ami-09b89ad3c5769cca2",
+        "eu-west-3"      => "ami-0697b068b80d79421",
+        "eu-central-1"      => "ami-08c148bb835696b45",
+        "ap-northeast-1"      => "ami-0053d11f74e9e7f52",
+        "ap-northeast-2"      => "ami-064a198accc7e80e0",
+        "ap-southeast-1"      => "ami-0b1e534a4ff9019e0",
+        "ap-southeast-2"      => "ami-0099823645f06b6a1",
+        "ca-central-1"      => "ami-020caff809d5a5307",
+        "ap-south-1"      => "ami-09a7bbd08886aafdf",
+        "sa-east-1"      => "ami-013dd6e24f90aa93f",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
