### PR TITLE
Update AMIs for ecs instances and bastion instance to to 2.0.20200928

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0bcd7ba1832b01f40",
-        "us-east-2"      => "ami-0c13994a654111ecb",
-        "us-west-1"      => "ami-0b95d46a7f7393cfa",
-        "us-west-2"      => "ami-04b70685392d8e5f0",
-        "eu-west-1"      => "ami-04f10c2331981345c",
-        "eu-west-2"      => "ami-09f5dea513082ee2d",
-        "eu-west-3"      => "ami-0f6b3f7cab5176dfa",
-        "eu-central-1"      => "ami-09d19304808dbb7b7",
-        "ap-northeast-1"      => "ami-0b229fb8956ace6cd",
-        "ap-northeast-2"      => "ami-0fcabb6617e7d4c3d",
-        "ap-southeast-1"      => "ami-0c2c4abd6fda1df1d",
-        "ap-southeast-2"      => "ami-0310b7b3566b52ecc",
-        "ca-central-1"      => "ami-0409d6d4d6b5a102c",
-        "ap-south-1"      => "ami-0c0dc7872b44903a6",
-        "sa-east-1"      => "ami-059217a09c5b0126f",
+        "us-east-1"      => "ami-0c1f575380708aa63",
+        "us-east-2"      => "ami-015a2afe7e1a8af56",
+        "us-west-1"      => "ami-032a827d612b78a50",
+        "us-west-2"      => "ami-05edb14e89a5b98f3",
+        "eu-west-1"      => "ami-0489c3efb4fe85f5d",
+        "eu-west-2"      => "ami-037dd70536680c11f",
+        "eu-west-3"      => "ami-0182381900083ba64",
+        "eu-central-1"      => "ami-09509e8f8dea8ab83",
+        "ap-northeast-1"      => "ami-06ee72c3360fd7fad",
+        "ap-northeast-2"      => "ami-0cfc5eb79eceeeec9",
+        "ap-southeast-1"      => "ami-09dd721a797640468",
+        "ap-southeast-2"      => "ami-040bd2e2325535b3d",
+        "ca-central-1"      => "ami-0a06b44c462364156",
+        "ap-south-1"      => "ami-078902ae8103daac8",
+        "sa-east-1"      => "ami-05313c3a9e9148109",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0c94855ba95c71c99",
-        "us-east-2"      => "ami-0603cbe34fd08cb81",
-        "us-west-1"      => "ami-0e65ed16c9bf1abc7",
-        "us-west-2"      => "ami-01ce4793a2f45922e",
-        "eu-west-1"      => "ami-08a2aed6e0a6f9c7d",
-        "eu-west-2"      => "ami-09b89ad3c5769cca2",
-        "eu-west-3"      => "ami-0697b068b80d79421",
-        "eu-central-1"      => "ami-08c148bb835696b45",
-        "ap-northeast-1"      => "ami-0053d11f74e9e7f52",
-        "ap-northeast-2"      => "ami-064a198accc7e80e0",
-        "ap-southeast-1"      => "ami-0b1e534a4ff9019e0",
-        "ap-southeast-2"      => "ami-0099823645f06b6a1",
-        "ca-central-1"      => "ami-020caff809d5a5307",
-        "ap-south-1"      => "ami-09a7bbd08886aafdf",
-        "sa-east-1"      => "ami-013dd6e24f90aa93f",
+        "us-east-1"      => "ami-0947d2ba12ee1ff75",
+        "us-east-2"      => "ami-03657b56516ab7912",
+        "us-west-1"      => "ami-0e4035ae3f70c400f",
+        "us-west-2"      => "ami-0528a5175983e7f28",
+        "eu-west-1"      => "ami-0bb3fad3c0286ebd5",
+        "eu-west-2"      => "ami-0a669382ea0feb73a",
+        "eu-west-3"      => "ami-0de12f76efe134f2f",
+        "eu-central-1"      => "ami-00a205cb8e06c3c4e",
+        "ap-northeast-1"      => "ami-0ce107ae7af2e92b5",
+        "ap-northeast-2"      => "ami-03b42693dc6a7dc35",
+        "ap-southeast-1"      => "ami-015a6758451df3cb9",
+        "ap-southeast-2"      => "ami-0f96495a064477ffb",
+        "ca-central-1"      => "ami-0c2f25c1f66a1ff4d",
+        "ap-south-1"      => "ami-0e306788ff2473ccb",
+        "sa-east-1"      => "ami-02898a1921d38a50b",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
