### PR TITLE
Use IMDSv2

### DIFF
--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -20,9 +20,6 @@ module Barcelona
           j.HealthCheckType "EC2"
           j.LaunchConfigurationName ref("ContainerInstanceLaunchConfiguration")
           j.VPCZoneIdentifier [ref("SubnetTrusted1"), ref("SubnetTrusted2")]
-          j.MetadataOptions do |m|
-            m.HttpTokens 'required'
-          end
           j.Tags [
             {
               "Key" => "Name",

--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -20,6 +20,7 @@ module Barcelona
           j.HealthCheckType "EC2"
           j.LaunchConfigurationName ref("ContainerInstanceLaunchConfiguration")
           j.VPCZoneIdentifier [ref("SubnetTrusted1"), ref("SubnetTrusted2")]
+          j.DisableIMDSv1 true
           j.Tags [
             {
               "Key" => "Name",

--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -20,7 +20,9 @@ module Barcelona
           j.HealthCheckType "EC2"
           j.LaunchConfigurationName ref("ContainerInstanceLaunchConfiguration")
           j.VPCZoneIdentifier [ref("SubnetTrusted1"), ref("SubnetTrusted2")]
-          j.DisableIMDSv1 true
+          j.MetadataOption do |m|
+            m.HttpTokens 'required'
+          end
           j.Tags [
             {
               "Key" => "Name",

--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -20,7 +20,7 @@ module Barcelona
           j.HealthCheckType "EC2"
           j.LaunchConfigurationName ref("ContainerInstanceLaunchConfiguration")
           j.VPCZoneIdentifier [ref("SubnetTrusted1"), ref("SubnetTrusted2")]
-          j.MetadataOption do |m|
+          j.MetadataOptions do |m|
             m.HttpTokens 'required'
           end
           j.Tags [

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -36,7 +36,9 @@ module Barcelona
           j.SecurityGroups [ref("InstanceSecurityGroup")]
           j.UserData instance_user_data
           j.EbsOptimized ebs_optimized_by_default?
-          j.DisableIMDSv1 true
+          j.MetadataOption do |m|
+            m.HttpTokens 'required'
+          end
           j.BlockDeviceMappings [
             # Root volume
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2ami-storage-config.html

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -36,8 +36,8 @@ module Barcelona
           j.SecurityGroups [ref("InstanceSecurityGroup")]
           j.UserData instance_user_data
           j.EbsOptimized ebs_optimized_by_default?
-          j.BlockDeviceMappings [
           j.DisableIMDSv1 true
+          j.BlockDeviceMappings [
             # Root volume
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2ami-storage-config.html
             {

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -37,6 +37,7 @@ module Barcelona
           j.UserData instance_user_data
           j.EbsOptimized ebs_optimized_by_default?
           j.BlockDeviceMappings [
+          j.DisableIMDSv1 true
             # Root volume
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2ami-storage-config.html
             {

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -36,7 +36,7 @@ module Barcelona
           j.SecurityGroups [ref("InstanceSecurityGroup")]
           j.UserData instance_user_data
           j.EbsOptimized ebs_optimized_by_default?
-          j.MetadataOption do |m|
+          j.MetadataOptions do |m|
             m.HttpTokens 'required'
           end
           j.BlockDeviceMappings [

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -103,6 +103,9 @@ module Barcelona
           j.SecurityGroups [ref("SecurityGroupBastion")]
           j.AssociatePublicIpAddress true
           j.UserData user_data
+          j.MetadataOptions do |m|
+            m.HttpTokens 'required'
+          end
         end
 
         add_resource(BastionAutoScaling, "BastionAutoScaling",

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -140,10 +140,13 @@ module Barcelona
         EOS
 
         ud.run_commands += [
+          # imdsv2
+          'IMDSTOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 3600"`',
+
           # awslogs
-          "ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)",
+          'ec2_id=$(curl -H "X-aws-ec2-metadata-token: $IMDSTOKEN" -v http://169.254.169.254/latest/meta-data/instance-id)',
           # There are cases when we must wait for meta-data
-          'while [ "$ec2_id" = "" ]; do sleep 1 ; ec2_id=$(curl http://169.254.169.254/latest/meta-data/instance-id) ; done',
+          'while [ "$ec2_id" = "" ]; do sleep 1 ; ec2_id=$(curl -H "X-aws-ec2-metadata-token: $IMDSTOKEN" -v http://169.254.169.254/latest/meta-data/instance-id) ; done',
           'sed -i -e "s/{ec2_id}/$ec2_id/g" /etc/awslogs/awslogs.conf',
           'sed -i -e "s/us-east-1/'+district.region+'/g" /etc/awslogs/awscli.conf',
           "systemctl start awslogsd",

--- a/lib/barcelona/network/nat_builder.rb
+++ b/lib/barcelona/network/nat_builder.rb
@@ -53,6 +53,9 @@ module Barcelona
                 "GroupSet" => [ref("SecurityGroupNAT")]
               }
             ]
+            j.MetadataOptions do |m|
+              m.HttpTokens 'required'
+            end
             j.Tags [
               tag("barcelona", stack.district.name),
               tag("barcelona-role", "nat"),

--- a/lib/barcelona/plugins/datadog_logs_plugin.rb
+++ b/lib/barcelona/plugins/datadog_logs_plugin.rb
@@ -4,9 +4,12 @@ module Barcelona
       LOCAL_LOGGER_PORT = 514
       SYSTEM_PACKAGES = %w[rsyslog-gnutls ca-certificates]
       RUN_COMMANDS = [
+        # imdsv2
+        'IMDSTOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 3600"`',
+
         # set up hostname properly on the host so we don't end up identifying the host differently
         # and pay an extra 23 dollars for each phantom host that posts logs on datadog
-        'sed "s/{{HOSTNAME}}/`curl http://169.254.169.254/latest/meta-data/instance-id`/g" /etc/rsyslog.d/datadog.conf > temp' ,
+        'sed "s/{{HOSTNAME}}/`curl -H "X-aws-ec2-metadata-token: $IMDSTOKEN" -v http://169.254.169.254/latest/meta-data/instance-id`/g" /etc/rsyslog.d/datadog.conf > temp' ,
         'cp temp /etc/rsyslog.d/datadog.conf',
         'rm temp',
         "service rsyslog restart"

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -217,6 +217,9 @@ module Barcelona
               }
             },
           ]
+          j.MetadataOptions do |m|
+            m.HttpTokens 'required'
+          end
         end
 
         add_resource("AWS::IAM::Role", "OSSECManagerRole") do |j|

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -142,6 +142,7 @@ describe Barcelona::Network::NetworkStack do
           "IamInstanceProfile" => {"Ref"=>"ECSInstanceProfile"},
           "ImageId" => kind_of(String),
           "InstanceType" => "t3.small",
+          "MetadataOptions"=>{"HttpTokens"=>"required"},
           "SecurityGroups" => [{"Ref"=>"InstanceSecurityGroup"}],
           "UserData" => instance_of(String),
           "EbsOptimized" => true,
@@ -366,6 +367,7 @@ describe Barcelona::Network::NetworkStack do
         "Type" => "AWS::AutoScaling::LaunchConfiguration",
         "Properties" => {
           "InstanceType" => "t3.micro",
+          "MetadataOptions"=>{"HttpTokens"=>"required"},
           "IamInstanceProfile" => {"Ref" => "BastionProfile"},
           "ImageId" => kind_of(String),
           "UserData" => anything,


### PR DESCRIPTION
IMDSv1 usage in Barcelona poses an immense security risk to webapps which provide proxy and callback services that are deployed using Barcelona. This PR aims to remove the dependency on IMDSv1 and switch over to IMDSv2 for better security.

https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/

Fixes #625

# How to test (brand new)
1. Simply create a district `bcn district create --region ap-northeast-1 new-test-district`
2. Check out `git clone https://github.com/degica/barcelona-hello`
3. `cd barcelona-hello`
4. Create a barcelona endpoint `bcn endpoint create --public --district=<name> hello`
5. Create a service `bcn create -e hello -d <name>`
6. Check that your app is running properly. Use `bcn endpoint show hello -d new-test-district` to get the URL
7. Check that bastion is working by going `bcn run -e hello echo hello`

# How to test (updating an existing stack)
1. Set your barcelona to the master branch and create a district as above
2. Check out `git clone https://github.com/degica/barcelona-hello`
3. `cd barcelona-hello`
4. Create a barcelona endpoint `bcn endpoint create --public --district=<name> hello`
5. Create a service `bcn create -e hello -d <name>`
6. Check that your app is running properly. Use `bcn endpoint show hello -d new-test-district` to get the URL
7. Update to this branch
8. Run `bcn district update default`
9. Redeploy hello `bcn deploy -e hello -d <name>`
10. Check that your app continues to run properly. Use `bcn endpoint show hello -d new-test-district` to get the URL
11. Check that bastion is working by going `bcn run -e hello echo hello`