### PR TITLE
Set rails env to test in rspec

### DIFF
--- a/Kaiserfile
+++ b/Kaiserfile
@@ -24,6 +24,7 @@ app_params "
 "
 
 attach_mount '.rspec', '/app/.rspec'
+attach_mount 'bin', '/app/bin'
 attach_mount 'app', '/app/app'
 attach_mount 'config', '/app/config'
 attach_mount 'db', '/app/db'

--- a/bin/rspec
+++ b/bin/rspec
@@ -12,6 +12,8 @@ require "pathname"
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile",
   Pathname.new(__FILE__).realpath)
 
+ENV['RAILS_ENV'] = 'test'
+
 bundle_binstub = File.expand_path("../bundle", __FILE__)
 
 if File.file?(bundle_binstub)


### PR DESCRIPTION
Before this you had to always go `RAILS_ENV=test rspec`. This was annoying. This PR solves this.

## How to test

1. `kaiser up -av bash`
2. `rspec`