### PR TITLE
Enable honeybadger reporting if API key is present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'gibberish'
 gem 'octokit'
 gem 'delayed_job_active_record'
 gem 'pundit'
+gem 'honeybadger', require: false
 gem 'jbuilder'
 gem 'lograge'
 gem 'net-ssh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (0.3.8)
+    honeybadger (4.7.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -322,6 +323,7 @@ DEPENDENCIES
   delayed_job_active_record
   factory_bot_rails
   gibberish
+  honeybadger
   jbuilder
   lograge
   net-ssh

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -1,0 +1,8 @@
+# Enable error reporting with Honeybadger if API key is present
+if ENV['HONEYBADGER_API_KEY']
+  require 'honeybadger'
+
+  Honeybadger.configure do |config|
+    config.api_key = ENV['HONEYBADGER_API_KEY']
+  end
+end


### PR DESCRIPTION
## Context

This pull requests allows `HONEYBADGER_API_KEY` to enable error reporting with Honeybadger.
This is a nice service to see errors in real-time so they can be debugged.