### PR TITLE
Update AMI of container and bastion instances to 2.0.20201119

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-09bee01cc997a78a6",
-        "us-east-2"      => "ami-0a9e12068cb98a01d",
-        "us-west-1"      => "ami-0fa6c8d131a220017",
-        "us-west-2"      => "ami-078c97cf1cefd1b38",
-        "eu-west-1"      => "ami-0c9ef930279337028",
-        "eu-west-2"      => "ami-0ce75da72db51b0f0",
-        "eu-west-3"      => "ami-015011bcdf1c3377a",
-        "eu-central-1"      => "ami-065c1e34da68f2b02",
-        "ap-northeast-1"      => "ami-02265963d1614d04d",
-        "ap-northeast-2"      => "ami-043f04a0533062573",
-        "ap-southeast-1"      => "ami-0b68661b29b9e058c",
-        "ap-southeast-2"      => "ami-00e4b147599c13588",
-        "ca-central-1"      => "ami-0223c41fb4b45f725",
-        "ap-south-1"      => "ami-0fa0107c4a8501039",
-        "sa-east-1"      => "ami-0e598e30f638c5363",
+        "us-east-1"      => "ami-043379e71bae59340",
+        "us-east-2"      => "ami-0113274b3600af1c2",
+        "us-west-1"      => "ami-017aaad1ac60aa475",
+        "us-west-2"      => "ami-0ba2327c56d53a8b3",
+        "eu-west-1"      => "ami-0f1a52b671e1360ac",
+        "eu-west-2"      => "ami-04e2f94ab8e78c976",
+        "eu-west-3"      => "ami-0dcb47a4d518e93d8",
+        "eu-central-1"      => "ami-0b7f40a0eabbcc8c0",
+        "ap-northeast-1"      => "ami-0ba238c6cfa8b1e42",
+        "ap-northeast-2"      => "ami-06a4a71a432620e4f",
+        "ap-southeast-1"      => "ami-0ac503285978338fd",
+        "ap-southeast-2"      => "ami-080c1cc5c78678da8",
+        "ca-central-1"      => "ami-0cf17f0044e469eed",
+        "ap-south-1"      => "ami-0844bb36a50579972",
+        "sa-east-1"      => "ami-0867306c666062040",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0947d2ba12ee1ff75",
-        "us-east-2"      => "ami-03657b56516ab7912",
-        "us-west-1"      => "ami-0e4035ae3f70c400f",
-        "us-west-2"      => "ami-0528a5175983e7f28",
-        "eu-west-1"      => "ami-0bb3fad3c0286ebd5",
-        "eu-west-2"      => "ami-0a669382ea0feb73a",
-        "eu-west-3"      => "ami-0de12f76efe134f2f",
-        "eu-central-1"      => "ami-00a205cb8e06c3c4e",
-        "ap-northeast-1"      => "ami-0ce107ae7af2e92b5",
-        "ap-northeast-2"      => "ami-03b42693dc6a7dc35",
-        "ap-southeast-1"      => "ami-015a6758451df3cb9",
-        "ap-southeast-2"      => "ami-0f96495a064477ffb",
-        "ca-central-1"      => "ami-0c2f25c1f66a1ff4d",
-        "ap-south-1"      => "ami-0e306788ff2473ccb",
-        "sa-east-1"      => "ami-02898a1921d38a50b",
+        "us-east-1"      => "ami-04d29b6f966df1537",
+        "us-east-2"      => "ami-09558250a3419e7d0",
+        "us-west-1"      => "ami-08d9a394ac1c2994c",
+        "us-west-2"      => "ami-0e472933a1395e172",
+        "eu-west-1"      => "ami-0ce1e3f77cd41957e",
+        "eu-west-2"      => "ami-08b993f76f42c3e2f",
+        "eu-west-3"      => "ami-0e9c91a3fc56a0376",
+        "eu-central-1"      => "ami-0bd39c806c2335b95",
+        "ap-northeast-1"      => "ami-00f045aed21a55240",
+        "ap-northeast-2"      => "ami-03461b78fdba0ff9d",
+        "ap-southeast-1"      => "ami-0d728fd4e52be968f",
+        "ap-southeast-2"      => "ami-09f765d333a8ebb4b",
+        "ca-central-1"      => "ami-0fca0f98dc87d39df",
+        "ap-south-1"      => "ami-08f63db601b82ff5f",
+        "sa-east-1"      => "ami-0096398577720a4a3",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
