### PR TITLE
Exclude variables that exist in new environment

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -317,14 +317,16 @@ class Heritage < ActiveRecord::Base
   end
 
   def environment_set
-    legacy_env_vars = env_vars.where(secret: false).map { |e| [e.key, e.value] }.to_h
+    legacy_env_vars = env_vars.where(secret: false).
+                               where.not(key: environments.pluck(:name)).
+                               map { |e| [e.key, e.value] }.to_h
     envs = environments.plains.map { |e| [e.name, e.value] }.to_h
     union = legacy_env_vars.merge(envs)
     union.map { |k, v| {name: k, value: v} }
   end
 
   def legacy_secrets
-    env_vars.where(secret: true).where.not(key: environments.secrets.pluck(:name))
+    env_vars.where(secret: true).where.not(key: environments.pluck(:name))
   end
 
   def review?

--- a/spec/models/heritage_spec.rb
+++ b/spec/models/heritage_spec.rb
@@ -97,16 +97,11 @@ describe Heritage do
       it { is_expected.to eq ["env2"] }
     end
 
-    context "when there are legacy secret env var and plain environment with the same name" do
-      before do
+    it "doesn't have env when there are legacy secret env var and plain environment with the same name" do
         heritage.env_vars.create!(key: "env", value: "abc", secret: true)
         heritage.environments.create!(name: "env", value: "value")
-      end
-
-      it "doesn't have env" do
         expect(subject).to_not include "env"
         expect(heritage.environment_set.map{|h| h[:name]}).to include "env"
-      end
     end
   end
 end

--- a/spec/models/heritage_spec.rb
+++ b/spec/models/heritage_spec.rb
@@ -65,6 +65,17 @@ describe Heritage do
                               {name: "env2", value: "value2"},
                               {name: "env3", value: "value3"}]}
     end
+
+    context "when plain env_var and secret environment exist with the same name" do
+      before do
+        heritage.env_vars.create!(key: "env", value: "value", secret: false)
+        heritage.environments.create!(name: "env", value_from: "path/to/ssm")
+      end
+
+      it "doesn't have env" do
+        expect(subject.map{|h| h[:name]}).to_not include "env"
+      end
+    end
   end
 
   describe "#legacy_secrets" do
@@ -89,6 +100,18 @@ describe Heritage do
       end
 
       it { is_expected.to eq ["env2"] }
+    end
+
+    context "when there are legacy secret env var and plain environment with the same name" do
+      before do
+        heritage.env_vars.create!(key: "env", value: "abc", secret: true)
+        heritage.environments.create!(name: "env", value: "value")
+      end
+
+      it "doesn't have env" do
+        expect(subject).to_not include "env"
+        expect(heritage.environment_set.map{|h| h[:name]}).to include "env"
+      end
     end
   end
 end

--- a/spec/models/heritage_spec.rb
+++ b/spec/models/heritage_spec.rb
@@ -66,15 +66,10 @@ describe Heritage do
                               {name: "env3", value: "value3"}]}
     end
 
-    context "when plain env_var and secret environment exist with the same name" do
-      before do
+    it "doesn't have env when plain env_var and secret environment exist with the same name" do
         heritage.env_vars.create!(key: "env", value: "value", secret: false)
         heritage.environments.create!(name: "env", value_from: "path/to/ssm")
-      end
-
-      it "doesn't have env" do
         expect(subject.map{|h| h[:name]}).to_not include "env"
-      end
     end
   end
 


### PR DESCRIPTION
Consider the following case:

### Case 1

- non-secret env var `VARIABLE` exists as a legacy `EnvVar`
- secret environment `VARIABLE` exists in `environment`

### Case 2

- secret env_var `VARIABLE` exists as a legacy `EnvVar`
- non-secret environment `VARIABLE` exists in environment
- 
With these cases Barcelona adds `VARIABLE` to both `Environment` and `Secrets` of task definition.

This PR solves the above issue by removing legacy environment variables that also exist in `environment`