### PR TITLE
Set correct value/value_from on update

### DIFF
--- a/app/models/environment.rb
+++ b/app/models/environment.rb
@@ -9,7 +9,12 @@ class Environment < ApplicationRecord
   validates :value, presence: true, if: -> { value_from.blank? }
   validates :value_from, presence: true, if: -> { value.blank? }
 
-  attr_accessor :ssm_path
+  attr_reader :ssm_path
+
+  def ssm_path=(val)
+    attribute_will_change!(:value_from)
+    @ssm_path = val
+  end
 
   before_validation do
     if ssm_path
@@ -17,6 +22,19 @@ class Environment < ApplicationRecord
       s = "/" + ssm_path unless ssm_path.start_with?("/")
       s = "/barcelona/#{district.name}" + s unless s.start_with?("/barcelona/#{district.name}")
       self.value_from = s
+    end
+  end
+
+  before_validation :cleanup_old_value
+
+  # value and value_from are exlusive. Only one of those can be non-null
+  def cleanup_old_value
+    if will_save_change_to_attribute?(:value) && !value.nil?
+      self.value_from = nil
+    end
+
+    if will_save_change_to_attribute?(:value_from) && !value_from.nil?
+      self.value = nil
     end
   end
 end

--- a/spec/models/environment_spec.rb
+++ b/spec/models/environment_spec.rb
@@ -1,17 +1,44 @@
 require "rails_helper"
 
 describe Environment do
-  describe "#ssm_path" do
-    let(:heritage) { create :heritage }
+  let(:heritage) { create :heritage }
 
+  describe "validations" do
+    it "value wins if both value and value_from are set" do
+      env = Environment.create!(heritage: heritage, name: "ENV", value: "raw value", ssm_path: "/path/to/secret")
+      expect(env.value).to eq "raw value"
+      expect(env.value_from).to eq nil
+    end
+
+    it "nullify value_from when value is set while value_from exists" do
+      env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "/path/to/secret")
+      env.update!(value: "raw value")
+
+      expect(env.value).to eq "raw value"
+      expect(env.value_from).to eq nil
+    end
+
+    it "nullify value_from when value is set while value_from exists" do
+      env = Environment.create!(heritage: heritage, name: "ENV", value: "raw value")
+      env.update!(ssm_path: "path/to/secret")
+
+      expect(env.value).to eq nil
+      expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/path/to/secret"
+    end
+  end
+
+  describe "#ssm_path" do
     it "generates value_from" do
       env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "/path/to/secret")
+      expect(env.value).to eq nil
       expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/path/to/secret"
     end
 
-    it "generates value_from" do
-      env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "path/to/secret")
-      expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/path/to/secret"
+    it "updates value_from" do
+      env = Environment.create!(heritage: heritage, name: "ENV", ssm_path: "/path/to/secret")
+      env.update!(ssm_path: "new/path")
+      expect(env.value).to eq nil
+      expect(env.value_from).to eq "/barcelona/#{heritage.district.name}/new/path"
     end
   end
 end


### PR DESCRIPTION
## Problem

Currently converting raw value environment to secret doesn't work.

Let's say we have the following raw environment:

```
environment:
  - name: SOME_ENV
    value: "some value"
```

and we want to change the environment to secret:

```
environment:
  - name: SOME_ENV
    ssm_path: "path/to/ssm"
```

This update is ignored. the raw "some value" is kept using. The opposite case (`ssm_path` -> `value`) also doesn't work.

This PR fixes the above issue.