### PR TITLE
Fix validation error with valid vault token

### DIFF
--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -15,7 +15,7 @@ class VaultAuth < Auth
     @current_user = User.find_by_token(vault_token)
 
     if @current_user.nil?
-      user = User.new(name: username)
+      user = User.find_or_create_by(name: username)
       user.auth = 'vault'
       user.token = vault_token
       user.roles = []

--- a/spec/auth/vault_auth_spec.rb
+++ b/spec/auth/vault_auth_spec.rb
@@ -84,6 +84,21 @@ describe VaultAuth do
 
       expect(auth.authenticate).to be_persisted
     end
+
+    it 'updates the token if the user already exists' do
+      allow(auth).to receive(:username) { 'someuniquename' }
+
+      u = User.create!(
+        name: 'someuniquename',
+        auth: 'vault',
+        token: 'defg', # instead of abcd
+        roles: []
+      )
+
+      expect(auth.authenticate.name).to eq 'someuniquename'
+      expect(auth.authenticate.token).to eq 'abcd'
+    end
+
   end
 
   describe "#login" do


### PR DESCRIPTION
A small oversight led to users not being able to re-login after the first time. This PR fixes it.

## How to test
1. Login with vault
2. Login again
3. Observe that errors don't come up