### PR TITLE
Fix barcelona deploys failing sometimes

### DIFF
--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -67,6 +67,7 @@ module CloudFormation
       })
       Rails.logger.info resp
 
+      sleep(5)
       begin
         @s3_client.wait_until(:object_exists, params, 
           before_wait: -> (attempts, response) do

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -8,6 +8,8 @@ module CloudFormation
       @client = district.aws.cloudformation
       @s3_client = district.aws.s3
       @bucket = district.s3_bucket_name
+
+      upload_to_s3!
     end
 
     def describe
@@ -68,7 +70,7 @@ module CloudFormation
       Rails.logger.info resp
 
       Rails.logger.info "Waiting for stack template to be uploaded"
-      sleep(5)
+      sleep(30)
       begin
         @s3_client.wait_until(:object_exists, params, 
           before_wait: -> (attempts, response) do
@@ -84,7 +86,6 @@ module CloudFormation
     end
 
     def stack_options
-      upload_to_s3!
       {
         stack_name: stack.name,
         capabilities: ["CAPABILITY_IAM"],

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -51,11 +51,7 @@ module CloudFormation
       client.create_change_set(options)
     end
 
-    def template_name
-      @template_name ||= "stack_templates/#{stack.name}/#{Time.current.strftime("%Y-%m-%d-%H%M%S")}.template"
-    end
-
-    def upload_to_s3!
+    def upload_to_s3!(template_name)
       params = {
         bucket: @bucket,
         key: template_name,
@@ -83,7 +79,8 @@ module CloudFormation
     end
 
     def stack_options
-      upload_to_s3!
+      template_name = "stack_templates/#{stack.name}/#{Time.current.strftime("%Y-%m-%d-%H%M%S")}.template"
+      upload_to_s3!(template_name)
       {
         stack_name: stack.name,
         capabilities: ["CAPABILITY_IAM"],

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -67,6 +67,7 @@ module CloudFormation
       })
       Rails.logger.info resp
 
+      Rails.logger.info "Waiting for stack template to be uploaded"
       sleep(5)
       begin
         @s3_client.wait_until(:object_exists, params, 

--- a/lib/cloud_formation/stack.rb
+++ b/lib/cloud_formation/stack.rb
@@ -29,6 +29,10 @@ module CloudFormation
       end
     end
 
+    def region
+      @options[:region]
+    end
+
     def build_parameters(json)
     end
 

--- a/spec/lib/cloud_formation/executor_spec.rb
+++ b/spec/lib/cloud_formation/executor_spec.rb
@@ -25,7 +25,7 @@ describe CloudFormation::Executor do
       executor.update(change_set: false)
     end
 
-    it "creates a change set if true" do
+    it "passes on any failures from s3 wait" do
       expect(s3).to receive(:put_object)
       expect(s3).to receive(:wait_until).with(:object_exists, anything, anything) do
         raise Aws::Waiters::Errors::WaiterFailed

--- a/spec/lib/cloud_formation/executor_spec.rb
+++ b/spec/lib/cloud_formation/executor_spec.rb
@@ -35,5 +35,15 @@ describe CloudFormation::Executor do
       expect(Rails.logger).to receive(:warn).with("Upload failed: Aws::Waiters::Errors::WaiterFailed")
       expect { executor.update(change_set: true) }.to raise_error Aws::Waiters::Errors::WaiterFailed
     end
+
+    it "has template name that is not time dependent (regression)" do
+      expect(executor).to receive(:stack) { double(name: 'foobar') }
+      travel_to DateTime.new(2017, 7, 7)
+      expect(executor.template_name).to eq "stack_templates/foobar/2017-07-07-000000.template"
+      travel_back
+      travel_to DateTime.new(2019, 9, 9)
+      expect(executor.template_name).to eq "stack_templates/foobar/2017-07-07-000000.template"
+      travel_back
+    end
   end
 end

--- a/spec/lib/cloud_formation/executor_spec.rb
+++ b/spec/lib/cloud_formation/executor_spec.rb
@@ -35,15 +35,5 @@ describe CloudFormation::Executor do
       expect(Rails.logger).to receive(:warn).with("Upload failed: Aws::Waiters::Errors::WaiterFailed")
       expect { executor.update(change_set: true) }.to raise_error Aws::Waiters::Errors::WaiterFailed
     end
-
-    it "has template name that is not time dependent (regression)" do
-      expect(executor).to receive(:stack) { double(name: 'foobar') }
-      travel_to DateTime.new(2017, 7, 7)
-      expect(executor.template_name).to eq "stack_templates/foobar/2017-07-07-000000.template"
-      travel_back
-      travel_to DateTime.new(2019, 9, 9)
-      expect(executor.template_name).to eq "stack_templates/foobar/2017-07-07-000000.template"
-      travel_back
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.include FactoryBot::Syntax::Methods
   config.include StubEnv::Helpers
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Shoulda matchers
   config.include(Shoulda::Matchers::ActiveModel, type: :model)


### PR DESCRIPTION
~This PR introduces a wait after put object as a way to ensure that S3 has updated and made the object we just placed available.~

Turns out it was a method that should have been memoized but was not.

Fixes #650 

# How to test
This is one of those bugs that happens only occasionally due S3's behavior so this is difficult to reproduce. The normal path however, should not be any different.

1. Deploy an application
2. Check that it successfully deployed
