### PR TITLE
Fix internal server error

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -9,7 +9,7 @@ class DeployRunnerJob < ActiveJob::Base
     @heritage = heritage
     heritage.with_lock do
       if other_deploy_in_progress?(heritage)
-        notify(heritage, level: :error, message: "The other deployment is in progress. Stopped deploying.")
+        notify(level: :error, message: "The other deployment is in progress. Stopped deploying.")
         return
       end
 

--- a/spec/jobs/deploy_runner_job_spec.rb
+++ b/spec/jobs/deploy_runner_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe DeployRunnerJob, type: :job do
+  it 'creates an event if another deploy is in progress' do
+    job = DeployRunnerJob.new
+
+    district_object = create :district
+    heritage = create :heritage, district: district_object
+    allow(job).to receive(:other_deploy_in_progress?) { true }
+
+    event_object = double("Event")
+    expect(event_object).to receive(:notify)
+
+    expect(Event).to receive(:new).with(district_object) { event_object }
+
+    job.perform(heritage, without_before_deploy: true, description: "meow")
+  end
+end


### PR DESCRIPTION
## Context

For a while now when you attempted to deploy a currently deploying stack, Barcelona would inexplicably return `internal_server_error`. After investigating the logs it turned out that a change was made in the past to remove the `heritage` parameter on `DeployRunnerJob#notify`, but one line of code was not updated. This PR fixes that and tests that code branch.
