### PR TITLE
Update AMI of container and bastion instances to 2.0.20210202

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0128839b21d19300e",
-        "us-east-2"      => "ami-0583ca2f3ce809fcb",
-        "us-west-1"      => "ami-0ac6a4a6e7e0949c4",
-        "us-west-2"      => "ami-030c9d6616d98227e",
-        "eu-west-1"      => "ami-0383e6ac19943cf6a",
-        "eu-west-2"      => "ami-0491c71e39d336e96",
-        "eu-west-3"      => "ami-06068eac7923b976b",
-        "eu-central-1"      => "ami-039bcbdcc961c4e81",
-        "ap-northeast-1"      => "ami-08c834e58473d808d",
-        "ap-northeast-2"      => "ami-0c0c0b030baf86093",
-        "ap-southeast-1"      => "ami-0791c84a135845cef",
-        "ap-southeast-2"      => "ami-0579b3efbc3a6c3e2",
-        "ca-central-1"      => "ami-0d0785328bd0eb34a",
-        "ap-south-1"      => "ami-01ab67467126a45fb",
-        "sa-east-1"      => "ami-0a339e14c13e704df",
+        "us-east-1"      => "ami-0e5b37ba2c8e7cc82",
+        "us-east-2"      => "ami-09c93f5e8e4b50e05",
+        "us-west-1"      => "ami-0306f5737181bb754",
+        "us-west-2"      => "ami-0927d80c641f8d8bb",
+        "eu-west-1"      => "ami-0c15700b4e6bf474e",
+        "eu-west-2"      => "ami-0f82969826859fb14",
+        "eu-west-3"      => "ami-0b2b26f34eb9f6482",
+        "eu-central-1"      => "ami-0f8ee411ba3a66276",
+        "ap-northeast-1"      => "ami-08aba6714243b1bf9",
+        "ap-northeast-2"      => "ami-0d9ea717f56829882",
+        "ap-southeast-1"      => "ami-093df4839e8df694e",
+        "ap-southeast-2"      => "ami-0122a3618e52b6418",
+        "ca-central-1"      => "ami-0c9bfd3e97bd089e9",
+        "ap-south-1"      => "ami-08fcbb6bcfbc5ced8",
+        "sa-east-1"      => "ami-0e32d15591985c079",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-04d29b6f966df1537",
-        "us-east-2"      => "ami-09558250a3419e7d0",
-        "us-west-1"      => "ami-08d9a394ac1c2994c",
-        "us-west-2"      => "ami-0e472933a1395e172",
-        "eu-west-1"      => "ami-0ce1e3f77cd41957e",
-        "eu-west-2"      => "ami-08b993f76f42c3e2f",
-        "eu-west-3"      => "ami-0e9c91a3fc56a0376",
-        "eu-central-1"      => "ami-0bd39c806c2335b95",
-        "ap-northeast-1"      => "ami-00f045aed21a55240",
-        "ap-northeast-2"      => "ami-03461b78fdba0ff9d",
-        "ap-southeast-1"      => "ami-0d728fd4e52be968f",
-        "ap-southeast-2"      => "ami-09f765d333a8ebb4b",
-        "ca-central-1"      => "ami-0fca0f98dc87d39df",
-        "ap-south-1"      => "ami-08f63db601b82ff5f",
-        "sa-east-1"      => "ami-0096398577720a4a3",
+        "us-east-1"      => "ami-047a51fa27710816e",
+        "us-east-2"      => "ami-01aab85a5e4a5a0fe",
+        "us-west-1"      => "ami-005c06c6de69aee84",
+        "us-west-2"      => "ami-0e999cbd62129e3b1",
+        "eu-west-1"      => "ami-0fc970315c2d38f01",
+        "eu-west-2"      => "ami-098828924dc89ea4a",
+        "eu-west-3"      => "ami-0ea4a063871686f37",
+        "eu-central-1"      => "ami-0a6dc7529cd559185",
+        "ap-northeast-1"      => "ami-0992fc94ca0f1415a",
+        "ap-northeast-2"      => "ami-09282971cf2faa4c9",
+        "ap-southeast-1"      => "ami-0e2e44c03b85f58b3",
+        "ap-southeast-2"      => "ami-04f77aa5970939148",
+        "ca-central-1"      => "ami-075cfad2d9805c5f2",
+        "ap-south-1"      => "ami-08e0ca9924195beba",
+        "sa-east-1"      => "ami-089aac6323aa08aee",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
