### PR TITLE
Update AMI of container and bastion instances to 2.0.20210301

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0e5b37ba2c8e7cc82",
-        "us-east-2"      => "ami-09c93f5e8e4b50e05",
-        "us-west-1"      => "ami-0306f5737181bb754",
-        "us-west-2"      => "ami-0927d80c641f8d8bb",
-        "eu-west-1"      => "ami-0c15700b4e6bf474e",
-        "eu-west-2"      => "ami-0f82969826859fb14",
-        "eu-west-3"      => "ami-0b2b26f34eb9f6482",
-        "eu-central-1"      => "ami-0f8ee411ba3a66276",
-        "ap-northeast-1"      => "ami-08aba6714243b1bf9",
-        "ap-northeast-2"      => "ami-0d9ea717f56829882",
-        "ap-southeast-1"      => "ami-093df4839e8df694e",
-        "ap-southeast-2"      => "ami-0122a3618e52b6418",
-        "ca-central-1"      => "ami-0c9bfd3e97bd089e9",
-        "ap-south-1"      => "ami-08fcbb6bcfbc5ced8",
-        "sa-east-1"      => "ami-0e32d15591985c079",
+        "us-east-1"      => "ami-0ec7896dee795dfa9",
+        "us-east-2"      => "ami-02ef98ccecbf47e86",
+        "us-west-1"      => "ami-0c95b81c98a196de2",
+        "us-west-2"      => "ami-006d48b829793b507",
+        "eu-west-1"      => "ami-0cdce788baec293cb",
+        "eu-west-2"      => "ami-0a7f94d6f878fdd02",
+        "eu-west-3"      => "ami-08b42a2167e4c521f",
+        "eu-central-1"      => "ami-027d55743533d8658",
+        "ap-northeast-1"      => "ami-0ee0c841e0940c58f",
+        "ap-northeast-2"      => "ami-098340641fcc77afb",
+        "ap-southeast-1"      => "ami-002281dd675dedcbf",
+        "ap-southeast-2"      => "ami-016f6cf165ef55d02",
+        "ca-central-1"      => "ami-0cde1f5ee149df291",
+        "ap-south-1"      => "ami-018ae918c152249f0",
+        "sa-east-1"      => "ami-02b0be10b5499d608",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-047a51fa27710816e",
-        "us-east-2"      => "ami-01aab85a5e4a5a0fe",
-        "us-west-1"      => "ami-005c06c6de69aee84",
-        "us-west-2"      => "ami-0e999cbd62129e3b1",
-        "eu-west-1"      => "ami-0fc970315c2d38f01",
-        "eu-west-2"      => "ami-098828924dc89ea4a",
-        "eu-west-3"      => "ami-0ea4a063871686f37",
-        "eu-central-1"      => "ami-0a6dc7529cd559185",
-        "ap-northeast-1"      => "ami-0992fc94ca0f1415a",
-        "ap-northeast-2"      => "ami-09282971cf2faa4c9",
-        "ap-southeast-1"      => "ami-0e2e44c03b85f58b3",
-        "ap-southeast-2"      => "ami-04f77aa5970939148",
-        "ca-central-1"      => "ami-075cfad2d9805c5f2",
-        "ap-south-1"      => "ami-08e0ca9924195beba",
-        "sa-east-1"      => "ami-089aac6323aa08aee",
+        "us-east-1"      => "ami-0915bcb5fa77e4892",
+        "us-east-2"      => "ami-09246ddb00c7c4fef",
+        "us-west-1"      => "ami-066c82dabe6dd7f73",
+        "us-west-2"      => "ami-09c5e030f74651050",
+        "eu-west-1"      => "ami-096f43ef67d75e998",
+        "eu-west-2"      => "ami-0ffd774e02309201f",
+        "eu-west-3"      => "ami-0ec28fc9814fce254",
+        "eu-central-1"      => "ami-02f9ea74050d6f812",
+        "ap-northeast-1"      => "ami-09d28faae2e9e7138",
+        "ap-northeast-2"      => "ami-006e2f9fa7597680a",
+        "ap-southeast-1"      => "ami-0d06583a13678c938",
+        "ap-southeast-2"      => "ami-075a72b1992cb0687",
+        "ca-central-1"      => "ami-0df612970f825f04c",
+        "ap-south-1"      => "ami-0eeb03e72075b9bcc",
+        "sa-east-1"      => "ami-0a0bc0fa94d632c94",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
