### PR TITLE
fix that endpoint names are global

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -121,7 +121,7 @@ class Endpoint < ActiveRecord::Base
 
   validates :name,
             presence: true,
-            uniqueness: true,
+            uniqueness: { scope: :district },
             immutable: true,
             format: { with: /\A[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]\z/ }
   validates :public, immutable: true

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -15,10 +15,20 @@ describe Endpoint do
       endpoint.save!
     end
 
-    it "deltes cloudformation stack" do
+    it "deletes cloudformation stack" do
       endpoint.save!
       expect_any_instance_of(CloudFormation::Executor).to receive(:delete)
       endpoint.destroy!
+    end
+  end
+
+  describe "#validations" do
+    it "name should be unique in district" do
+      endpoint.save!
+      endpoint2 = build(:endpoint, district: endpoint.district, name:endpoint.name)
+
+      expect(endpoint2).to_not be_valid
+      expect(endpoint2.errors.messages[:name]).to eq ['has already been taken']
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/degica/barcelona/issues/616

If you create an endpoint named A in district 1, you cant make an endpoint named A in district 2, even though there is no reason you shouldn't be able to.

How to test
I think looking at the test should be ok

