### PR TITLE
throw error if heritage name already exits

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -12,6 +12,10 @@ class HeritagesController < ApplicationController
   end
 
   def create
+    if Heritage.find_by(name: params[:name]).present?
+      raise ExceptionHandler::InternalServerError.new("heritage name is already used ")
+    end
+
     @heritage = BuildHeritage.new(permitted_params, district: @district).execute
     @heritage.save_and_deploy!(without_before_deploy: true, description: "Create")
     render json: @heritage

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -99,6 +99,15 @@ describe "POST /districts/:district/heritages", type: :request do
     context "when version is 1" do
       let(:version) { 1 }
       it_behaves_like "create"
+
+      it "throw error when heritage name is already used" do
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+
+        # create same name heritage
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 500
+        expect(JSON.parse(response.body)["error"]).to eq "heritage name is already used "
+      end
     end
 
     context "when version is 2" do


### PR DESCRIPTION
Part of https://github.com/degica/barcelona/issues/617

Currently you can do

If you have district A and district B, it is possible to go

```
bcn create -e prod -d A
```

and then go

```
bcn create -e prod -d B
```

For now we need to prevent heritages of the same name created from being created.

### Note
Originally, I tried to do this inside BuildHeritage class, but the BuildHeritage class is also used in the reviewApp, and is used in both the create and find. So, I decided to handle it in the controller.