### PR TITLE
Fix that endpoint names are global

### DIFF
--- a/app/controllers/endpoints_controller.rb
+++ b/app/controllers/endpoints_controller.rb
@@ -8,12 +8,12 @@ class EndpointsController < ApplicationController
   end
 
   def create
-    endpoint = @district.endpoints.create!(permitted_params)
+    endpoint = @district.endpoints.create!(create_params)
     render json: endpoint
   end
 
   def update
-    @endpoint.update!(permitted_params)
+    @endpoint.update!(update_params)
     render json: @endpoint
   end
 
@@ -28,7 +28,9 @@ class EndpointsController < ApplicationController
 
   private
 
-  def permitted_params
+  def create_params
+    params[:name] =  name_prefix + params[:name]
+
     params.permit(
       :name,
       :public,
@@ -37,11 +39,26 @@ class EndpointsController < ApplicationController
     )
   end
 
+  def update_params
+    params.permit(
+      :certificate_id,
+      :ssl_policy
+    )
+  end
+
   def load_endpoint
-    @endpoint = @district.endpoints.find_by!(name: params[:id])
+    @endpoint = @district.endpoints.find_by(name: params[:id])
+    unless @endpoint.present?
+      @endpoint = @district.endpoints.find_by!(name: name_prefix + params[:id])
+    end
+    @endpoint
   end
 
   def load_district
     @district = District.find_by!(name: params[:district_id])
+  end
+
+  def name_prefix
+    "#{@district.name}-"
   end
 end

--- a/app/services/build_heritage.rb
+++ b/app/services/build_heritage.rb
@@ -17,15 +17,9 @@ class BuildHeritage
 
         unless service[:listeners].nil?
           endpoint_names = service[:listeners].map { |e| e[:endpoint] }
-
-          endpoints = if @district.present?
-            Endpoint.where(name: endpoint_names, district: @district).pluck(:name, :id)
-          else
-            Endpoint.where(name: endpoint_names).pluck(:name, :id)
-          end
+          endpoints = Endpoint.where(name: endpoint_names, district: @district).pluck(:name, :id)
 
           listener_map = Hash[endpoints]
-
           service[:listeners_attributes] = service.delete(:listeners).map do |listener|
             {
               endpoint_id: listener_map[listener[:endpoint]],

--- a/spec/requests/create_endpoint_spec.rb
+++ b/spec/requests/create_endpoint_spec.rb
@@ -50,25 +50,5 @@ describe "POST /districts/:district/endpoints", type: :request do
       expect(endpoint["ssl_policy"]).to eq 'modern'
       expect(endpoint["dns_name"]).to eq "dns.name"
     end
-
-    it "it should failed if the endpoint name is same" do
-      allow_any_instance_of(CloudFormation::Executor).to receive(:outputs) {
-        {"DNSName" => "dns.name"}
-      }
-
-      district = create :district, name: "staging"
-      district.endpoints.create(name: "staging-blue-green")
-      district2 = create :district, name: "staging-blue"
-
-      params = {
-        name: "green",
-        public: true,
-        ssl_policy: 'modern',
-        certificate_id: 'certificate_id'
-      }
-
-      api_request(:post, "/v1/districts/#{district2.name}/endpoints", params)
-      expect(response.status).to eq 422
-    end
   end
 end

--- a/spec/requests/create_endpoint_spec.rb
+++ b/spec/requests/create_endpoint_spec.rb
@@ -50,5 +50,25 @@ describe "POST /districts/:district/endpoints", type: :request do
       expect(endpoint["ssl_policy"]).to eq 'modern'
       expect(endpoint["dns_name"]).to eq "dns.name"
     end
+
+    it "it should failed if the endpoint name is same" do
+      allow_any_instance_of(CloudFormation::Executor).to receive(:outputs) {
+        {"DNSName" => "dns.name"}
+      }
+
+      district = create :district, name: "staging"
+      district.endpoints.create(name: "staging-blue-green")
+      district2 = create :district, name: "staging-blue"
+
+      params = {
+        name: "green",
+        public: true,
+        ssl_policy: 'modern',
+        certificate_id: 'certificate_id'
+      }
+
+      api_request(:post, "/v1/districts/#{district2.name}/endpoints", params)
+      expect(response.status).to eq 422
+    end
   end
 end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -122,7 +122,7 @@ describe "POST /districts/:district/heritages", type: :request do
       end
     end
 
-    context "when existing endpoint exists" do
+    context "when an existing endpoint exists" do
       let(:version) { 1 }
       let(:district) { create :district}
       let(:district2) { create :district, name: "staging-blue" }

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -115,8 +115,23 @@ describe "POST /districts/:district/heritages", type: :request do
       let(:version) { 1 }
       let(:endpoint) { create :endpoint }
 
-      it "it should throw error" do
+      it "it should throw an error" do
         api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 422
+        expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
+      end
+    end
+
+    context "when existing endpoint exists" do
+      let(:version) { 1 }
+      let(:district) { create :district}
+      let(:district2) { create :district, name: "staging-blue" }
+      let(:endpoint) { build :endpoint, name: "green" }
+
+      it "do not pick wrong one" do
+        create :endpoint, name: "staging-blue-green", district: district
+
+        api_request(:post, "/v1/districts/#{district2.name}/heritages", params)
         expect(response.status).to eq 422
         expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
       end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -111,7 +111,7 @@ describe "POST /districts/:district/heritages", type: :request do
       it_behaves_like "create"
     end
 
-    context "when the endpoint is not belonged to heritage" do
+    context "when the endpoint does not belong to a district " do
       let(:version) { 1 }
       let(:endpoint) { create :endpoint }
 

--- a/spec/requests/update_endpoint_spec.rb
+++ b/spec/requests/update_endpoint_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe "PATCH /districts/:district/endpoints/:endpoint", type: :request do
+  let(:user) { create :user }
+  let(:district) { create :district }
+
+  let(:params) do
+    {
+      certificate_id: "test_certificate_id",
+      ssl_policy: "old"
+    }
+  end
+
+  given_auth(GithubAuth) do
+    before do
+      allow_any_instance_of(CloudFormation::Executor).to receive(:outputs) {
+        {"DNSName" => "dns.name"}
+      }
+    end
+
+    it "update endpoint" do
+      district.endpoints.create(name: "ep1")
+      endpoint = district.endpoints.first
+
+      api_request(:patch, "/v1/districts/#{district.name}/endpoints/#{endpoint.name}", params)
+
+      endpoint.reload
+      expect(response.status).to eq 200
+      expect(endpoint.certificate_id).to eq "test_certificate_id"
+      expect(endpoint.ssl_policy).to eq "old"
+      expect(endpoint.name).to eq "ep1"
+    end
+
+    it "update district-endpoint" do
+      district.endpoints.create(name: "#{district.name}-ep1")
+      endpoint = district.endpoints.first
+
+      api_request(:patch, "/v1/districts/#{district.name}/endpoints/ep1", params)
+
+      endpoint.reload
+      expect(response.status).to eq 200
+      expect(endpoint.certificate_id).to eq "test_certificate_id"
+      expect(endpoint.ssl_policy).to eq "old"
+      expect(endpoint.name).to eq "#{district.name}-ep1"
+    end
+  end
+end

--- a/spec/requests/update_endpoint_spec.rb
+++ b/spec/requests/update_endpoint_spec.rb
@@ -43,5 +43,21 @@ describe "PATCH /districts/:district/endpoints/:endpoint", type: :request do
       expect(endpoint.ssl_policy).to eq "old"
       expect(endpoint.name).to eq "#{district.name}-ep1"
     end
+
+    it "throw error if there is a existing same name endpoint" do
+      params = {
+        name: "bar",
+        public: true,
+        ssl_policy: 'modern',
+        certificate_id: 'certificate_id'
+      }
+
+      district = create :district, name: "food"
+      district.endpoints.create(name: "food-bar")
+
+      api_request(:post, "/v1/districts/#{district.name}/endpoints", params)
+
+      expect(response.status).to eq 422
+    end
   end
 end

--- a/spec/requests/update_endpoint_spec.rb
+++ b/spec/requests/update_endpoint_spec.rb
@@ -43,21 +43,5 @@ describe "PATCH /districts/:district/endpoints/:endpoint", type: :request do
       expect(endpoint.ssl_policy).to eq "old"
       expect(endpoint.name).to eq "#{district.name}-ep1"
     end
-
-    it "throw error if there is a existing same name endpoint" do
-      params = {
-        name: "bar",
-        public: true,
-        ssl_policy: 'modern',
-        certificate_id: 'certificate_id'
-      }
-
-      district = create :district, name: "food"
-      district.endpoints.create(name: "food-bar")
-
-      api_request(:post, "/v1/districts/#{district.name}/endpoints", params)
-
-      expect(response.status).to eq 422
-    end
   end
 end


### PR DESCRIPTION
Fixes #616

If you create an endpoint named A in district 1, you cant make an endpoint named A in district 2, even though there is no reason you shouldn't be able to.

When creating an endpoint, we now add the district name as a prefix.

When `load_endpoint`, for compatibility with existing endpoints, I changed it to first look for the endpoint by name only, and if not found, look for it by heritage and name.