### PR TITLE
Update AMI of container and bastion instances to 2.0.20210316

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0ec7896dee795dfa9",
-        "us-east-2"      => "ami-02ef98ccecbf47e86",
-        "us-west-1"      => "ami-0c95b81c98a196de2",
-        "us-west-2"      => "ami-006d48b829793b507",
-        "eu-west-1"      => "ami-0cdce788baec293cb",
-        "eu-west-2"      => "ami-0a7f94d6f878fdd02",
-        "eu-west-3"      => "ami-08b42a2167e4c521f",
-        "eu-central-1"      => "ami-027d55743533d8658",
-        "ap-northeast-1"      => "ami-0ee0c841e0940c58f",
-        "ap-northeast-2"      => "ami-098340641fcc77afb",
-        "ap-southeast-1"      => "ami-002281dd675dedcbf",
-        "ap-southeast-2"      => "ami-016f6cf165ef55d02",
-        "ca-central-1"      => "ami-0cde1f5ee149df291",
-        "ap-south-1"      => "ami-018ae918c152249f0",
-        "sa-east-1"      => "ami-02b0be10b5499d608",
+        "us-east-1"      => "ami-09a3cad575b7eabaa",
+        "us-east-2"      => "ami-0ecb1ece84d43215d",
+        "us-west-1"      => "ami-0ec4aded37931c8b5",
+        "us-west-2"      => "ami-0b58521c622a24969",
+        "eu-west-1"      => "ami-05fece3209ae18166",
+        "eu-west-2"      => "ami-0cfa29782743cdde5",
+        "eu-west-3"      => "ami-0e6d1d5809fc340aa",
+        "eu-central-1"      => "ami-01d359866d075d46c",
+        "ap-northeast-1"      => "ami-0a3769ff70e8ed2c7",
+        "ap-northeast-2"      => "ami-0125b4993023eaf1c",
+        "ap-southeast-1"      => "ami-0eb8001f83aa58b4c",
+        "ap-southeast-2"      => "ami-0b3a132b2a4c91d72",
+        "ca-central-1"      => "ami-0a861b9a80035b882",
+        "ap-south-1"      => "ami-036eaa870decb368d",
+        "sa-east-1"      => "ami-02e1f6dc90eb8de9d",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0915bcb5fa77e4892",
-        "us-east-2"      => "ami-09246ddb00c7c4fef",
-        "us-west-1"      => "ami-066c82dabe6dd7f73",
-        "us-west-2"      => "ami-09c5e030f74651050",
-        "eu-west-1"      => "ami-096f43ef67d75e998",
-        "eu-west-2"      => "ami-0ffd774e02309201f",
-        "eu-west-3"      => "ami-0ec28fc9814fce254",
-        "eu-central-1"      => "ami-02f9ea74050d6f812",
-        "ap-northeast-1"      => "ami-09d28faae2e9e7138",
-        "ap-northeast-2"      => "ami-006e2f9fa7597680a",
-        "ap-southeast-1"      => "ami-0d06583a13678c938",
-        "ap-southeast-2"      => "ami-075a72b1992cb0687",
-        "ca-central-1"      => "ami-0df612970f825f04c",
-        "ap-south-1"      => "ami-0eeb03e72075b9bcc",
-        "sa-east-1"      => "ami-0a0bc0fa94d632c94",
+        "us-east-1"      => "ami-0533f2ba8a1995cf9",
+        "us-east-2"      => "ami-089c6f2e3866f0f14",
+        "us-west-1"      => "ami-0a245a00f741d6301",
+        "us-west-2"      => "ami-05b622b5fa0269787",
+        "eu-west-1"      => "ami-0d712b3e6e1f798ef",
+        "eu-west-2"      => "ami-01c835443b86fe988",
+        "eu-west-3"      => "ami-0575fc648136871a1",
+        "eu-central-1"      => "ami-013fffc873b1eaa1c",
+        "ap-northeast-1"      => "ami-0bc8ae3ec8e338cbc",
+        "ap-northeast-2"      => "ami-081511b9e3af53902",
+        "ap-southeast-1"      => "ami-0ba0ce0c11eb723a1",
+        "ap-southeast-2"      => "ami-0b3d7a5ecc2daba4c",
+        "ca-central-1"      => "ami-09d75fc0586859f7a",
+        "ap-south-1"      => "ami-068d43a544160b7ef",
+        "sa-east-1"      => "ami-0ca43e15336e41670",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
