### PR TITLE
Bump `mimemagic` minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,9 @@ GEM
       mimemagic (~> 0.3.2)
     maruku (0.7.3)
     method_source (0.9.2)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.1)


### PR DESCRIPTION
it needs to be updated to fix

```
#14 2.798 Your bundle is locked to mimemagic (0.3.5), but that version could not be found
#14 2.798 in any of the sources listed in your Gemfile. If you haven't changed sources,
#14 2.798 that means the author of mimemagic (0.3.5) has removed it. You'll need to update
#14 2.798 your bundle to a version other than mimemagic (0.3.5) that hasn't been removed
```