### PR TITLE
add `retrive-manifest` endpoint

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -1,6 +1,6 @@
 class HeritagesController < ApplicationController
   before_action :load_district, only:   [:index, :create]
-  before_action :load_heritage, except: [:index, :create, :trigger]
+  before_action :load_heritage, except: [:index, :create, :trigger, :retrieve_manifest]
   skip_before_action :authenticate, only: [:trigger]
 
   def index
@@ -149,6 +149,20 @@ class HeritagesController < ApplicationController
 
   def load_district
     @district = District.find_by!(name: params[:district_id])
+  end
+
+  def retrieve_manifest
+    heritage = Heritage.find_by!(name: params[:heritage_id])
+    user = params[:user]
+    password = params[:password]
+
+    if heritage.image_name.start_with?("quay.io/")
+      response = RetrieveQuayManifest.new().process(user, password, heritage)
+    else
+      raise ExceptionHandler::InternalServerError.new("Unsupported Registry")
+    end
+
+    render json: response.body
   end
 
   private

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -249,8 +249,11 @@ class Heritage < ActiveRecord::Base
 
   def image_path
     return nil if image_name.blank?
-    tag = image_tag || 'latest'
     "#{image_name}:#{tag}"
+  end
+
+  def tag
+    image_tag || 'latest'
   end
 
   def deploy!(without_before_deploy: false, description: "")

--- a/app/services/retrieve_quay_manifest.rb
+++ b/app/services/retrieve_quay_manifest.rb
@@ -1,0 +1,46 @@
+class RetrieveQuayManifest
+
+    def process(user, password, heritage)
+        image_name = heritage.image_name
+        unless image_name.start_with?("quay.io/")
+            raise ExceptionHandler::InternalServerError.new("Registry should be quay.io")
+        end
+
+        repo = image_name.sub('quay.io/', "")
+        tag = heritage.tag
+
+        uri = URI.parse("https://quay.io/v2/auth?service=quay.io&scope=repository:#{repo}:pull")
+
+        request = Net::HTTP::Get.new(uri)
+        request.basic_auth(user, password)
+
+        req_options = {
+            use_ssl: uri.scheme == "https",
+        }
+
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+            http.request(request)
+        end
+
+        if response.code != "200"
+            return response
+        end
+
+        token = JSON.parse(response.body)["token"]
+
+        uri = URI.parse("https://quay.io/v2/#{repo}/manifests/#{tag}")
+        request = Net::HTTP::Get.new(uri)
+        request["Authorization"] = "Bearer #{token}"
+        request["Accept"] = "application/vnd.docker.distribution.manifest.v2+json"
+
+        req_options = {
+            use_ssl: uri.scheme == "https",
+        }
+
+        response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
+            http.request(request)
+        end
+
+        response
+	end
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
         delete :env_vars, on: :member, to: "heritages#delete_env_vars"
 
         post "/trigger/:token", to: "heritages#trigger"
+        post "/retrieve_manifest", to: "heritages#retrieve_manifest"
+
         resources :oneoffs, only: [:show, :create]
 
         get "/releases", to: "releases#index"

--- a/spec/requests/retrive_manifest_spec.rb
+++ b/spec/requests/retrive_manifest_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe "retrieve a manifest" do
+  let(:district) { create :district }
+  let(:user) { create :user }
+
+  given_auth(GithubAuth) do
+    before do
+      params = {
+        name: "nginx",
+        image_name: "quay.io/degica/barcelona",
+        image_tag: "latest",
+        before_deploy: "echo hello",
+        environment: [
+          {name: "ENV_KEY", value: "my value"},
+          {name: "SECRET", value_from: "arn"}
+        ],
+        services: [
+          {
+            name: "web",
+            public: true,
+            cpu: 128,
+            memory: 256,
+            command: "nginx",
+            port_mappings: [
+              {
+                lb_port: 80,
+                container_port: 80
+              }
+            ]
+          },
+          {
+            name: "worker",
+            command: "rake jobs:work"
+          }
+        ]
+      }
+      api_request :post, "/v1/districts/#{district.name}/heritages?debug=true", params
+    end
+
+    describe "PATCH /heritages/:heritage/retrieve_manifest", type: :request do
+      it "retrieve a manifest" do
+        params = {
+          user: "userId",
+          password: "password"
+        }
+
+        retrieve_manifest = instance_double(RetrieveQuayManifest)
+        response = double(:response)
+        allow(response).to receive(:body).and_return({schemaVersion: "v1"})
+        allow(response).to receive(:successful?).and_return(true)
+
+        allow(RetrieveQuayManifest).to receive(:new).and_return(retrieve_manifest)
+        allow(retrieve_manifest).to receive(:process).and_return(response)
+
+
+        api_request :post, "/v1/heritages/nginx/retrieve_manifest", params
+        expect(response).to be_successful
+        expect(response.body).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/retrive_quay_manifest_spec.rb
+++ b/spec/services/retrive_quay_manifest_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe RetrieveQuayManifest do
+  let(:heritage) { create :heritage, image_name: "quay.io/degica/barcelona" }
+  let(:endpoint) { district.endpoints.create!(name: "load-balancer")}
+
+  describe "retrieve a manifest" do
+    let(:heritage) { create :heritage, image_name: "quay.io/degica/barcelona" }
+    let(:user) { "user" }
+    let(:password) { "test" }
+    let(:token) { "testTokenValue" }
+
+    it "it should return correct response" do
+      stub_request(:get, "https://quay.io/v2/auth?scope=repository:degica/barcelona:pull&service=quay.io").
+      with(
+        headers: {
+          'Authorization'=>'Basic dXNlcjp0ZXN0',
+          'Host'=>'quay.io',
+        }).
+      to_return(body: {token: token }.to_json)
+
+      body = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+           "mediaType": "application/vnd.docker.container.image.v1+json",
+           "size": 10987,
+           "digest": "test"
+        },
+        "layers": []
+      }
+
+      stub_request(:get, "https://quay.io/v2/degica/barcelona/manifests/1.9.5").
+      with(
+        headers: {
+          'Accept'=>'application/vnd.docker.distribution.manifest.v2+json',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'=>"Bearer #{token}",
+          'Host'=>'quay.io',
+          'User-Agent'=>'Ruby'
+        }).
+      to_return(status: 200, body: body.to_json, headers: {})
+
+      response = RetrieveQuayManifest.new().process(user, password, heritage)
+      expect(response.code).to eq "200"
+      expect(JSON.parse(response.body)["mediaType"]).to eq "application/vnd.docker.distribution.manifest.v2+json"
+    end
+
+    context "when user and password is not correct" do
+      it "it should return an error response" do
+        error_response = {
+          "errors":[
+            {
+              "code": "UNAUTHORIZED",
+              "message": "Could not find robot with specified username"
+            }
+          ]
+        }
+
+        stub_request(:get, "https://quay.io/v2/auth?scope=repository:degica/barcelona:pull&service=quay.io").
+        with(
+          headers: {
+            'Authorization'=>'Basic dXNlcjp0ZXN0',
+            'Host'=>'quay.io',
+          }).
+        to_return(status: 401, body: error_response.to_json)
+
+        response = RetrieveQuayManifest.new().process(user, password, heritage)
+        expect(response.code).to eq "401"
+        expect(response.body).to eq error_response.to_json
+      end
+    end
+
+    context "when token is not correct" do
+      it "it should return an error response" do
+        stub_request(:get, "https://quay.io/v2/auth?scope=repository:degica/barcelona:pull&service=quay.io").
+        with(
+          headers: {
+            'Authorization'=>'Basic dXNlcjp0ZXN0',
+            'Host'=>'quay.io',
+          }).
+        to_return(status: 200, body: {token: token }.to_json)
+
+        error_response = {
+          "error": "Signature verification failed"
+        }
+
+        stub_request(:get, "https://quay.io/v2/degica/barcelona/manifests/1.9.5").
+        with(
+          headers: {
+            'Accept'=>'application/vnd.docker.distribution.manifest.v2+json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization'=>"Bearer #{token}",
+            'Host'=>'quay.io',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 401, body: error_response.to_json, headers: {})
+
+        response = RetrieveQuayManifest.new().process(user, password, heritage)
+        expect(response.code).to eq "401"
+        expect(response.body).to eq error_response.to_json
+      end
+    end
+
+    context "when registry is not quay" do
+      let(:heritage) { create :heritage, image_name: "test.io/degica/barcelona" }
+
+      it "it should return an error" do
+        quay_manifest = RetrieveQuayManifest.new()
+        expect { quay_manifest.process(user, password, heritage) }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
part of https://github.com/degica/barcelona/issues/613

Add a ` retrive-manifest` endpoint to Barcerola to resolve this issue.
Initially, I tried to get the manifest using dockercfg, but after checking with quay's CS, he said that was not possible.
So we need a user and password for auth.

We can use this endpoint to check if the docker image is in the registry.

