### PR TITLE
Fix to select correct auth user

### DIFF
--- a/app/auth/vault_auth.rb
+++ b/app/auth/vault_auth.rb
@@ -15,8 +15,7 @@ class VaultAuth < Auth
     @current_user = User.find_by_token(vault_token)
 
     if @current_user.nil?
-      user = User.find_or_create_by(name: username)
-      user.auth = 'vault'
+      user = User.find_or_create_by(name: username, auth: 'vault')
       user.token = vault_token
       user.roles = []
       user.save!

--- a/spec/auth/github_auth_spec.rb
+++ b/spec/auth/github_auth_spec.rb
@@ -93,6 +93,27 @@ describe GithubAuth do
 
         it { is_expected.to be_nil }
       end
+
+      context "pick the correct user even if the user already exists in deferent auth" do
+        before do
+          vault_user = User.create!(
+            name: 'someuniquename',
+            auth: 'vault',
+            token: 'defg',
+            roles: []
+          )
+
+          vault_user = User.create!(
+            name: 'someuniquename',
+            auth: 'github',
+            token: 'token',
+            roles: []
+          )
+        end
+
+        its(:auth) { is_expected.to eq nil }
+        its(:token) { is_expected.to be_present }
+      end
     end
   end
 end

--- a/spec/auth/vault_auth_spec.rb
+++ b/spec/auth/vault_auth_spec.rb
@@ -85,6 +85,27 @@ describe VaultAuth do
       expect(auth.authenticate).to be_persisted
     end
 
+    it 'pick the correct user even if the user already exists in deferent auth' do
+      allow(auth).to receive(:username) { 'someuniquename' }
+
+      User.create!(
+        name: 'someuniquename',
+        auth: 'vault',
+        token: 'defg',
+        roles: []
+      )
+
+      User.create!(
+        name: 'someuniquename',
+        auth: 'github',
+        token: 'token',
+        roles: []
+      )
+
+      expect(auth.authenticate.name).to eq 'someuniquename'
+      expect(auth.authenticate.auth).to eq 'vault'
+    end
+
     it 'updates the token if the user already exists' do
       allow(auth).to receive(:username) { 'someuniquename' }
 
@@ -98,7 +119,6 @@ describe VaultAuth do
       expect(auth.authenticate.name).to eq 'someuniquename'
       expect(auth.authenticate.token).to eq 'abcd'
     end
-
   end
 
   describe "#login" do


### PR DESCRIPTION
fix https://github.com/degica/barcelona/issues/672

## Context
If a user exists in multiple auth, the wrong user will be selected in the valut auth.

This is  because we do not specify `auth type` in `app/auth/vault_auth.rb`.

If auth is nil, it will be github auth.
so I specify auth when selecting.