### PR TITLE
Fix ssm path for delete endpoint

### DIFF
--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -14,7 +14,7 @@ class SsmParameters
 
   def delete_parameter
     client.delete_parameters({
-                               names: [@name]
+                               names: [ssm_path]
                              })
   end
 

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -23,8 +23,11 @@ describe SsmParameters do
 
   describe "#delete_parameter" do
     it "delete ssm parameter" do
-      expect_any_instance_of(Aws::SSM::Client).to receive(:delete_parameters).and_call_original
-      response = described_class.new(district, name).delete_parameter
+      ssm_parameters = described_class.new(district, name)
+      expect_any_instance_of(Aws::SSM::Client).to receive(:delete_parameters).
+        with(names: [ssm_parameters.ssm_path]).and_call_original
+
+      response = ssm_parameters.delete_parameter
       expect(response.deleted_parameters).to eq []
       expect(response.invalid_parameters).to eq []
     end


### PR DESCRIPTION
While testing, I noticed that there was a mistake in the delete endpoint.
the name should be ssm_path not `name` itself.
this pr should fix this issue
