### PR TITLE
Validate ssm parameters

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -255,7 +255,7 @@ class Heritage < ActiveRecord::Base
   end
 
   def deploy!(without_before_deploy: false, description: "")
-    validate_ssm_parameters
+    validate_ssm_parameters!
     release = releases.create!(description: description)
     update_services(release, without_before_deploy)
     release

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -255,6 +255,7 @@ class Heritage < ActiveRecord::Base
   end
 
   def deploy!(without_before_deploy: false, description: "")
+    validate_ssm_parameters
     release = releases.create!(description: description)
     update_services(release, without_before_deploy)
     release
@@ -352,5 +353,18 @@ class Heritage < ActiveRecord::Base
 
   def delete_stack
     cf_executor.delete
+  end
+
+  def validate_ssm_parameters
+    ssm_paths = environments.secrets.select{ |key|
+      key.value_from.start_with?("/barcelona/#{district.name}")
+    }.map(&:value_from)
+
+    ssm_parameter = SsmParameters.new(self.district, "")
+    response = ssm_parameter.get_parameters(ssm_paths)
+
+    if response.invalid_parameters.present?
+      raise ExceptionHandler::BadRequest.new("These ssm keys do not exist: #{response.invalid_parameters}")
+    end
   end
 end

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -355,16 +355,16 @@ class Heritage < ActiveRecord::Base
     cf_executor.delete
   end
 
-  def validate_ssm_parameters
+  def validate_ssm_parameters!
     ssm_paths = environments.secrets.select{ |key|
       key.value_from.start_with?("/barcelona/#{district.name}")
     }.map(&:value_from)
 
     ssm_parameter = SsmParameters.new(self.district, "")
-    response = ssm_parameter.get_parameters(ssm_paths)
+    invalid_parameters = ssm_parameter.get_invalid_parameters(ssm_paths)
 
-    if response.invalid_parameters.present?
-      raise ExceptionHandler::BadRequest.new("These ssm keys do not exist: #{response.invalid_parameters}")
+    if invalid_parameters.present?
+      raise ExceptionHandler::BadRequest.new("These ssm keys do not exist: #{invalid_parameters}")
     end
   end
 end

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -18,10 +18,11 @@ class SsmParameters
                              })
   end
 
-  def get_parameters(ssm_paths)
-    client.get_parameters({
-                            names: ssm_paths
-                          })
+  def get_invalid_parameters(ssm_paths)
+    response = client.get_parameters({
+                                       names: ssm_paths
+                                     })
+    response.invalid_parameters
   end
 
   def ssm_path

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -25,6 +25,8 @@ class SsmParameters
                                        names: ssm_paths
                                      })
     response.invalid_parameters
+  rescue StandardError => e
+    Rails.logger.error("Unexpected error #{e}")
   end
 
   def ssm_path

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -26,7 +26,7 @@ class SsmParameters
                                      })
     response.invalid_parameters
   rescue StandardError => e
-    Rails.logger.error("Unexpected error #{e}")
+    raise ExceptionHandler::UnprocessableEntity.new("Failed to get ssm parameters: #{e}")
   end
 
   def ssm_path

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -19,6 +19,8 @@ class SsmParameters
   end
 
   def get_invalid_parameters(ssm_paths)
+    return [] if ssm_paths.empty?
+
     response = client.get_parameters({
                                        names: ssm_paths
                                      })

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -18,6 +18,12 @@ class SsmParameters
                              })
   end
 
+  def get_parameters(ssm_paths)
+    client.get_parameters({
+                            names: ssm_paths
+                          })
+  end
+
   def ssm_path
     "/barcelona/#{@district.name}/#{@name}"
   end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -18,6 +18,10 @@ describe "POST /districts/:district/heritages", type: :request do
           command: "echo hello"
         }
       ],
+      environment: [
+        {name: "ENV_KEY", ssm_path: "path/to/env_key"},
+        {name: "SECRET", value: "raw"}
+      ],
       services: [
         {
           name: "web",
@@ -143,6 +147,23 @@ describe "POST /districts/:district/heritages", type: :request do
         api_request(:post, "/v1/districts/#{district2.name}/heritages", params)
         expect(response.status).to eq 422
         expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
+      end
+    end
+
+    context "when ssm_path doest not exist exists" do
+      let(:version) { 1 }
+
+      it "throw an error" do
+        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
+        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
+        expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
+          with(names: ssm_paths).and_return(
+            mock_response.new(parameters: [], invalid_parameters: ssm_paths)
+          )
+
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 400
+        expect(JSON.parse(response.body)["error"]).to eq "These ssm keys do not exist: [\"/barcelona/#{district.name}/path/to/env_key\"]"
       end
     end
   end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -150,7 +150,7 @@ describe "POST /districts/:district/heritages", type: :request do
       end
     end
 
-    context "when ssm_path doest not exist exists" do
+    context "when ssm_path doest not exist" do
       let(:version) { 1 }
 
       it "throw an error" do
@@ -164,6 +164,20 @@ describe "POST /districts/:district/heritages", type: :request do
         api_request(:post, "/v1/districts/#{district.name}/heritages", params)
         expect(response.status).to eq 400
         expect(JSON.parse(response.body)["error"]).to eq "These ssm keys do not exist: [\"/barcelona/#{district.name}/path/to/env_key\"]"
+      end
+    end
+
+    context "when ssm_path is empty" do
+      let(:version) { 1 }
+
+      it "do not throw an error" do
+        params.delete(:environment)
+        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
+        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
+        expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters)
+
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -33,8 +33,8 @@ describe SsmParameters do
     end
   end
 
-  describe "#get_parameters" do
-    it "get ssm parameter" do
+  describe "#get_invalids_parameters" do
+    it "get invalid parameter" do
       ssm_parameters = described_class.new(district, "")
       ssm_paths = [
         "/barcelona/test/path/to/secret-1",
@@ -44,9 +44,8 @@ describe SsmParameters do
       expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
         with(names: ssm_paths).and_call_original
 
-      response = ssm_parameters.get_parameters(ssm_paths)
-      expect(response.parameters).to eq []
-      expect(response.invalid_parameters).to eq []
+      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
+      expect(invalid_parameters).to eq []
     end
   end
 end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -47,5 +47,16 @@ describe SsmParameters do
       invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
       expect(invalid_parameters).to eq []
     end
+
+    it "return empty when ssm path is empty" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = []
+
+      expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters).
+        with(names: ssm_paths)
+
+      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
+      expect(invalid_parameters).to eq []
+    end
   end
 end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -58,5 +58,15 @@ describe SsmParameters do
       invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
       expect(invalid_parameters).to eq []
     end
+
+    it "throw UnprocessableEntity error" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = [
+        "/barcelona/test/path/to/secret-1",
+      ]
+
+      allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).and_raise(StandardError)
+      expect { ssm_parameters.get_invalid_parameters(ssm_paths) }.to raise_error(ExceptionHandler::UnprocessableEntity)
+    end
   end
 end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -32,4 +32,21 @@ describe SsmParameters do
       expect(response.invalid_parameters).to eq []
     end
   end
+
+  describe "#get_parameters" do
+    it "get ssm parameter" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = [
+        "/barcelona/test/path/to/secret-1",
+        "/barcelona/test/path/to/secret-2"
+      ]
+
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
+        with(names: ssm_paths).and_call_original
+
+      response = ssm_parameters.get_parameters(ssm_paths)
+      expect(response.parameters).to eq []
+      expect(response.invalid_parameters).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Currently, when deploying, even if the `ssm_path` does not exist, deploy is performed and cloudformation fails.
adeed the logic to check them before deploying.