### PR TITLE
Update AMI of container and bastion instances to 2.0.20210723

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0ae3143bc8c29507d",
-        "us-east-2"      => "ami-01a4986c9e49a5c6a",
-        "us-west-1"      => "ami-0154d362b1af1d7fa",
-        "us-west-2"      => "ami-09821bb7e5aa7e648",
-        "eu-west-1"      => "ami-01ef64c116fe1364f",
-        "eu-west-2"      => "ami-03f4b65c6b7b2e83d",
-        "eu-west-3"      => "ami-0975a74e69d1b66c3",
-        "eu-central-1"      => "ami-00a755f84af357e9e",
-        "ap-northeast-1"      => "ami-0ff8df45400dc4e3d",
-        "ap-northeast-2"      => "ami-019c34e0d65f3727c",
-        "ap-southeast-1"      => "ami-0d242941de637dea8",
-        "ap-southeast-2"      => "ami-03f9a9874affbb05b",
-        "ca-central-1"      => "ami-0617d8461ebdae2b9",
-        "ap-south-1"      => "ami-0b948665b52b6ac61",
-        "sa-east-1"      => "ami-0170497bab30979e8",
+        "us-east-1"      => "ami-09d2c35d7664ddd48",
+        "us-east-2"      => "ami-00b70fb5bca6ac778",
+        "us-west-1"      => "ami-046185e5373558eba",
+        "us-west-2"      => "ami-0b2bd1a0c09913fd8",
+        "eu-west-1"      => "ami-03d256b62e46142e5",
+        "eu-west-2"      => "ami-060618797d1decb3e",
+        "eu-west-3"      => "ami-094711aebfd2b111b",
+        "eu-central-1"      => "ami-0114eb74b66592f8b",
+        "ap-northeast-1"      => "ami-02898546ea44fc778",
+        "ap-northeast-2"      => "ami-0bd002eaae0485874",
+        "ap-southeast-1"      => "ami-085fd8639f8b2ad71",
+        "ap-southeast-2"      => "ami-0432fca19dd3ca234",
+        "ca-central-1"      => "ami-025373a49914a3494",
+        "ap-south-1"      => "ami-0fd39ae05e1da03c0",
+        "sa-east-1"      => "ami-051b03c7f6f2e0175",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0d5eff06f840b45e9",
-        "us-east-2"      => "ami-077e31c4939f6a2f3",
-        "us-west-1"      => "ami-04468e03c37242e1e",
-        "us-west-2"      => "ami-0cf6f5c8a62fa5da6",
-        "eu-west-1"      => "ami-063d4ab14480ac177",
-        "eu-west-2"      => "ami-06dc09bb8854cbde3",
-        "eu-west-3"      => "ami-0b3e57ee3b63dd76b",
-        "eu-central-1"      => "ami-043097594a7df80ec",
-        "ap-northeast-1"      => "ami-0ca38c7440de1749a",
-        "ap-northeast-2"      => "ami-0f2c95e9fe3f8f80e",
-        "ap-southeast-1"      => "ami-02f26adf094f51167",
-        "ap-southeast-2"      => "ami-0186908e2fdeea8f3",
-        "ca-central-1"      => "ami-0101734ab73bd9e15",
-        "ap-south-1"      => "ami-010aff33ed5991201",
-        "sa-east-1"      => "ami-05373777d08895384",
+        "us-east-1"      => "ami-0c2b8ca1dad447f8a",
+        "us-east-2"      => "ami-0443305dabd4be2bc",
+        "us-west-1"      => "ami-04b6c97b14c54de18",
+        "us-west-2"      => "ami-083ac7c7ecf9bb9b0",
+        "eu-west-1"      => "ami-02b4e72b17337d6c1",
+        "eu-west-2"      => "ami-0d26eb3972b7f8c96",
+        "eu-west-3"      => "ami-0d49cec198762b78c",
+        "eu-central-1"      => "ami-0453cb7b5f2b7fca2",
+        "ap-northeast-1"      => "ami-09ebacdc178ae23b7",
+        "ap-northeast-2"      => "ami-0a0de518b1fc4524c",
+        "ap-southeast-1"      => "ami-0f511ead81ccde020",
+        "ap-southeast-2"      => "ami-0aab712d6363da7f9",
+        "ca-central-1"      => "ami-02f84cf47c23f1769",
+        "ap-south-1"      => "ami-04db49c0fb2215364",
+        "sa-east-1"      => "ami-0f8243a5175208e08",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
