### PR TITLE
Revert "Validate ssm parameters"

### DIFF
--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -255,7 +255,6 @@ class Heritage < ActiveRecord::Base
   end
 
   def deploy!(without_before_deploy: false, description: "")
-    validate_ssm_parameters!
     release = releases.create!(description: description)
     update_services(release, without_before_deploy)
     release
@@ -353,18 +352,5 @@ class Heritage < ActiveRecord::Base
 
   def delete_stack
     cf_executor.delete
-  end
-
-  def validate_ssm_parameters!
-    ssm_paths = environments.secrets.select{ |key|
-      key.value_from.start_with?("/barcelona/#{district.name}")
-    }.map(&:value_from)
-
-    ssm_parameter = SsmParameters.new(self.district, "")
-    invalid_parameters = ssm_parameter.get_invalid_parameters(ssm_paths)
-
-    if invalid_parameters.present?
-      raise ExceptionHandler::BadRequest.new("These ssm keys do not exist: #{invalid_parameters}")
-    end
   end
 end

--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -18,17 +18,6 @@ class SsmParameters
                              })
   end
 
-  def get_invalid_parameters(ssm_paths)
-    return [] if ssm_paths.empty?
-
-    response = client.get_parameters({
-                                       names: ssm_paths
-                                     })
-    response.invalid_parameters
-  rescue StandardError => e
-    raise ExceptionHandler::UnprocessableEntity.new("Failed to get ssm parameters: #{e}")
-  end
-
   def ssm_path
     "/barcelona/#{@district.name}/#{@name}"
   end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -18,10 +18,6 @@ describe "POST /districts/:district/heritages", type: :request do
           command: "echo hello"
         }
       ],
-      environment: [
-        {name: "ENV_KEY", ssm_path: "path/to/env_key"},
-        {name: "SECRET", value: "raw"}
-      ],
       services: [
         {
           name: "web",
@@ -147,37 +143,6 @@ describe "POST /districts/:district/heritages", type: :request do
         api_request(:post, "/v1/districts/#{district2.name}/heritages", params)
         expect(response.status).to eq 422
         expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
-      end
-    end
-
-    context "when ssm_path doest not exist" do
-      let(:version) { 1 }
-
-      it "throw an error" do
-        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
-        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
-        expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
-          with(names: ssm_paths).and_return(
-            mock_response.new(parameters: [], invalid_parameters: ssm_paths)
-          )
-
-        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
-        expect(response.status).to eq 400
-        expect(JSON.parse(response.body)["error"]).to eq "These ssm keys do not exist: [\"/barcelona/#{district.name}/path/to/env_key\"]"
-      end
-    end
-
-    context "when ssm_path is empty" do
-      let(:version) { 1 }
-
-      it "do not throw an error" do
-        params.delete(:environment)
-        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
-        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
-        expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters)
-
-        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
-        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -32,41 +32,4 @@ describe SsmParameters do
       expect(response.invalid_parameters).to eq []
     end
   end
-
-  describe "#get_invalids_parameters" do
-    it "get invalid parameter" do
-      ssm_parameters = described_class.new(district, "")
-      ssm_paths = [
-        "/barcelona/test/path/to/secret-1",
-        "/barcelona/test/path/to/secret-2"
-      ]
-
-      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
-        with(names: ssm_paths).and_call_original
-
-      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
-      expect(invalid_parameters).to eq []
-    end
-
-    it "return empty when ssm path is empty" do
-      ssm_parameters = described_class.new(district, "")
-      ssm_paths = []
-
-      expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters).
-        with(names: ssm_paths)
-
-      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
-      expect(invalid_parameters).to eq []
-    end
-
-    it "throw UnprocessableEntity error" do
-      ssm_parameters = described_class.new(district, "")
-      ssm_paths = [
-        "/barcelona/test/path/to/secret-1",
-      ]
-
-      allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).and_raise(StandardError)
-      expect { ssm_parameters.get_invalid_parameters(ssm_paths) }.to raise_error(ExceptionHandler::UnprocessableEntity)
-    end
-  end
 end


### PR DESCRIPTION
Reverts degica/barcelona#686

@Yuuki77 I am reverting this because we seem to have an issue with too many parameters to list that we did not anticipate.

https://github.com/degica/hats/pull/11223/checks?check_run_id=3228217394