### PR TITLE
Validate ssm parameters

### DIFF
--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -18,6 +18,21 @@ class SsmParameters
                              })
   end
 
+  def get_invalid_parameters(ssm_paths)
+    return [] if ssm_paths.empty?
+
+    if ssm_paths.length > 10
+      raise ExceptionHandler::UnprocessableEntity.new("Failed to get ssm parameters: length should be less than 10 #{ssm_paths}")
+    end
+
+    response = client.get_parameters({
+                                       names: ssm_paths
+                                     })
+    response.invalid_parameters
+  rescue StandardError => e
+    raise ExceptionHandler::UnprocessableEntity.new("Failed to get ssm parameters: #{e}")
+  end
+
   def ssm_path
     "/barcelona/#{@district.name}/#{@name}"
   end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -18,6 +18,10 @@ describe "POST /districts/:district/heritages", type: :request do
           command: "echo hello"
         }
       ],
+      environment: [
+        {name: "ENV_KEY", ssm_path: "path/to/env_key"},
+        {name: "SECRET", value: "raw"}
+      ],
       services: [
         {
           name: "web",
@@ -143,6 +147,54 @@ describe "POST /districts/:district/heritages", type: :request do
         api_request(:post, "/v1/districts/#{district2.name}/heritages", params)
         expect(response.status).to eq 422
         expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
+      end
+    end
+
+    context "when ssm_path doest not exist" do
+      let(:version) { 1 }
+
+      it "throw an error" do
+        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
+        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
+        expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
+          with(names: ssm_paths).and_return(
+            mock_response.new(parameters: [], invalid_parameters: ssm_paths)
+          )
+
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 400
+        expect(JSON.parse(response.body)["error"]).to eq "These ssm keys do not exist: [\"/barcelona/#{district.name}/path/to/env_key\"]"
+      end
+    end
+
+    context "when ssm_path is empty" do
+      let(:version) { 1 }
+
+      it "do not throw an error" do
+        params.delete(:environment)
+        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
+        expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters)
+
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 200
+      end
+    end
+
+    context "when ssm_paths are more than 10" do
+      let(:version) { 1 }
+
+      it "do not throw an error" do
+        ssm_paths = []
+
+        for i in 0..11
+          ssm_paths << {name: "ENV_KEY", ssm_path: "path/to/env_key#{i}"}
+        end
+        params[:environment] = ssm_paths
+        ssm_paths = ["/barcelona/#{district.name}/path/to/env_key"]
+        mock_response = Struct.new(:parameters, :invalid_parameters, keyword_init: true)
+
+        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -32,4 +32,54 @@ describe SsmParameters do
       expect(response.invalid_parameters).to eq []
     end
   end
+
+  describe "#get_invalids_parameters" do
+    it "get invalid parameter" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = [
+        "/barcelona/test/path/to/secret-1",
+        "/barcelona/test/path/to/secret-2"
+      ]
+
+      expect_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).
+        with(names: ssm_paths).and_call_original
+
+      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
+      expect(invalid_parameters).to eq []
+    end
+
+    it "return empty when ssm path is empty" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = []
+
+      expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters).
+        with(names: ssm_paths)
+
+      invalid_parameters = ssm_parameters.get_invalid_parameters(ssm_paths)
+      expect(invalid_parameters).to eq []
+    end
+
+    it "throw UnprocessableEntity error" do
+      ssm_parameters = described_class.new(district, "")
+      ssm_paths = [
+        "/barcelona/test/path/to/secret-1",
+      ]
+
+      allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).and_raise(StandardError)
+      expect { ssm_parameters.get_invalid_parameters(ssm_paths) }.to raise_error(ExceptionHandler::UnprocessableEntity)
+    end
+
+    it "throw an error when ssm_paths are more than 10" do
+      ssm_parameters = described_class.new(district, "")
+
+      ssm_paths = []
+
+      for i in 0..10
+        ssm_paths <<  "/barcelona/test/path/to/secret-#{i}"
+      end
+
+      expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters)
+      expect { ssm_parameters.get_invalid_parameters(ssm_paths) }.to raise_error(ExceptionHandler::UnprocessableEntity)
+    end
+  end
 end


### PR DESCRIPTION
Original pr was reverted https://github.com/degica/barcelona/pull/689

Currently, when deploying, even if the ssm_path does not exist, deploy is performed and cloudformation fails.
added the logic to check them before deploying.

 we seem to have an issue with too many parameters to list that we did not anticipate.
so in this pr, I added the logic to handle in that case
