### PR TITLE
Revert #660 Fix endpoint is global

### DIFF
--- a/app/controllers/endpoints_controller.rb
+++ b/app/controllers/endpoints_controller.rb
@@ -8,12 +8,12 @@ class EndpointsController < ApplicationController
   end
 
   def create
-    endpoint = @district.endpoints.create!(create_params)
+    endpoint = @district.endpoints.create!(permitted_params)
     render json: endpoint
   end
 
   def update
-    @endpoint.update!(update_params)
+    @endpoint.update!(permitted_params)
     render json: @endpoint
   end
 
@@ -28,9 +28,7 @@ class EndpointsController < ApplicationController
 
   private
 
-  def create_params
-    params[:name] = name_prefix + params[:name]
-
+  def permitted_params
     params.permit(
       :name,
       :public,
@@ -39,26 +37,11 @@ class EndpointsController < ApplicationController
     )
   end
 
-  def update_params
-    params.permit(
-      :certificate_id,
-      :ssl_policy
-    )
-  end
-
   def load_endpoint
-    @endpoint = @district.endpoints.find_by(name: params[:id])
-    unless @endpoint.present?
-      @endpoint = @district.endpoints.find_by!(name: name_prefix + params[:id])
-    end
-    @endpoint
+    @endpoint = @district.endpoints.find_by!(name: params[:id])
   end
 
   def load_district
     @district = District.find_by!(name: params[:district_id])
-  end
-
-  def name_prefix
-    "#{@district.name}-"
   end
 end

--- a/spec/requests/create_endpoint_spec.rb
+++ b/spec/requests/create_endpoint_spec.rb
@@ -18,33 +18,7 @@ describe "POST /districts/:district/endpoints", type: :request do
       api_request(:post, "/v1/districts/#{district.name}/endpoints", params)
       expect(response.status).to eq 200
       endpoint = JSON.load(response.body)["endpoint"]
-      expect(endpoint["name"]).to eq "#{district.name}-my-endpoint"
-      expect(endpoint["public"]).to eq true
-      expect(endpoint["certificate_id"]).to eq 'certificate_id'
-      expect(endpoint["ssl_policy"]).to eq 'modern'
-      expect(endpoint["dns_name"]).to eq "dns.name"
-    end
-
-    it "creates same endpoint name in two district" do
-      allow_any_instance_of(CloudFormation::Executor).to receive(:outputs) {
-        {"DNSName" => "dns.name"}
-      }
-      params = {
-        name: "my-endpoint",
-        public: true,
-        ssl_policy: 'modern',
-        certificate_id: 'certificate_id'
-      }
-      api_request(:post, "/v1/districts/#{district.name}/endpoints", params)
-      expect(response.status).to eq 200
-
-      # create same name in other district
-      district2 = create :district
-      api_request(:post, "/v1/districts/#{district2.name}/endpoints", params)
-      expect(response.status).to eq 200
-
-      endpoint = JSON.load(response.body)["endpoint"]
-      expect(endpoint["name"]).to eq "#{district2.name}-my-endpoint"
+      expect(endpoint["name"]).to eq "my-endpoint"
       expect(endpoint["public"]).to eq true
       expect(endpoint["certificate_id"]).to eq 'certificate_id'
       expect(endpoint["ssl_policy"]).to eq 'modern'

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -124,32 +124,6 @@ describe "POST /districts/:district/heritages", type: :request do
       it_behaves_like "create"
     end
 
-    context "when the endpoint does not belong to a district " do
-      let(:version) { 1 }
-      let(:endpoint) { create :endpoint }
-
-      it "it should throw an error" do
-        api_request(:post, "/v1/districts/#{district.name}/heritages", params)
-        expect(response.status).to eq 422
-        expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
-      end
-    end
-
-    context "when an existing endpoint exists" do
-      let(:version) { 1 }
-      let(:district) { create :district}
-      let(:district2) { create :district, name: "staging-blue" }
-      let(:endpoint) { build :endpoint, name: "green" }
-
-      it "do not pick wrong one" do
-        create :endpoint, name: "staging-blue-green", district: district
-
-        api_request(:post, "/v1/districts/#{district2.name}/heritages", params)
-        expect(response.status).to eq 422
-        expect(JSON.parse(response.body)["error"]).to eq "Validation failed: Services listeners endpoint must exist"
-      end
-    end
-
     context "when ssm_path doest not exist" do
       let(:version) { 1 }
 

--- a/spec/requests/update_endpoint_spec.rb
+++ b/spec/requests/update_endpoint_spec.rb
@@ -30,18 +30,5 @@ describe "PATCH /districts/:district/endpoints/:endpoint", type: :request do
       expect(endpoint.ssl_policy).to eq "old"
       expect(endpoint.name).to eq "ep1"
     end
-
-    it "update district-endpoint" do
-      district.endpoints.create(name: "#{district.name}-ep1")
-      endpoint = district.endpoints.first
-
-      api_request(:patch, "/v1/districts/#{district.name}/endpoints/ep1", params)
-
-      endpoint.reload
-      expect(response.status).to eq 200
-      expect(endpoint.certificate_id).to eq "test_certificate_id"
-      expect(endpoint.ssl_policy).to eq "old"
-      expect(endpoint.name).to eq "#{district.name}-ep1"
-    end
   end
 end


### PR DESCRIPTION
Revert #660 
When I talked to David, we decided to revert this change

since it will add district name and it causes the barcelona.yml files to break