### PR TITLE
Add error message and update instance class to a usable one

### DIFF
--- a/lib/barcelona/network/rds_stack.rb
+++ b/lib/barcelona/network/rds_stack.rb
@@ -48,8 +48,8 @@ module Barcelona::Network
                    db_user: 'default',
                    multi_az: false,
                    encoding: :utf8,
-                   allocated_storage: 5,
-                   instance_class: "db.t2.micro")
+                   allocated_storage: 10,
+                   instance_class: "db.t4g.micro")
       @engine = engine
       @district = district
       @db_user = db_user

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -9,7 +9,7 @@ namespace :bcn do
       when /_IN_PROGRESS/
         print "."
       else
-        raise "Unexpected CF stack status"
+        raise "Unexpected CF stack status #{executor.stack_status}"
       end
     end
   end
@@ -107,12 +107,12 @@ namespace :bcn do
     heritage.destroy!
 
     puts
-    puts <<-EOS
-Barcelona Bootstrap Completed!
-Endpoint: #{dns_name}
+    puts <<~EOS
+      Barcelona Bootstrap Completed!
+      Endpoint: #{dns_name}
 
-Set your DNS record to point to the above endpoint and run the following Barcelona client command
-$ bcn login https://<your barcelona domain> <GitHub Token>
+      Set your DNS record to point to the above endpoint and run the following Barcelona client command
+      $ bcn login https://<your barcelona domain> <GitHub Token>
     EOS
   end
 


### PR DESCRIPTION
This PR has a few changes:

1. It updates the default allocated instance type to a new one for new versions of Postgres
2. Use the `<<~` syntax to avoid having to indent inline code weirdly.
3. Return the stack status as well to ease diagnosis