### PR TITLE
Update AMI of container and bastion instances to 2.0.20210929

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0706a79e169de19a2",
-        "us-east-2"      => "ami-0dcd3f3bc942819cf",
-        "us-west-1"      => "ami-0432f87ba2fb5a0da",
-        "us-west-2"      => "ami-07764a7d8502d36a2",
-        "eu-west-1"      => "ami-0cf04242e75fd2000",
-        "eu-west-2"      => "ami-0480e9547ca26f499",
-        "eu-west-3"      => "ami-0b26fe8ef33211fce",
-        "eu-central-1"      => "ami-02662254373ce730d",
-        "ap-northeast-1"      => "ami-04958171303876da0",
-        "ap-northeast-2"      => "ami-0210432d1c9737aff",
-        "ap-southeast-1"      => "ami-0ab1966ee863c98fd",
-        "ap-southeast-2"      => "ami-06b3adcd9a6d3b154",
-        "ca-central-1"      => "ami-07bee82ddd97631a4",
-        "ap-south-1"      => "ami-0cc6b8cf3ed4d3ac0",
-        "sa-east-1"      => "ami-0dea1107d2f7474eb",
+        "us-east-1"      => "ami-04942e54b391af5d0",
+        "us-east-2"      => "ami-0c38a2329ed4dae9a",
+        "us-west-1"      => "ami-0ab1b97c4bbf16bf3",
+        "us-west-2"      => "ami-06c73a8827b372409",
+        "eu-west-1"      => "ami-0fdb1527ad8bf80f7",
+        "eu-west-2"      => "ami-0b5e334d61108a1aa",
+        "eu-west-3"      => "ami-004138ffbf7aad984",
+        "eu-central-1"      => "ami-0da383d2d6bdb9100",
+        "ap-northeast-1"      => "ami-0b155218d6916661a",
+        "ap-northeast-2"      => "ami-0cacf8fb201c07e6b",
+        "ap-southeast-1"      => "ami-0f9e7ad4abf49df6b",
+        "ap-southeast-2"      => "ami-0cdf16bb10adcaaa1",
+        "ca-central-1"      => "ami-0a5cfc26b04c4a20e",
+        "ap-south-1"      => "ami-0405ea06ab2621cff",
+        "sa-east-1"      => "ami-00f653b3399483762",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-087c17d1fe0178315",
-        "us-east-2"      => "ami-00dfe2c7ce89a450b",
-        "us-west-1"      => "ami-011996ff98de391d1",
-        "us-west-2"      => "ami-0c2d06d50ce30b442",
-        "eu-west-1"      => "ami-0d1bf5b68307103c2",
-        "eu-west-2"      => "ami-0dbec48abfe298cab",
-        "eu-west-3"      => "ami-072056ff9d3689e7b",
-        "eu-central-1"      => "ami-07df274a488ca9195",
-        "ap-northeast-1"      => "ami-02892a4ea9bfa2192",
-        "ap-northeast-2"      => "ami-08c64544f5cfcddd0",
-        "ap-southeast-1"      => "ami-082105f875acab993",
-        "ap-southeast-2"      => "ami-0210560cedcb09f07",
-        "ca-central-1"      => "ami-0e2407e55b9816758",
-        "ap-south-1"      => "ami-0a23ccb2cdd9286bb",
-        "sa-east-1"      => "ami-09b9b17384f68fd7c",
+        "us-east-1"      => "ami-02e136e904f3da870",
+        "us-east-2"      => "ami-074cce78125f09d61",
+        "us-west-1"      => "ami-03ab7423a204da002",
+        "us-west-2"      => "ami-013a129d325529d4d",
+        "eu-west-1"      => "ami-05cd35b907b4ffe77",
+        "eu-west-2"      => "ami-02f5781cba46a5e8a",
+        "eu-west-3"      => "ami-0eb34a1ff6bafc83f",
+        "eu-central-1"      => "ami-058e6df85cfc7760b",
+        "ap-northeast-1"      => "ami-0701e21c502689c31",
+        "ap-northeast-2"      => "ami-0e4a9ad2eb120e054",
+        "ap-southeast-1"      => "ami-073998ba87e205747",
+        "ap-southeast-2"      => "ami-05c029a4b57edda9e",
+        "ca-central-1"      => "ami-0a70476e631caa6d3",
+        "ap-south-1"      => "ami-041d6256ed0f2061c",
+        "sa-east-1"      => "ami-05855ed85de7fbd77",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
