### PR TITLE
Move all container references to ECR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,25 +5,34 @@ jobs:
       image: docker:git
       env:
         BARCELONA_ENDPOINT: https://barcelona.degica.com
-        DOCKER_REPOSITORY: quay.io/degica/barcelona
+        DOCKER_REPOSITORY: public.ecr.aws/degica/barcelona
         DOCKER_BUILDKIT: '1'
-        QUAY_USERNAME: degica+github_actions
     runs-on: ubuntu-18.04
     steps:
+    - name: prepare
+      run: |-
+        apk add --no-cache python3 py3-pip
+        pip3 install --upgrade pip
+        pip3 install awscli
     - uses: actions/checkout@v2
     - name: setup
       run: git submodule update --init
     - name: script
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |-
-        docker build . -t $DOCKER_REPOSITORY:$GITHUB_HEAD_REF --pull || true
-        docker build . -t $DOCKER_REPOSITORY:$GITHUB_SHA --pull
-        echo ${{ github.ref }}
-    - name: push_images
-      if: github.ref == 'refs/heads/master'
-      run: |-
-        docker login -u "$QUAY_USERNAME" -p "${{ secrets.QUAY_TOKEN }}" quay.io
-        docker push $DOCKER_REPOSITORY:$GITHUB_HEAD_REF || true
-        docker push $DOCKER_REPOSITORY:$GITHUB_SHA
+        if [[ ${GITHUB_REF##*/} == 'master' ]]; then
+            IMAGE_TAG=$GITHUB_SHA # git SHA for staging/production deployments
+        else
+            IMAGE_TAG=${GITHUB_REF##*/} # branch name for dev usecases
+        fi
+
+        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/degica
+
+        docker build . -t $DOCKER_REPOSITORY:$IMAGE_TAG --build-arg git_revision=$IMAGE_TAG --pull
+        docker images
+        docker push $DOCKER_REPOSITORY:$IMAGE_TAG
 
   deploy:
     container:
@@ -45,8 +54,4 @@ jobs:
       run: bcn deploy -q -e production --tag $GITHUB_SHA --heritage-token ${{ secrets.MAINLINE_HERITAGE_TOKEN }}
 'on':
   push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+    branches: '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,4 @@ jobs:
           --health-retries 5
 'on':
   push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+    branches: '*'

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -141,7 +141,7 @@ class HeritageTaskDefinition
       cpu: 1,
       memory: 16,
       essential: false,
-      image: "quay.io/degica/barcelona-run-pack"
+      image: "public.ecr.aws/degica/barcelona-run-pack"
     )
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,5 +1,5 @@
 class Service < ActiveRecord::Base
-  DEFAULT_REVERSE_PROXY = 'quay.io/degica/barcelona-reverse-proxy:latest'.freeze
+  DEFAULT_REVERSE_PROXY = 'public.ecr.aws/degica/barcelona-reverse-proxy:latest'.freeze
   WEB_CONTAINER_PORT_DEFAULT = 3000
 
   belongs_to :heritage, inverse_of: :services

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -1,7 +1,7 @@
 environments:
   production:
     name: barcelona2
-    image_name: quay.io/degica/barcelona
+    image_name: public.ecr.aws/degica/barcelona
     before_deploy: rake db:migrate
     scheduled_tasks:
       # 10AM JST every week day
@@ -24,7 +24,7 @@ environments:
         memory: 256
   test:
     name: barcelona
-    image_name: quay.io/degica/barcelona
+    image_name: public.ecr.aws/degica/barcelona
     before_deploy: rake db:migrate
     scheduled_tasks:
       # 10AM JST every week day

--- a/dockerfiles/run-pack/Makefile
+++ b/dockerfiles/run-pack/Makefile
@@ -1,4 +1,4 @@
 build:
-	docker build -t quay.io/degica/barcelona-run-pack .
+	docker build -t public.ecr.aws/degica/barcelona-run-pack .
 build-dev:
 	docker build -t run-pack-dev -f Dockerfile.dev .

--- a/dockerfiles/run-pack/README.md
+++ b/dockerfiles/run-pack/README.md
@@ -6,7 +6,7 @@ Basically this image is intended to run in ECS cluster but you can emulate the E
 
 ```
 $ make build
-$ docker run --name runpack quay.io/degica/barcelona-run-pack
+$ docker run --name runpack public.ecr.aws/degica/barcelona-run-pack
 $ docker run --volumes-from runpack debian:jessie /barcelona/barcelona-run load-env-and-run \
     --region ap-northeast-1 \
     --bucket-name your-s3-bucket-name \

--- a/dockerfiles/wazuh-kibana-proxy/barcelona.yml
+++ b/dockerfiles/wazuh-kibana-proxy/barcelona.yml
@@ -1,7 +1,7 @@
 environments:
   production:
     name: wazuh-kibana-proxy
-    image_name: quay.io/degica/barcelona-wazuh-kibana-proxy
+    image_name: public.ecr.aws/degica/barcelona-wazuh-kibana-proxy
     services:
       - name: web
         service_type: web

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -5,7 +5,7 @@ To start using Barcelona, you'll first need to deploy Barcelona API service.
 Install docker on your machine and run the bellow command.
 
 ```
-$ docker run --rm -it quay.io/degica/barcelona bin/bootstrap
+$ docker run --rm -it public.ecr.aws/degica/barcelona bin/bootstrap
 ```
 
 ## Install Barcelona Client

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -30,7 +30,7 @@ All heritage configurations are declared in a barcelona configuration file `barc
 environments:
   production:
     name: barcelona
-    image_name: quay.io/degica/barcelona
+    image_name: public.ecr.aws/degica/barcelona
     services:
       - name: web
         service_type: web

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -134,7 +134,7 @@ module Barcelona
           version: '2'
           services:
             wazuh:
-              image: quay.io/degica/barcelona-wazuh
+              image: public.ecr.aws/degica/barcelona-wazuh
               restart: always
               ports:
                 - "1514:1514/udp"

--- a/lib/tasks/bootstrap.rake
+++ b/lib/tasks/bootstrap.rake
@@ -64,7 +64,7 @@ namespace :bcn do
     # Run oneoff task that runs inside the VPC and creates barcelona service and endpoint
     heritage = district.heritages.new(
       name: "barcelona-bootstrap",
-      image_name: "quay.io/degica/barcelona",
+      image_name: "public.ecr.aws/degica/barcelona",
       image_tag: "master"
     )
     heritage.env_vars.build(key: "DATABASE_URL", value: ENV["BOOTSTRAP_DATABASE_URL"], secret: true)
@@ -139,7 +139,7 @@ namespace :bcn do
 
       heritage = district.heritages.new(
         name: "barcelona",
-        image_name: "quay.io/degica/barcelona",
+        image_name: "public.ecr.aws/degica/barcelona",
         image_tag: "master",
         before_deploy: "rake db:migrate",
         env_vars_attributes: [

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -50,7 +50,7 @@ describe HeritageTaskDefinition do
                                   cpu: 1,
                                   memory: 16,
                                   essential: false,
-                                  image: "quay.io/degica/barcelona-run-pack",
+                                  image: "public.ecr.aws/degica/barcelona-run-pack",
                                   environment: [],
                                   log_configuration: expected_log_configuration
                                 }
@@ -103,7 +103,7 @@ describe HeritageTaskDefinition do
                                     cpu: 1,
                                     memory: 16,
                                     essential: false,
-                                    image: "quay.io/degica/barcelona-run-pack",
+                                    image: "public.ecr.aws/degica/barcelona-run-pack",
                                     environment: [],
                                     log_configuration: expected_log_configuration
                                   },
@@ -195,7 +195,7 @@ describe HeritageTaskDefinition do
                                     cpu: 1,
                                     memory: 16,
                                     essential: false,
-                                    image: "quay.io/degica/barcelona-run-pack",
+                                    image: "public.ecr.aws/degica/barcelona-run-pack",
                                     environment: [],
                                     log_configuration: expected_log_configuration
                                   },
@@ -281,7 +281,7 @@ describe HeritageTaskDefinition do
                                   cpu: 1,
                                   memory: 16,
                                   essential: false,
-                                  image: "quay.io/degica/barcelona-run-pack",
+                                  image: "public.ecr.aws/degica/barcelona-run-pack",
                                   environment: [],
                                   log_configuration: expected_log_configuration
                                 }
@@ -350,7 +350,7 @@ describe HeritageTaskDefinition do
                                   "Cpu" => 1,
                                   "Memory" => 16,
                                   "Essential" => false,
-                                  "Image" => "quay.io/degica/barcelona-run-pack",
+                                  "Image" => "public.ecr.aws/degica/barcelona-run-pack",
                                   "Environment" => [],
                                   "LogConfiguration" => expected_log_configuration
                                 }


### PR DESCRIPTION
We have created a public repo on AWS ECR and migration has started moving images to the ECR.

This PR changes barcelona, its CI and barcelona.yml to start pushing to AWS ECR and pull from AWS ECR

To test, bootstrap barcelona on your AWS account and deploy a district, endpoint and heritage.

For those who have access:
https://github.com/degica/barcelona-e2e/actions/runs/1367622009