### PR TITLE
Update AMI of container and bastion instances to 2.0.20211115

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0706a79e169de19a2",
-        "us-east-2"      => "ami-0dcd3f3bc942819cf",
-        "us-west-1"      => "ami-0432f87ba2fb5a0da",
-        "us-west-2"      => "ami-07764a7d8502d36a2",
-        "eu-west-1"      => "ami-0cf04242e75fd2000",
-        "eu-west-2"      => "ami-0480e9547ca26f499",
-        "eu-west-3"      => "ami-0b26fe8ef33211fce",
-        "eu-central-1"      => "ami-02662254373ce730d",
-        "ap-northeast-1"      => "ami-04958171303876da0",
-        "ap-northeast-2"      => "ami-0210432d1c9737aff",
-        "ap-southeast-1"      => "ami-0ab1966ee863c98fd",
-        "ap-southeast-2"      => "ami-06b3adcd9a6d3b154",
-        "ca-central-1"      => "ami-07bee82ddd97631a4",
-        "ap-south-1"      => "ami-0cc6b8cf3ed4d3ac0",
-        "sa-east-1"      => "ami-0dea1107d2f7474eb",
+        "us-east-1"      => "ami-01783fbb0757adced",
+        "us-east-2"      => "ami-0adc4758ea76442e2",
+        "us-west-1"      => "ami-00becdb34b62bf459",
+        "us-west-2"      => "ami-09f043c293281ecd4",
+        "eu-west-1"      => "ami-015b1508a2ff2c65a",
+        "eu-west-2"      => "ami-0141564f07476504d",
+        "eu-west-3"      => "ami-04cb3664fdfc392bd",
+        "eu-central-1"      => "ami-097b8c9927f9a27bc",
+        "ap-northeast-1"      => "ami-04bbc04d168366d27",
+        "ap-northeast-2"      => "ami-0273b23020d7a59de",
+        "ap-southeast-1"      => "ami-071fbc655b2398016",
+        "ap-southeast-2"      => "ami-032edebfa34883542",
+        "ca-central-1"      => "ami-092b596d9b942c4f8",
+        "ap-south-1"      => "ami-000e4b3f0c9f06ffb",
+        "sa-east-1"      => "ami-003a04511c336560c",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-087c17d1fe0178315",
-        "us-east-2"      => "ami-00dfe2c7ce89a450b",
-        "us-west-1"      => "ami-011996ff98de391d1",
-        "us-west-2"      => "ami-0c2d06d50ce30b442",
-        "eu-west-1"      => "ami-0d1bf5b68307103c2",
-        "eu-west-2"      => "ami-0dbec48abfe298cab",
-        "eu-west-3"      => "ami-072056ff9d3689e7b",
-        "eu-central-1"      => "ami-07df274a488ca9195",
-        "ap-northeast-1"      => "ami-02892a4ea9bfa2192",
-        "ap-northeast-2"      => "ami-08c64544f5cfcddd0",
-        "ap-southeast-1"      => "ami-082105f875acab993",
-        "ap-southeast-2"      => "ami-0210560cedcb09f07",
-        "ca-central-1"      => "ami-0e2407e55b9816758",
-        "ap-south-1"      => "ami-0a23ccb2cdd9286bb",
-        "sa-east-1"      => "ami-09b9b17384f68fd7c",
+        "us-east-1"      => "ami-04ad2567c9e3d7893",
+        "us-east-2"      => "ami-0dd0ccab7e2801812",
+        "us-west-1"      => "ami-0074ef78ecb07948c",
+        "us-west-2"      => "ami-00be885d550dcee43",
+        "eu-west-1"      => "ami-09d4a659cdd8677be",
+        "eu-west-2"      => "ami-0fc15d50d39e4503c",
+        "eu-west-3"      => "ami-05f0a049e7aeb407c",
+        "eu-central-1"      => "ami-030e490c34394591b",
+        "ap-northeast-1"      => "ami-0e60b6d05dc38ff11",
+        "ap-northeast-2"      => "ami-0a5a6128e65676ebb",
+        "ap-southeast-1"      => "ami-024221a59c9020e72",
+        "ap-southeast-2"      => "ami-043e0add5c8665836",
+        "ca-central-1"      => "ami-0730e12069ab20c26",
+        "ap-south-1"      => "ami-0f1fb91a596abf28d",
+        "sa-east-1"      => "ami-03a343b9045171cec",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
