### PR TITLE
set overwrite  option true by default for `put_parameter`

### DIFF
--- a/app/services/ssm_parameters.rb
+++ b/app/services/ssm_parameters.rb
@@ -8,7 +8,8 @@ class SsmParameters
     client.put_parameter({
                            name: ssm_path, # required
                            value: value, # required
-                           type: "SecureString"
+                           type: "SecureString",
+                           overwrite: true
                          })
   end
 

--- a/spec/services/ssm_parameters_spec.rb
+++ b/spec/services/ssm_parameters_spec.rb
@@ -14,7 +14,10 @@ describe SsmParameters do
     let(:parameter_value) { "test123"}
 
     it "put ssm parameters" do
-      expect_any_instance_of(Aws::SSM::Client).to receive(:put_parameter).and_call_original
+      expect_any_instance_of(Aws::SSM::Client).to receive(:put_parameter).with(name: "/barcelona/district_name/district_name", # required
+                                                                               value: "test123",
+                                                                               type: "SecureString",
+                                                                               overwrite: true).and_call_original
 
       response = described_class.new(district, name).put_parameter(parameter_value)
       expect(response.version).to eq 0
@@ -62,7 +65,7 @@ describe SsmParameters do
     it "throw UnprocessableEntity error" do
       ssm_parameters = described_class.new(district, "")
       ssm_paths = [
-        "/barcelona/test/path/to/secret-1",
+        "/barcelona/test/path/to/secret-1"
       ]
 
       allow_any_instance_of(Aws::SSM::Client).to receive(:get_parameters).and_raise(StandardError)
@@ -74,8 +77,8 @@ describe SsmParameters do
 
       ssm_paths = []
 
-      for i in 0..10
-        ssm_paths <<  "/barcelona/test/path/to/secret-#{i}"
+      (0..10).each do |i|
+        ssm_paths << "/barcelona/test/path/to/secret-#{i}"
       end
 
       expect_any_instance_of(Aws::SSM::Client).not_to receive(:get_parameters)


### PR DESCRIPTION
if the value exists already, we could not set it.
with this option, now it should overwrite the value.

doc is here
https://docs.aws.amazon.com/cli/latest/reference/ssm/put-parameter.html
## how to test

you can try something like
```
aws ssm put-parameter \
                                     --name "MyConvertedParameter" \
                                     --value "abc123" \
                                     --type "String" \
                                     --tier Advanced \
```
and see if you can override the value