### PR TITLE
Relax stack status check frequency

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -17,7 +17,7 @@ class DeployRunnerJob < ActiveJob::Base
         break unless heritage.cf_executor.in_progress?
 
         puts "Waiting for heritage stack to be complete"
-        sleep 5
+        sleep 30
       end
 
       notify(message: "Deploying to #{heritage.district.name} district: #{description}")

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -4,11 +4,11 @@ class MonitorDeploymentJob < ActiveJob::Base
   def perform(service, count: 0, deployment_id: nil)
     if service.deployment_finished?(deployment_id)
       notify(service, message: "#{service.name} service deployed")
-    elsif count > 200
-      # deploys not finished after 1000 seconds are marked as timeout
+    elsif count > 20
+      # deploys not finished after 20 minutes are marked as timeout
       notify(service, level: :error, message: "Deploying #{service.name} service has not finished for a while.")
     else
-      MonitorDeploymentJob.set(wait: 5.seconds).perform_later(service,
+      MonitorDeploymentJob.set(wait: 60.seconds).perform_later(service,
                                                               count: count + 1,
                                                               deployment_id: deployment_id)
     end


### PR DESCRIPTION
When there are many apps (normal apps and reviewapps), the DescribeStacks API call gets rate-limited. To mitigate the issue, we can loosen the service status check frequency from 5 seconds to 60 seconds, and heritage stack status check from 5 seconds to 30 seconds. This way deployment time-to-complete will get longer up to 30 seconds, and the deployment complete notification can be delayed up to 55 seconds. I think it's acceptable and much better than deployments being rejected ☺️ 