### PR TITLE
Update AMI of container and bastion instances to 2.0.20220304

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-01783fbb0757adced",
-        "us-east-2"      => "ami-0adc4758ea76442e2",
-        "us-west-1"      => "ami-00becdb34b62bf459",
-        "us-west-2"      => "ami-09f043c293281ecd4",
-        "eu-west-1"      => "ami-015b1508a2ff2c65a",
-        "eu-west-2"      => "ami-0141564f07476504d",
-        "eu-west-3"      => "ami-04cb3664fdfc392bd",
-        "eu-central-1"      => "ami-097b8c9927f9a27bc",
-        "ap-northeast-1"      => "ami-04bbc04d168366d27",
-        "ap-northeast-2"      => "ami-0273b23020d7a59de",
-        "ap-southeast-1"      => "ami-071fbc655b2398016",
-        "ap-southeast-2"      => "ami-032edebfa34883542",
-        "ca-central-1"      => "ami-092b596d9b942c4f8",
-        "ap-south-1"      => "ami-000e4b3f0c9f06ffb",
-        "sa-east-1"      => "ami-003a04511c336560c",
+        "us-east-1"      => "ami-0bb273345f0961e90",
+        "us-east-2"      => "ami-0b9412c869f55216b",
+        "us-west-1"      => "ami-0b8ca4b7493b969fb",
+        "us-west-2"      => "ami-0794df61693647a62",
+        "eu-west-1"      => "ami-034153729211d5d49",
+        "eu-west-2"      => "ami-03dcd3376643be0b2",
+        "eu-west-3"      => "ami-0b9514df9ecc6e210",
+        "eu-central-1"      => "ami-0165971292603e43d",
+        "ap-northeast-1"      => "ami-0f519b7a14dde593c",
+        "ap-northeast-2"      => "ami-0558e36b239113dcb",
+        "ap-southeast-1"      => "ami-00efd500963d83017",
+        "ap-southeast-2"      => "ami-0408190b11a73de67",
+        "ca-central-1"      => "ami-05d9a9c9ea29dfb5a",
+        "ap-south-1"      => "ami-0da7defaf4c4b50ce",
+        "sa-east-1"      => "ami-0ea38f2e9aeeefb18",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-04ad2567c9e3d7893",
-        "us-east-2"      => "ami-0dd0ccab7e2801812",
-        "us-west-1"      => "ami-0074ef78ecb07948c",
-        "us-west-2"      => "ami-00be885d550dcee43",
-        "eu-west-1"      => "ami-09d4a659cdd8677be",
-        "eu-west-2"      => "ami-0fc15d50d39e4503c",
-        "eu-west-3"      => "ami-05f0a049e7aeb407c",
-        "eu-central-1"      => "ami-030e490c34394591b",
-        "ap-northeast-1"      => "ami-0e60b6d05dc38ff11",
-        "ap-northeast-2"      => "ami-0a5a6128e65676ebb",
-        "ap-southeast-1"      => "ami-024221a59c9020e72",
-        "ap-southeast-2"      => "ami-043e0add5c8665836",
-        "ca-central-1"      => "ami-0730e12069ab20c26",
-        "ap-south-1"      => "ami-0f1fb91a596abf28d",
-        "sa-east-1"      => "ami-03a343b9045171cec",
+        "us-east-1"      => "ami-01b20f5ea962e3fe7",
+        "us-east-2"      => "ami-07e19c485c7cf2266",
+        "us-west-1"      => "ami-0577aef94c154720e",
+        "us-west-2"      => "ami-07c73ee7f59efbb9a",
+        "eu-west-1"      => "ami-01ddabedd99da311e",
+        "eu-west-2"      => "ami-0127d411688545f05",
+        "eu-west-3"      => "ami-000fb470705e9b427",
+        "eu-central-1"      => "ami-0b67cc43bc64a6060",
+        "ap-northeast-1"      => "ami-0726c1c7e01759156",
+        "ap-northeast-2"      => "ami-036f006e994752282",
+        "ap-southeast-1"      => "ami-0b65860b1b39327d1",
+        "ap-southeast-2"      => "ami-00b8a691539cc0039",
+        "ca-central-1"      => "ami-08b873ca28bee919b",
+        "ap-south-1"      => "ami-058927a80413afd9e",
+        "sa-east-1"      => "ami-01f19ebd61bd11278",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
