### PR TITLE
Refactor the CF stack

### DIFF
--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -231,19 +231,21 @@ module Backend::Ecs::V2
       end
     end
 
-    def initialize(service, task_definition, desired_count)
+    attr_accessor :task_definition, :desired_count
+
+    def initialize(service)
       stack_name = "#{service.district.name}-#{service.service_name}"
-      options = {
-        service: service,
-        task_definition: task_definition,
-        desired_count: desired_count
-      }
-      super(stack_name, options)
+      @service = service
+      super(stack_name)
     end
 
     def build
       super do |builder|
-        builder.add_builder Builder.new(self, options)
+        builder.add_builder Builder.new(self, {
+          service: @service,
+          task_definition: task_definition,
+          desired_count: desired_count
+        })
       end
     end
   end

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -128,9 +128,9 @@ module CloudFormation
 
     # Returns CF ID => Real ID hash
     def resource_ids
-      @resource_ids ||= begin
-        @resource_ids = Hash[*stack_resources.map { |r| [r.logical_resource_id, r.physical_resource_id] }.flatten]
-      end
+      @resource_ids ||= stack_resources.map do |r|
+        [r.logical_resource_id, r.physical_resource_id]
+      end.to_h
     end
 
     def outputs

--- a/lib/cloud_formation/executor.rb
+++ b/lib/cloud_formation/executor.rb
@@ -122,12 +122,15 @@ module CloudFormation
       !!(status =~ /_IN_PROGRESS/)
     end
 
+    def stack_resources
+      client.describe_stack_resources(stack_name: stack.name).stack_resources
+    end
+
     # Returns CF ID => Real ID hash
     def resource_ids
-      return @resource_ids if @resource_ids
-
-      resp = client.describe_stack_resources(stack_name: stack.name).stack_resources
-      @resource_ids = Hash[*resp.map { |r| [r.logical_resource_id, r.physical_resource_id] }.flatten]
+      @resource_ids ||= begin
+        @resource_ids = Hash[*stack_resources.map { |r| [r.logical_resource_id, r.physical_resource_id] }.flatten]
+      end
     end
 
     def outputs

--- a/spec/models/backend/ecs/v2/adapter_spec.rb
+++ b/spec/models/backend/ecs/v2/adapter_spec.rb
@@ -5,7 +5,9 @@ describe Backend::Ecs::V2::Adapter do
     it "sets desired count to 1" do
       service = create :service, desired_container_count: 1
       adapter = described_class.new(service)
-      expect(adapter).to receive(:cf_executor).with(anything, 1).and_call_original
+      service_stack = adapter.send(:service_stack)
+      expect(service_stack).to receive(:desired_count=).with(1)
+      expect(adapter).to receive(:cf_executor).and_call_original
 
       adapter.apply
     end
@@ -15,9 +17,11 @@ describe Backend::Ecs::V2::Adapter do
 
       adapter = described_class.new(service)
       ecs_service = instance_double('something')
+      service_stack = adapter.send(:service_stack)
       allow(ecs_service).to receive(:desired_count) { 5 }
       allow(adapter).to receive(:ecs_service) { ecs_service }
-      expect(adapter).to receive(:cf_executor).with(anything, 5).and_call_original
+      expect(service_stack).to receive(:desired_count=).with(5)
+      expect(adapter).to receive(:cf_executor).and_call_original
 
       adapter.apply
     end
@@ -27,9 +31,11 @@ describe Backend::Ecs::V2::Adapter do
 
       adapter = described_class.new(service)
       ecs_service = instance_double('something')
+      service_stack = adapter.send(:service_stack)
       allow(ecs_service).to receive(:desired_count) { 5 }
       allow(adapter).to receive(:ecs_service) { ecs_service }
-      expect(adapter).to receive(:cf_executor).with(anything, 2).and_call_original
+      expect(service_stack).to receive(:desired_count=).with(2)
+      expect(adapter).to receive(:cf_executor).and_call_original
 
       adapter.apply
     end

--- a/spec/models/backend/ecs/v2/service_stack_spec.rb
+++ b/spec/models/backend/ecs/v2/service_stack_spec.rb
@@ -3,7 +3,12 @@ require 'rails_helper'
 describe Backend::Ecs::V2::ServiceStack do
   let(:service) { create :service }
   let(:task_definition) { HeritageTaskDefinition.service_definition(service).to_task_definition }
-  let(:stack) { described_class.new(service, task_definition, 1) }
+  let(:stack) { described_class.new(service) }
+
+  before do
+    stack.task_definition = task_definition
+    stack.desired_count = 1
+  end
 
   it "generates resources" do
     generated = JSON.load stack.target!


### PR DESCRIPTION
This is a refactor on the cloudformation stack management kit, and add some memoization to some methods.

Hopefully the memoization will save us some calls to `describe` in cloudformation that is increasingly causing rate limit errors.

## How to test

This change affects the deployment routines of barcelona so we test it still works properly by just deploying and checking the result.