### PR TITLE
Better branch name error

### DIFF
--- a/.github/workflows/build-reverse-proxy.yml
+++ b/.github/workflows/build-reverse-proxy.yml
@@ -25,6 +25,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip

--- a/.github/workflows/build-run-pack.yml
+++ b/.github/workflows/build-run-pack.yml
@@ -11,6 +11,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip

--- a/.github/workflows/build-wazuh-kibana-proxy.yml
+++ b/.github/workflows/build-wazuh-kibana-proxy.yml
@@ -11,6 +11,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip

--- a/.github/workflows/build-wazuh.yml
+++ b/.github/workflows/build-wazuh.yml
@@ -11,6 +11,8 @@ jobs:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
         DOCKER_BUILDKIT: '1'
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
         ENCRYPTION_KEY: abcdefghijklmn
     runs-on: ubuntu-18.04
     steps:
+    - name: workaround
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v2
     - name: before_install
       run: bundle install

--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -6,7 +6,7 @@ class ReviewApp < ApplicationRecord
   validates :subject, :image_name, :image_tag, :retention, :services, presence: true
   validates :subject, format: {
     with: /\A[a-z0-9][a-z0-9(-|_)]*[a-z0-9]\z/,
-    message: 'must only contain lowercase characters, numbers and hyphens, and can only start and end with a letter or a number'
+    message: 'branch name must only contain lowercase characters, numbers and hyphens, and can only start and end with a letter or a number'
   }
 
   validates :retention, numericality: {greater_than: 0, less_than: 24 * 3600 * 30}

--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -4,7 +4,11 @@ class ReviewApp < ApplicationRecord
 
   attr_accessor :image_name, :image_tag, :services, :before_deploy, :environment
   validates :subject, :image_name, :image_tag, :retention, :services, presence: true
-  validates :subject, format: {with: /\A[a-z0-9][a-z0-9(-|_)]*[a-z0-9]\z/}
+  validates :subject, format: {
+    with: /\A[a-z0-9][a-z0-9(-|_)]*[a-z0-9]\z/,
+    message: 'must only contain lowercase characters, numbers and hyphens, and can only start and end with a letter or a number'
+  }
+
   validates :retention, numericality: {greater_than: 0, less_than: 24 * 3600 * 30}
 
   before_validation :build_heritage

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -96,5 +96,31 @@ describe ReviewApp do
         expect(review_app.heritage.services[0].listeners[0].health_check_path).to eq "/healthcheck"
       end
     end
+
+    context "when a service has capital letters" do
+      let(:review_app) {
+        group.review_apps.new(
+          subject: "SUBJECT",
+          image_name: "image",
+          image_tag: "tag",
+          retention: 12 * 3600,
+          before_deploy: "true",
+          environment: [],
+          services: [{
+            name: "review",
+            command: "true",
+            service_type: "web",
+            listeners: [{
+              health_check_path: "/healthcheck",
+              health_check_interval: 300
+            }]
+          }])
+      }
+
+      it "preserves configurations" do
+        expect(review_app).to_not be_valid
+        expect(review_app.errors[:subject]).to eq(["branch name must only contain lowercase characters, numbers and hyphens, and can only start and end with a letter or a number"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Right now if you deploy a reviewapp with the branch name containing big letters it will fail. This PR will make the message better so the user can fix the problem without having to inspect logs and trace the error back to the source where the verification occurs.