### PR TITLE
Yet another attempt to reduce describe stacks

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -36,6 +36,10 @@ class DeployRunnerJob < ActiveJob::Base
       heritage.services.each do |service|
         result = service.apply
         MonitorDeploymentJob.set(wait: 60.seconds).perform_later(service, deployment_id: result[:deployment_id])
+        # CloudFormation's DescribeStacks has very low rate limit (per second).
+        # To avoid updating all services in a second, here we sleep for 3 second.
+        # (`service.apply` calls `DescribeStacks` API)
+        sleep 3
       end
     end
   end

--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -35,7 +35,7 @@ class DeployRunnerJob < ActiveJob::Base
 
       heritage.services.each do |service|
         result = service.apply
-        MonitorDeploymentJob.perform_later(service, deployment_id: result[:deployment_id])
+        MonitorDeploymentJob.set(wait: 60.seconds).perform_later(service, deployment_id: result[:deployment_id])
       end
     end
   end


### PR DESCRIPTION
- `MonitorDeploymentJob` runs 1 minute later. checking status right after deployment trigger doesn't make sense since deploying a service typically takes at least 1 minute
- `sleep 3`  after triggering service deployment
  - `service.deploy` calls `DescribeStacks`