### PR TITLE
Revert "Merge pull request #606 from degica/expose-deployed"

### DIFF
--- a/app/serializers/heritage_serializer.rb
+++ b/app/serializers/heritage_serializer.rb
@@ -1,6 +1,6 @@
 class HeritageSerializer < ActiveModel::Serializer
   attributes :name, :image_name, :image_tag, :env_vars, :before_deploy,
-             :token, :version, :scheduled_tasks, :environment, :deployed
+             :token, :version, :scheduled_tasks, :environment
 
   has_many :services
   belongs_to :district
@@ -15,9 +15,5 @@ class HeritageSerializer < ActiveModel::Serializer
     object.environments.
       map { |e| e.slice(:name, :value, :value_from) }.
       sort_by { |e| e[:name] }
-  end
-
-  def deployed
-    object.services.map { |s| s.deployment_finished?(nil) }.all?
   end
 end

--- a/app/serializers/service_serializer.rb
+++ b/app/serializers/service_serializer.rb
@@ -1,5 +1,5 @@
 class ServiceSerializer < ActiveModel::Serializer
-  attributes :name, :public, :command, :cpu, :memory, :endpoint, :status, :deployed,
+  attributes :name, :public, :command, :cpu, :memory, :endpoint, :status,
              :port_mappings, :running_count, :pending_count, :desired_count,
              :reverse_proxy_image, :hosts, :service_type, :force_ssl, :health_check
 
@@ -14,9 +14,5 @@ class ServiceSerializer < ActiveModel::Serializer
         protocol: pm.protocol
       }
     end
-  end
-
-  def deployed
-    object.deployment_finished?(nil)
   end
 end

--- a/spec/requests/show_heritage_spec.rb
+++ b/spec/requests/show_heritage_spec.rb
@@ -37,10 +37,8 @@ describe "GET /heritages/:heritage", type: :request do
       expect(heritage["name"]).to eq "nginx"
       expect(heritage["image_name"]).to eq "nginx"
       expect(heritage["image_tag"]).to eq "latest"
-      expect(heritage["deployed"]).to eq true
       expect(heritage["before_deploy"]).to eq "echo hello"
       expect(heritage["services"][0]["name"]).to eq "web"
-      expect(heritage["services"][0]["deployed"]).to eq true
       expect(heritage["services"][0]["public"]).to eq true
       expect(heritage["services"][0]["cpu"]).to eq 128
       expect(heritage["services"][0]["memory"]).to eq 256


### PR DESCRIPTION
This reverts commit da1b113cc9458bcb35f0e99f6d2b5c2d66b76073, reversing
changes made to 38e7bfc7e2812563c787a531acfbe33140b4ca85.

these `deployed` parameter calls CloudFormation's `DescribeStacks` API, 2 times per service so if a heritage has 6 services the API is called 12 times which exceeds CF's rate limit.
Currently the parameter is not actively used so let's revert it. if in the future we need to check deployment status, I think we should add a dedicated API for that.