### PR TITLE
Apply immediate flag

### DIFF
--- a/app/controllers/districts_controller.rb
+++ b/app/controllers/districts_controller.rb
@@ -35,7 +35,7 @@ class DistrictsController < ApplicationController
   def apply_stack
     # Make sure the related resources are in-sync
     @district.save!
-    ApplyDistrict.new(@district).apply
+    ApplyDistrict.new(@district).apply(immediate: apply_params['immediate'])
     head 202
   end
 
@@ -54,6 +54,10 @@ class DistrictsController < ApplicationController
     permitted = create_params
     permitted.delete :name
     permitted
+  end
+
+  def apply_params
+    params.permit(:immediate)
   end
 
   def create_params

--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -31,10 +31,10 @@ class ApplyDistrict
     district.save!
   end
 
-  def apply
+  def apply(immediate: false)
     district.save!
     update_ecs_config
-    district.stack_executor.update(change_set: true)
+    district.stack_executor.update(change_set: !immediate)
   end
 
   def destroy!

--- a/spec/services/apply_district_spec.rb
+++ b/spec/services/apply_district_spec.rb
@@ -30,6 +30,41 @@ describe ApplyDistrict do
     end
   end
 
+  describe "#apply" do
+    # we can't detect a call to this class unless we
+    # replace it with a double. rspec does not automatically
+    # do this for us.
+    let(:stack_executor) { double('Executor') }
+
+    before do
+      allow(district).to receive(:stack_executor) { stack_executor }
+    end
+
+    it 'called without args' do
+      thing = described_class.new(district)
+      expect(thing).to receive(:update_ecs_config)
+      expect(district.stack_executor).to receive(:update).with(change_set: true)
+
+      thing.apply
+    end
+
+    it 'called with true' do
+      thing = described_class.new(district)
+      expect(thing).to receive(:update_ecs_config)
+      expect(district.stack_executor).to receive(:update).with(change_set: false)
+
+      thing.apply(immediate: true)
+    end
+
+    it 'called with false' do
+      thing = described_class.new(district)
+      expect(thing).to receive(:update_ecs_config)
+      expect(district.stack_executor).to receive(:update).with(change_set: true)
+
+      thing.apply(immediate: false)
+    end
+  end
+
   context "When running as ECS task" do
     describe "#create!" do
       context "when district role does not exist" do


### PR DESCRIPTION
This makes it possible to call the API to apply the district change immediately, without requiring a human to log in to the AWS console to apply the stack changeset.