### PR TITLE
Update service count in place

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -77,6 +77,9 @@ class HeritagesController < ApplicationController
     service.save_and_update_container_count!(desired_container_count)
 
     render json: @heritage
+
+  rescue Service::ServiceNotFoundException => e
+    raise ExceptionHandler::NotFound, e.message
   end
 
   PERMITTED_PARAMS = [

--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -74,10 +74,7 @@ class HeritagesController < ApplicationController
   end
 
   def update_service_scale
-    service.desired_container_count = desired_container_count
-    service.save!
-    @heritage.save_and_deploy!(without_before_deploy: true,
-                               description: "Change service scale #{service.name} to #{desired_container_count}")
+    service.save_and_update_container_count!(desired_container_count)
 
     render json: @heritage
   end

--- a/app/models/aws_accessor.rb
+++ b/app/models/aws_accessor.rb
@@ -40,6 +40,10 @@ class AwsAccessor
     @ssm ||= Aws::SSM::Client.new(client_config)
   end
 
+  def sts
+    @ssm ||= Aws::STS::Client.new(client_config)
+  end
+
   private
 
   def client_config

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -123,7 +123,7 @@ class Service < ActiveRecord::Base
   private
 
   def ecs
-    ecs = district.aws.ecs
+    @ecs ||= district.aws.ecs
   end
 
   def validate_listener_count

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -96,7 +96,16 @@ class Service < ActiveRecord::Base
     })
   end
 
+  def service_exists
+    !arn.nil?
+  end
+
+  class ServiceNotFoundException < StandardError
+  end
+
   def logical_name
+    raise ServiceNotFoundException, arn_prefix unless service_exists
+
     arn.split('/').last
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -85,7 +85,46 @@ class Service < ActiveRecord::Base
     backend.deployment_finished?(deployment_id)
   end
 
+  def save_and_update_container_count!(desired_container_count)
+    self.desired_container_count = desired_container_count
+    self.save!
+
+    ecs.update_service({
+      desired_count: desired_container_count,
+      cluster: district.name,
+      service: logical_name
+    })
+  end
+
+  def logical_name
+    arn.split('/').last
+  end
+
+  def arn
+    service_arns.find { |x| x.start_with? arn_prefix }
+  end
+
+  def service_arns
+    s = ecs.list_services({
+      cluster: district.name
+    })
+    s.service_arns
+  end
+
+  def arn_prefix
+    [
+      'arn:aws:ecs',
+      district.region,
+      district.aws.sts.get_caller_identity[:account],
+      "service/#{district.name}/#{district.name}-#{service_name}"
+    ].join(':')
+  end
+
   private
+
+  def ecs
+    ecs = district.aws.ecs
+  end
 
   def validate_listener_count
     # Currently ECS doesn't allow multiple target groups
@@ -107,7 +146,7 @@ class Service < ActiveRecord::Base
     self.port_mappings.where(protocol: 'http').update_all(container_port: self.web_container_port)
     self.port_mappings.where(protocol: 'https').update_all(container_port: self.web_container_port)
   end
-
+    
   def backend
     @backend ||= case heritage.version
                  when 1

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -36,6 +36,12 @@ describe Service do
 
       expect(service.logical_name).to eq 'testdistrict-testserv-abcdef'
     end
+
+    it 'throws an error is arn is nil' do
+      allow(service).to receive(:arn) { nil }
+
+      expect{service.logical_name}.to raise_error Service::ServiceNotFoundException
+    end
   end
 
   describe '#arn' do
@@ -44,6 +50,13 @@ describe Service do
       allow(service).to receive(:arn_prefix) { 'arn:' }
 
       expect(service.arn).to eq 'arn:hello'
+    end
+
+    it 'returns nil if no ARN' do
+      allow(service).to receive(:service_arns) { ['kkk:hello', 'ggg:hello'] }
+      allow(service).to receive(:arn_prefix) { 'arn:' }
+
+      expect(service.arn).to be_nil
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -6,6 +6,82 @@ describe Service do
 
   it { expect{service.save}.to_not raise_error }
 
+  describe '#save_and_update_container_count!' do
+    it 'saves and sets the container count' do
+      expect(service.desired_container_count).to eq nil
+
+      district = double('District')
+      allow(service).to receive(:district) { district }
+      allow(district).to receive(:name) { 'districtest' }
+
+      ecs = double('ECS')
+      allow(service).to receive(:ecs) { ecs }
+      allow(service).to receive(:logical_name) { 'abc' }
+
+      expect(ecs).to receive(:update_service).with({
+        desired_count: 10,
+        cluster: 'districtest',
+        service: 'abc'
+      })
+
+      service.save_and_update_container_count!(10)
+
+      expect(service.desired_container_count).to eq 10
+    end
+  end
+
+  describe '#logical_name' do
+    it 'gives the name of the service' do
+      allow(service).to receive(:arn) { 'arn:aws:ecs:un-north-2:1234567890:service/testdistrict/testdistrict-testserv-abcdef' }
+
+      expect(service.logical_name).to eq 'testdistrict-testserv-abcdef'
+    end
+  end
+
+  describe '#arn' do
+    it 'searches the array and finds the ARN' do
+      allow(service).to receive(:service_arns) { ['arn:hello', 'ggg:hello'] }
+      allow(service).to receive(:arn_prefix) { 'arn:' }
+
+      expect(service.arn).to eq 'arn:hello'
+    end
+  end
+
+  describe '#service_arns' do
+    it 'returns service arns' do
+      district = double('District', name: 'testdistrict')
+
+      result = double('PaginatedSawyer')
+      allow(result).to receive(:service_arns) { ['abc'] }
+
+      ecs = double('ECS')
+      allow(ecs).to receive(:list_services).with(cluster: 'testdistrict') { result }
+
+      allow(service).to receive(:district) { district }
+      allow(service).to receive(:ecs) { ecs }
+
+      expect(service.service_arns).to eq ['abc']
+    end
+  end
+
+  describe '#arn_prefix' do
+    it 'produces a prefix for the arn' do
+      district = double('District',
+        region: 'un-north-2',
+        name: 'testdistrict',
+        aws: double('AWS',
+          sts: double('STS', get_caller_identity: {
+            account: '1234567890'
+          })
+        )
+      )
+      allow(service).to receive(:district) { district }
+      allow(service).to receive(:service_name) { 'testserv' }
+
+      expect(service.arn_prefix).to eq 'arn:aws:ecs:un-north-2:1234567890:service/testdistrict/testdistrict-testserv'
+    end
+  end
+
   describe 'handling port mappings' do
     context 'created with default port' do
       before { service.save }


### PR DESCRIPTION
Previously we used the heritage deploy service to set the task count desired. The issue with this was that the heritage deployer would always create a new task definition, and then deploy that. This meant that ECS would create a new set of tasks with the new count before removing the old set of tasks. This resulted in if you wanted to scale a service from 10 to 20 tasks, you would have a transient situation of 30 tasks online.

This was suboptimal, and this PR fixes that. It calls ECS directly to modify the task count, and updates the db so non-changes do not get propagated.

## How to test

You can use a local ver to test it on any account you have
1. `bcn login https://mytestbarcelona`
2. `bcn district create --region ap-northeast-1 test`
3. `bcn endpoint create -d test --public hello`
4. `cd barcelona-hello` <- this is just the barcelona hello repo
5. `bcn create -e hello -d test`
6. `bcn api post /districts/test/heritages/hello/services/web/count '{"desired_container_count": 2}'`

note that no new task definition is created but the container count is immediately updated.