### PR TITLE
Support legacy ECS services

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -110,7 +110,7 @@ class Service < ActiveRecord::Base
   end
 
   def arn
-    service_arns.find { |x| x.start_with? arn_prefix }
+    service_arns.find { |x| x.start_with?(arn_prefix) || x.start_with?(arn_prefix_legacy) }
   end
 
   def service_arns
@@ -125,7 +125,16 @@ class Service < ActiveRecord::Base
       'arn:aws:ecs',
       district.region,
       district.aws.sts.get_caller_identity[:account],
-      "service/#{district.name}/#{district.name}-#{service_name}"
+      "service/#{district.name}/#{district.name}-#{service_name}-ECSService"
+    ].join(':')
+  end
+
+  def arn_prefix_legacy
+    [
+      'arn:aws:ecs',
+      district.region,
+      district.aws.sts.get_caller_identity[:account],
+      "service/#{district.name}-#{service_name}-ECSService"
     ].join(':')
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -52,6 +52,14 @@ describe Service do
       expect(service.arn).to eq 'arn:hello'
     end
 
+    it 'searches the array and finds a legacy ARN' do
+      allow(service).to receive(:service_arns) { ['arn:old:schwarzenegger', 'ggg:hello'] }
+      allow(service).to receive(:arn_prefix) { 'arn:new' }
+      allow(service).to receive(:arn_prefix_legacy) { 'arn:old' }
+
+      expect(service.arn).to eq 'arn:old:schwarzenegger'
+    end
+
     it 'returns nil if no ARN' do
       allow(service).to receive(:service_arns) { ['kkk:hello', 'ggg:hello'] }
       allow(service).to receive(:arn_prefix) { 'arn:' }
@@ -91,7 +99,25 @@ describe Service do
       allow(service).to receive(:district) { district }
       allow(service).to receive(:service_name) { 'testserv' }
 
-      expect(service.arn_prefix).to eq 'arn:aws:ecs:un-north-2:1234567890:service/testdistrict/testdistrict-testserv'
+      expect(service.arn_prefix).to eq 'arn:aws:ecs:un-north-2:1234567890:service/testdistrict/testdistrict-testserv-ECSService'
+    end
+  end
+
+  describe '#arn_prefix_legacy' do
+    it 'produces a prefix for the arn that conforms to the legacy version' do
+      district = double('District',
+        region: 'un-north-2',
+        name: 'old',
+        aws: double('AWS',
+          sts: double('STS', get_caller_identity: {
+            account: '11111111'
+          })
+        )
+      )
+      allow(service).to receive(:district) { district }
+      allow(service).to receive(:service_name) { 'serv' }
+
+      expect(service.arn_prefix_legacy).to eq 'arn:aws:ecs:un-north-2:11111111:service/old-serv-ECSService'
     end
   end
 


### PR DESCRIPTION
Older services seem to have a different service ARN format.

This PR addresses that and allows us to perform operations on the older services too.