### PR TITLE
iterate through the full service list

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -117,7 +117,9 @@ class Service < ActiveRecord::Base
     s = ecs.list_services({
       cluster: district.name
     })
-    s.service_arns
+
+    # See test to get a model fo thinking about the returned object
+    s.flat_map(&:service_arns)
   end
 
   def arn_prefix


### PR DESCRIPTION
This PR is opened due to a small thing we overlooked where the ecs service can be longer than one page. I have included an explanation to clear up the way AWS works.

Unfortunately to test this you need to create a cluster with lots of services to coax out the behavior. You can modify the code to only return 1 result at a time. But this is well documented now: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/PageableResponse.html