### PR TITLE
Specify a better DeploymentConfiguration on deployment

### DIFF
--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -1,11 +1,13 @@
 module Backend::Ecs::V2
   class ServiceStack < CloudFormation::Stack
     class Builder < CloudFormation::Builder
+      DEPLOYMENT_CONFIGURATION = { "MaximumPercent"=>150, "MinimumHealthyPercent"=>100 }
       def build_resources
         add_resource("AWS::ECS::Service", "ECSService") do |j|
           j.Cluster district.name
           j.TaskDefinition options[:task_definition]
           j.DesiredCount options[:desired_count]
+          j.DeploymentConfiguration DEPLOYMENT_CONFIGURATION
           if use_tcp_load_balancer?
             port_mapping = service.port_mappings.lb_registerable.first
             container_name = service.service_name

--- a/spec/models/backend/ecs/v2/service_stack_spec.rb
+++ b/spec/models/backend/ecs/v2/service_stack_spec.rb
@@ -53,6 +53,18 @@ describe Backend::Ecs::V2::ServiceStack do
         expect(generated["Resources"]["ClassicLoadBalancer"]).to_not be_present
         expect(generated["Resources"]["ECSServiceRole"]).to be_present
       end
+
+      it "generates a service with a proper DeploymentConfiguration" do
+        generated = JSON.load stack.target!
+        generated_service = generated["Resources"]["ECSService"]
+        expect(generated_service["Type"]).to eq("AWS::ECS::Service")
+        expect(generated_service["Properties"]["DesiredCount"]).to eq(1)
+        deployment_configuration = {
+          "MaximumPercent" => 150,
+          "MinimumHealthyPercent" => 100
+        }
+        expect(generated_service["Properties"]["DeploymentConfiguration"]).to eq(deployment_configuration)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR specifies `MaximumPercent` as 150 instead of 200, the default value on deployment.

When you set `desired_count` 100 and default, ECS tries to invoke 100 tasks at once, which causes rate limit error.

Specifying  `MaximumPercent` as 150 makes ECS to invoke 50 tasks and wait for them to be deployed before invoking others.
