### PR TITLE
Update AMI of container and bastion instances to 2.0.20221010

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-07da26e39622a03dc",
-        "us-east-2"      => "ami-0ee5088f037f0da87",
-        "us-west-1"      => "ami-0f71b77f57e47333c",
-        "us-west-2"      => "ami-005b5f3941c234694",
-        "eu-west-1"      => "ami-002e2fef4b94f8fd0",
-        "eu-west-2"      => "ami-0fd6a5614931e9e58",
-        "eu-west-3"      => "ami-0c640b37549b56866",
-        "eu-central-1"      => "ami-0319b5b60d7feac49",
-        "ap-northeast-1"      => "ami-0d7f22d6755eea788",
-        "ap-northeast-2"      => "ami-0a6677068219e7cfc",
-        "ap-southeast-1"      => "ami-0855712a34b3f2bf5",
-        "ap-southeast-2"      => "ami-0d03e0afc8a3a307d",
-        "ca-central-1"      => "ami-035efbeaa56bdc777",
-        "ap-south-1"      => "ami-0416723f8e455592c",
-        "sa-east-1"      => "ami-0d081bb03165198ac",
+        "us-east-1"      => "ami-00eb90638788e810f",
+        "us-east-2"      => "ami-0b0033935e98632de",
+        "us-west-1"      => "ami-03d937713d2d29e68",
+        "us-west-2"      => "ami-0091142fcd273792c",
+        "eu-west-1"      => "ami-0bfc7754dbd389d88",
+        "eu-west-2"      => "ami-02bfd81009b599d71",
+        "eu-west-3"      => "ami-05f31f29ba1347d15",
+        "eu-central-1"      => "ami-0479e02f9b310c857",
+        "ap-northeast-1"      => "ami-0ed1560bb509908b1",
+        "ap-northeast-2"      => "ami-0dfe299a8a7fe500e",
+        "ap-southeast-1"      => "ami-0996cfb3acf118b24",
+        "ap-southeast-2"      => "ami-0ace32fdb211c83e0",
+        "ca-central-1"      => "ami-0720b74139c459b83",
+        "ap-south-1"      => "ami-08db0e1881e30be69",
+        "sa-east-1"      => "ami-027961ea9f99b94b8",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-03f8a7b55051ae0d4",
-        "us-east-2"      => "ami-0693a7971cd761811",
-        "us-west-1"      => "ami-0f987281f7836b330",
-        "us-west-2"      => "ami-014b01f8aa1a38b78",
-        "eu-west-1"      => "ami-0e592a261c043bc6a",
-        "eu-west-2"      => "ami-085b9e3ecde6f7626",
-        "eu-west-3"      => "ami-02406e08f57b68b1c",
-        "eu-central-1"      => "ami-0b41652f00b442576",
-        "ap-northeast-1"      => "ami-06228cb76d02ff1c7",
-        "ap-northeast-2"      => "ami-0d15c49f8a42016ec",
-        "ap-southeast-1"      => "ami-026c70a35138a1088",
-        "ap-southeast-2"      => "ami-029517bdb38391983",
-        "ca-central-1"      => "ami-0d1173d3588c3f426",
-        "ap-south-1"      => "ami-09fee13e183eb2baf",
-        "sa-east-1"      => "ami-07414326f9dde3558",
+        "us-east-1"      => "ami-07da26e39622a03dc",
+        "us-east-2"      => "ami-0ee5088f037f0da87",
+        "us-west-1"      => "ami-0f71b77f57e47333c",
+        "us-west-2"      => "ami-005b5f3941c234694",
+        "eu-west-1"      => "ami-002e2fef4b94f8fd0",
+        "eu-west-2"      => "ami-0fd6a5614931e9e58",
+        "eu-west-3"      => "ami-0c640b37549b56866",
+        "eu-central-1"      => "ami-0319b5b60d7feac49",
+        "ap-northeast-1"      => "ami-0d7f22d6755eea788",
+        "ap-northeast-2"      => "ami-0a6677068219e7cfc",
+        "ap-southeast-1"      => "ami-0855712a34b3f2bf5",
+        "ap-southeast-2"      => "ami-0d03e0afc8a3a307d",
+        "ca-central-1"      => "ami-035efbeaa56bdc777",
+        "ap-south-1"      => "ami-0416723f8e455592c",
+        "sa-east-1"      => "ami-0d081bb03165198ac",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-02538f8925e3aa27a",
-        "us-east-2"      => "ami-0ee5c62243ab25259",
-        "us-west-1"      => "ami-0019ad94c6124959d",
-        "us-west-2"      => "ami-07d59d159373b8030",
-        "eu-west-1"      => "ami-038e9cdc714b15936",
-        "eu-west-2"      => "ami-0c496e8bea496ed67",
-        "eu-west-3"      => "ami-002e2b155689f6e23",
-        "eu-central-1"      => "ami-041e64b0129bffca9",
-        "ap-northeast-1"      => "ami-0b069de314c9ab4c4",
-        "ap-northeast-2"      => "ami-066d41d96fc160063",
-        "ap-southeast-1"      => "ami-013586750d303f89d",
-        "ap-southeast-2"      => "ami-0336d88ead51a9210",
-        "ca-central-1"      => "ami-0300c413e2de1804e",
-        "ap-south-1"      => "ami-068cda7597e78094b",
-        "sa-east-1"      => "ami-058f4e20c17271f68",
+        "us-east-1"      => "ami-0464d49b8794eba32",
+        "us-east-2"      => "ami-058d017bb0407da05",
+        "us-west-1"      => "ami-0147bd0a180d521bd",
+        "us-west-2"      => "ami-0620766f9d10d6c9e",
+        "eu-west-1"      => "ami-0af7a5885e3ff0439",
+        "eu-west-2"      => "ami-023665fdad063c8a9",
+        "eu-west-3"      => "ami-0eeba548a1a39b254",
+        "eu-central-1"      => "ami-08658d5197becde34",
+        "ap-northeast-1"      => "ami-01154243795368525",
+        "ap-northeast-2"      => "ami-0bb19571ca7f4bf31",
+        "ap-southeast-1"      => "ami-08326d8b49f61f528",
+        "ap-southeast-2"      => "ami-00aa03f67b64f75dd",
+        "ca-central-1"      => "ami-0d681e46bfc23b29c",
+        "ap-south-1"      => "ami-064687fa05edcd686",
+        "sa-east-1"      => "ami-0e41adb6f66146d4f",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
