### PR TITLE
Enable deploy tracking

### DIFF
--- a/app/jobs/deploy_runner_job.rb
+++ b/app/jobs/deploy_runner_job.rb
@@ -42,6 +42,10 @@ class DeployRunnerJob < ActiveJob::Base
         sleep 3
       end
     end
+
+  rescue => e
+    Rails.logger.error e
+    Rails.logger.error e.backtrace
   end
 
   def other_deploy_in_progress?(heritage)
@@ -51,6 +55,7 @@ class DeployRunnerJob < ActiveJob::Base
   end
 
   def notify(level: :good, message:)
+    Rails.logger.info message
     Event.new(@heritage.district).notify(level: level, message: "[#{@heritage.name}] #{message}")
   end
 end

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -23,6 +23,7 @@ class MonitorDeploymentJob < ActiveJob::Base
   end
 
   def notify(service, level: :good, message:)
+    Rails.logger.info message
     Event.new(service.district).notify(level: level, message: "[#{service.heritage.name}] #{message}")
   end
 end

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -2,6 +2,14 @@ class MonitorDeploymentJob < ActiveJob::Base
   queue_as :default
 
   def perform(service, count: 0, deployment_id: nil)
+    if service.heritage.version == 2
+      ServiceDeployment.create!(service)
+      return
+    end
+
+    # old version does not rely on cloudformation and thus has to be
+    # polled one by one. We will need to clean this up later.
+
     if service.deployment_finished?(deployment_id)
       notify(service, message: "#{service.name} service deployed")
     elsif count > 20

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -2,11 +2,6 @@ class MonitorDeploymentJob < ActiveJob::Base
   queue_as :default
 
   def perform(service, count: 0, deployment_id: nil)
-    if service.heritage.version == 2
-      ServiceDeployment.create!(service: service)
-      return
-    end
-
     # old version does not rely on cloudformation and thus has to be
     # polled one by one. We will need to clean this up later.
 

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -3,7 +3,7 @@ class MonitorDeploymentJob < ActiveJob::Base
 
   def perform(service, count: 0, deployment_id: nil)
     if service.heritage.version == 2
-      ServiceDeployment.create!(service)
+      ServiceDeployment.create!(service: service)
       return
     end
 

--- a/app/jobs/monitor_deployment_job.rb
+++ b/app/jobs/monitor_deployment_job.rb
@@ -2,6 +2,11 @@ class MonitorDeploymentJob < ActiveJob::Base
   queue_as :default
 
   def perform(service, count: 0, deployment_id: nil)
+    if service.heritage.version == 2
+      ServiceDeployment.create!(service: service)
+      return
+    end
+
     # old version does not rely on cloudformation and thus has to be
     # polled one by one. We will need to clean this up later.
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -82,8 +82,11 @@ class Service < ActiveRecord::Base
     port_mappings.find_by(protocol: 'https')
   end
 
-  def deployment_finished?(deployment_id)
-    backend.deployment_finished?(deployment_id)
+  def deployment_finished?(deployment_id=nil)
+    backend.deployment_finished?(deployment_id) if heritage.version == 1
+
+    return true if service_deployment_object.nil?
+    service_deployment_object.finished?
   end
 
   def save_and_update_container_count!(desired_container_count)
@@ -123,6 +126,10 @@ class Service < ActiveRecord::Base
     s.flat_map(&:service_arns)
   end
 
+  def stack_name
+    "#{district.name}-#{heritage.name}-#{name}"
+  end
+
   def arn_prefix
     [
       'arn:aws:ecs',
@@ -147,12 +154,6 @@ class Service < ActiveRecord::Base
     end
 
     service_deployment_object
-  end
-
-  def deployment_finished?
-    return true if service_deployment_object.nil?
-
-    service_deployment_object.finished?
   end
 
   private

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -141,7 +141,25 @@ class Service < ActiveRecord::Base
     ].join(':')
   end
 
+  def deployment
+    if service_deployment_object.nil?
+      ServiceDeployment.create!(service: self)
+    end
+
+    service_deployment_object
+  end
+
+  def deployment_finished?
+    return true if service_deployment_object.nil?
+
+    service_deployment_object.finished?
+  end
+
   private
+
+  def service_deployment_object
+    service_deployments.unfinished.last || service_deployments.last
+  end
 
   def ecs
     @ecs ||= district.aws.ecs

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -1,0 +1,92 @@
+class DeployService
+
+  STATUS_TO_ACTION_MAP = {
+                              "CREATE_IN_PROGRESS" => :incomplete,
+                                   "CREATE_FAILED" => :failed,
+                                 "CREATE_COMPLETE" => :completed,
+                            "ROLLBACK_IN_PROGRESS" => :incomplete,
+                                 "ROLLBACK_FAILED" => :failed,
+                               "ROLLBACK_COMPLETE" => :failed,
+                              "DELETE_IN_PROGRESS" => :incomplete,
+                                   "DELETE_FAILED" => :failed,
+                                 "DELETE_COMPLETE" => :completed,
+                              "UPDATE_IN_PROGRESS" => :incomplete,
+             "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS" => :incomplete,
+                                 "UPDATE_COMPLETE" => :completed,
+                                   "UPDATE_FAILED" => :failed,
+                     "UPDATE_ROLLBACK_IN_PROGRESS" => :failed,
+                          "UPDATE_ROLLBACK_FAILED" => :failed,
+    "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS" => :failed,
+                        "UPDATE_ROLLBACK_COMPLETE" => :failed,
+                              "REVIEW_IN_PROGRESS" => :incomplete,
+                              "IMPORT_IN_PROGRESS" => :incomplete,
+                                 "IMPORT_COMPLETE" => :completed,
+                     "IMPORT_ROLLBACK_IN_PROGRESS" => :failed,
+                          "IMPORT_ROLLBACK_FAILED" => :failed,
+                        "IMPORT_ROLLBACK_COMPLETE" => :failed
+  }.freeze
+
+  class << self
+    def deploy_service(service)
+      ServiceDeployment.create!(service: service)
+    end
+  end
+
+  def initialize(district)
+    @district = district
+  end
+
+  def check
+    statuses = stack_statuses
+
+    @district.heritages.each do |heritage|
+      heritage.services.each do |service|
+        next if service.deployment.finished?
+
+        status = statuses[heritage.name]
+        action = STATUS_TO_ACTION_MAP[status]
+        notify(service, action)
+      end
+    end
+  end
+
+  def notify(service, action)
+    send("notify_#{action}", service)
+  end
+
+  def notify_completed(service)
+  end
+
+  def notify_incomplete(service)
+  end
+
+  def notify_failed(service)
+  end
+
+  def stack_names
+    @stack_names ||= @district.heritages.pluck(:name).map do |x|
+      ["heritage-#{x}", x]
+    end.to_h
+  end
+
+  def stack_statuses
+    results = {}
+
+    cloudformation.list_stacks.each do |response|
+      response.stack_summaries.each do |summary|
+        if stack_names.key?(summary.stack_name)
+          results[stack_names[summary.stack_name]] = summary.stack_status
+        end
+      end
+    end
+
+    results
+  end
+
+  private
+
+  def cloudformation
+    @cloudformation ||= @district.aws.cloudformation
+  end
+
+end

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -14,10 +14,6 @@ environments:
     name: barcelona2
     image_name: public.ecr.aws/degica/barcelona
     before_deploy: rake db:migrate
-    scheduled_tasks:
-      # 10AM JST every week day
-      - schedule: cron(0 1 ? * MON-FRI *)
-        command: bin/chaos
     services:
       - name: web
         service_type: web

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -1,5 +1,16 @@
+scheduled_tasks: &scheduled_tasks
+  scheduled_tasks:
+      # 10AM JST every week day
+      - schedule: cron(0 1 ? * MON-FRI *)
+        command: bin/chaos
+      # every 5 minutes
+      # - schedule: cron(0/5 * ? * * *)
+      #   command: rake bcn:deployment_check
+      # TODO IMPLEMENT A CHECKING FLAG SO TWO TASKS DO NOT COLLIDE
+
 environments:
   production:
+    <<: *scheduled_tasks
     name: barcelona2
     image_name: public.ecr.aws/degica/barcelona
     before_deploy: rake db:migrate
@@ -23,13 +34,10 @@ environments:
         cpu: 128
         memory: 256
   test:
+    <<: *scheduled_tasks
     name: barcelona
     image_name: public.ecr.aws/degica/barcelona
     before_deploy: rake db:migrate
-    scheduled_tasks:
-      # 10AM JST every week day
-      - schedule: cron(0 1 ? * MON-FRI *)
-        command: bin/chaos
     services:
       - name: web
         service_type: web

--- a/barcelona.yml
+++ b/barcelona.yml
@@ -4,9 +4,8 @@ scheduled_tasks: &scheduled_tasks
       - schedule: cron(0 1 ? * MON-FRI *)
         command: bin/chaos
       # every 5 minutes
-      # - schedule: cron(0/5 * ? * * *)
-      #   command: rake bcn:deployment_check
-      # TODO IMPLEMENT A CHECKING FLAG SO TWO TASKS DO NOT COLLIDE
+      - schedule: cron(0/5 * ? * * *)
+        command: rake bcn:deployment_check
 
 environments:
   production:

--- a/lib/tasks/deployment_check.rake
+++ b/lib/tasks/deployment_check.rake
@@ -1,0 +1,10 @@
+namespace :bcn do
+  desc "Check deployments"
+  task :deployment_check => :environment do
+    Rails.logger = Logger.new(STDOUT)
+    Rails.logger.level = :info
+
+    Rails.logger.info("Starting deployment check...")
+    DeployService.check_all
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -232,4 +232,14 @@ describe Service do
       expect(s).to_not be_deployment_finished
     end
   end
+
+  describe '#stack_name' do
+    it 'returns the corresponding stack name' do
+      s = create :service, name: 'serv'
+      allow(s.district).to receive(:name) { 'dist' }
+      allow(s.heritage).to receive(:name) { 'heri' }
+
+      expect(s.stack_name).to eq "dist-heri-serv"
+    end
+  end
 end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -210,4 +210,26 @@ describe Service do
       expect(s2.service_deployments).to eq [s2d1]
     end
   end
+
+  describe '#deployment_finished?' do
+    it 'returns true if there are no deployments (backwards compat)' do
+      s = create :service
+
+      expect(s).to be_deployment_finished
+    end
+
+    it 'returns true if the last one is finished' do
+      s = create :service
+      create :service_deployment, service: s, completed_at: Time.now
+
+      expect(s).to be_deployment_finished
+    end
+
+    it 'returns false if the last one is not yet finished' do
+      s = create :service
+      create :service_deployment, service: s
+
+      expect(s).to_not be_deployment_finished
+    end
+  end
 end

--- a/spec/services/deploy_service_spec.rb
+++ b/spec/services/deploy_service_spec.rb
@@ -14,6 +14,28 @@ describe DeployService, type: :model do
     end
   end
 
+  describe '.check_all' do
+    it 'iterates through all districts' do
+      d1 = create :district
+      d2 = create :district
+      d3 = create :district
+
+      dsdouble1 = double('DeployService')
+      dsdouble2 = double('DeployService')
+      dsdouble3 = double('DeployService')
+
+      expect(DeployService).to receive(:new).with(d1) { dsdouble1 }
+      expect(DeployService).to receive(:new).with(d2) { dsdouble2 }
+      expect(DeployService).to receive(:new).with(d3) { dsdouble3 }
+
+      expect(dsdouble1).to receive(:check)
+      expect(dsdouble2).to receive(:check)
+      expect(dsdouble3).to receive(:check)
+
+      DeployService.check_all
+    end
+  end
+
   describe '#check' do
     it 'is backwards compatible' do
       heritage = create :heritage, name: 'sname', district: district
@@ -215,7 +237,6 @@ describe DeployService, type: :model do
       ds.notify_failed(service)
 
       expect(deployment.reload).to be_failed
-
     end
 
     it 'sets all deployment objects for that service to failed' do

--- a/spec/services/deploy_service_spec.rb
+++ b/spec/services/deploy_service_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+describe DeployService, type: :model do
+  let(:district) { create :district }
+  let(:deployer) { DeployService.new(district) }
+
+  describe '.deploy_service' do
+    it 'simply creates a service deployment object' do
+      heritage = create :heritage, district: district
+      service = create :service, heritage: heritage
+      DeployService.deploy_service(service)
+
+      expect(ServiceDeployment.last.service).to eq service
+    end
+  end
+
+  describe '#check' do
+    it 'is backwards compatible' do
+      heritage = create :heritage, name: 'sname', district: district
+      service = create :service, heritage: heritage
+
+      # if no service deployment object was created
+      # it would need to create one
+
+      ds = DeployService.new(district)
+
+      expect(ds).to receive(:notify_completed).with(service)
+      allow(ds).to receive(:stack_statuses) {
+        {
+          'sname' => 'UPDATE_COMPLETE'
+        }
+      }
+
+      ds.check
+    end
+
+    it 'updates state of services' do
+      heritage = create :heritage, name: 'sname', district: district
+      service = create :service, heritage: heritage
+      create :service_deployment, service: service
+
+      ds = DeployService.new(district)
+
+      expect(ds).to receive(:notify_completed).with(service)
+      allow(ds).to receive(:stack_statuses) {
+        {
+          'sname' => 'UPDATE_COMPLETE'
+        }
+      }
+
+      ds.check
+    end
+
+    it 'updates state of services that are not ready yet' do
+      heritage = create :heritage, name: 'sname', district: district
+      service = create :service, heritage: heritage
+      create :service_deployment, service: service
+
+      ds = DeployService.new(district)
+
+      expect(ds).to receive(:notify_incomplete).with(service)
+      allow(ds).to receive(:stack_statuses) {
+        {
+          'sname' => 'UPDATE_IN_PROGRESS'
+        }
+      }
+
+      ds.check
+    end
+
+    it 'update state of services that are failed' do
+      heritage = create :heritage, name: 'sname', district: district
+      service = create :service, heritage: heritage
+      create :service_deployment, service: service
+
+      ds = DeployService.new(district)
+
+      expect(ds).to receive(:notify_failed).with(service)
+      allow(ds).to receive(:stack_statuses) {
+        {
+          'sname' => 'UPDATE_ROLLBACK_COMPLETE'
+        }
+      }
+
+      ds.check
+    end
+  end
+
+  describe '#stack_statuses' do
+    let(:cfclient) { double('CloudformationClient') }
+
+    it 'updates state of services' do
+      heritage1 = create :heritage, name: 'service-1', district: district
+      heritage2 = create :heritage, name: 'service-2', district: district
+
+      ds = DeployService.new(district)
+
+      allow(ds).to receive(:cloudformation) { cfclient }
+
+      allow(cfclient).to receive(:list_stacks) do
+        [
+          double('Response', stack_summaries:[
+            double('Summary', {
+              stack_name: 'heritage-service-1',
+              stack_status: 'UPDATE_COMPLETE'
+            }),
+
+            double('Summary', {
+              stack_name: 'heritage-service-2',
+              stack_status: 'UPDATE_FAILED'
+            }),
+
+            double('Summary', {
+              stack_name: 'heritage-service-3',
+              stack_status: 'UPDATE_IN_PROGRESS'
+            })
+          ])
+        ]
+      end
+
+      expect(ds.stack_statuses).to eq({
+          'service-1' => 'UPDATE_COMPLETE',
+          'service-2' => 'UPDATE_FAILED'
+      })
+    end
+  end
+
+  describe '#notify_completed' do
+  end
+
+  describe '#notify_incomplete' do
+  end
+
+  describe '#notify_failed' do
+  end
+end


### PR DESCRIPTION
This enables deployment tracking, and replaces the monitor deployment job.