### PR TITLE
Update AMI of container and bastion instances to 2.0.20221230

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-00eb90638788e810f",
-        "us-east-2"      => "ami-0b0033935e98632de",
-        "us-west-1"      => "ami-03d937713d2d29e68",
-        "us-west-2"      => "ami-0091142fcd273792c",
-        "eu-west-1"      => "ami-0bfc7754dbd389d88",
-        "eu-west-2"      => "ami-02bfd81009b599d71",
-        "eu-west-3"      => "ami-05f31f29ba1347d15",
-        "eu-central-1"      => "ami-0479e02f9b310c857",
-        "ap-northeast-1"      => "ami-0ed1560bb509908b1",
-        "ap-northeast-2"      => "ami-0dfe299a8a7fe500e",
-        "ap-southeast-1"      => "ami-0996cfb3acf118b24",
-        "ap-southeast-2"      => "ami-0ace32fdb211c83e0",
-        "ca-central-1"      => "ami-0720b74139c459b83",
-        "ap-south-1"      => "ami-08db0e1881e30be69",
-        "sa-east-1"      => "ami-027961ea9f99b94b8",
+        "us-east-1"      => "ami-00eb0dc604a8124fd",
+        "us-east-2"      => "ami-050d450188abdf32b",
+        "us-west-1"      => "ami-0c8f678811ec85b4c",
+        "us-west-2"      => "ami-0941a7859f46171d5",
+        "eu-west-1"      => "ami-05f3dba3afebe21b5",
+        "eu-west-2"      => "ami-07bce8cc7445f0677",
+        "eu-west-3"      => "ami-0d1bd3a7b041618ca",
+        "eu-central-1"      => "ami-0348a4a91adc75319",
+        "ap-northeast-1"      => "ami-016d3c75481ae6b79",
+        "ap-northeast-2"      => "ami-036e92dacf8a46be6",
+        "ap-southeast-1"      => "ami-0fb7999e80111be40",
+        "ap-southeast-2"      => "ami-0aed88177c42bc09d",
+        "ca-central-1"      => "ami-0f6a7cdcde8d6a540",
+        "ap-south-1"      => "ami-03021e0f712f1a007",
+        "sa-east-1"      => "ami-0b39fbcb9d379b83b",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0464d49b8794eba32",
-        "us-east-2"      => "ami-058d017bb0407da05",
-        "us-west-1"      => "ami-0147bd0a180d521bd",
-        "us-west-2"      => "ami-0620766f9d10d6c9e",
-        "eu-west-1"      => "ami-0af7a5885e3ff0439",
-        "eu-west-2"      => "ami-023665fdad063c8a9",
-        "eu-west-3"      => "ami-0eeba548a1a39b254",
-        "eu-central-1"      => "ami-08658d5197becde34",
-        "ap-northeast-1"      => "ami-01154243795368525",
-        "ap-northeast-2"      => "ami-0bb19571ca7f4bf31",
-        "ap-southeast-1"      => "ami-08326d8b49f61f528",
-        "ap-southeast-2"      => "ami-00aa03f67b64f75dd",
-        "ca-central-1"      => "ami-0d681e46bfc23b29c",
-        "ap-south-1"      => "ami-064687fa05edcd686",
-        "sa-east-1"      => "ami-0e41adb6f66146d4f",
+        "us-east-1"      => "ami-0fe472d8a85bc7b0e",
+        "us-east-2"      => "ami-0ea1d45dcdd47edf6",
+        "us-west-1"      => "ami-0fc161d91b03576d0",
+        "us-west-2"      => "ami-0849a313b038afda0",
+        "eu-west-1"      => "ami-08c149f9b2ace933d",
+        "eu-west-2"      => "ami-02a1ade676420a021",
+        "eu-west-3"      => "ami-065764f88497fd546",
+        "eu-central-1"      => "ami-04a2b113b98bfa0e8",
+        "ap-northeast-1"      => "ami-0b8b7786ce75a2b4f",
+        "ap-northeast-2"      => "ami-0a1d2fce2d3ca6e35",
+        "ap-southeast-1"      => "ami-02c7d3513f9fdf3f6",
+        "ap-southeast-2"      => "ami-0043df2e553ad12b6",
+        "ca-central-1"      => "ami-01aca21057a013fd0",
+        "ap-south-1"      => "ami-093613b5938a7e47c",
+        "sa-east-1"      => "ami-03faa3bc786326505",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the ami of container instances as following page.

- [Amazon ECS\-optimized AMIs \- Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates ami for bastion image.

- https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
