### PR TITLE
Revert ruby to 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/degica/rails-buildpack:2.7 AS builder
+FROM degica/rails-buildpack:2.6 AS builder
 
 ENV APP_HOME=/app
 WORKDIR $APP_HOME

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/degica/rails-buildpack:2.7
+FROM degica/rails-buildpack:2.6
 
 ARG UID=1000
 ARG APP_HOME


### PR DESCRIPTION
This PR reverts #745.

It failed on deployment.

```
$ bcn run -H barcelona2 --user=root bash
Waiting for the process to start
Connecting to the process
root@7533a1a55091:/app# bundle exec rake -T
Could not find racc-1.6.1 in any of the sources
Run `bundle install` to install missing gems.
root@7533a1a55091:/app# ls /usr/local/bundle/gems/racc-1.6.1/
COPYING  ChangeLog  README.ja.rdoc  README.rdoc  TODO  bin  doc  ext  lib
```