### PR TITLE
Update AMI of container and bastion instances to Amazon Linux 2.0.20230214

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Gemfile.lock $APP_HOME/
 
 RUN bundle install -j=4 --without development test
 
-FROM ruby:2.6.5-slim-buster
+FROM --platform=linux/amd64 ruby:2.6.5-slim-buster
 
 ENV APP_HOME=/app
 ENV PATH=$APP_HOME/bin:$PATH

--- a/Kaiserfile
+++ b/Kaiserfile
@@ -13,6 +13,7 @@ vault_host = ENV['VAULT_HOST'] || "http://vault-app"
 vault_port = ENV['VAULT_PORT'] || '8211'
 
 app_params "
+  --platform linux/amd64
   -e RAILS_ENV=development
   -e DATABASE_URL=postgres://postgres:example@<%= db_container_name %>:5432
   -e ENCRYPTION_KEY=abcdefghijklmn

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -4,21 +4,21 @@ module Barcelona
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-00eb0dc604a8124fd",
-        "us-east-2"      => "ami-050d450188abdf32b",
-        "us-west-1"      => "ami-0c8f678811ec85b4c",
-        "us-west-2"      => "ami-0941a7859f46171d5",
-        "eu-west-1"      => "ami-05f3dba3afebe21b5",
-        "eu-west-2"      => "ami-07bce8cc7445f0677",
-        "eu-west-3"      => "ami-0d1bd3a7b041618ca",
-        "eu-central-1"      => "ami-0348a4a91adc75319",
-        "ap-northeast-1"      => "ami-016d3c75481ae6b79",
-        "ap-northeast-2"      => "ami-036e92dacf8a46be6",
-        "ap-southeast-1"      => "ami-0fb7999e80111be40",
-        "ap-southeast-2"      => "ami-0aed88177c42bc09d",
-        "ca-central-1"      => "ami-0f6a7cdcde8d6a540",
-        "ap-south-1"      => "ami-03021e0f712f1a007",
-        "sa-east-1"      => "ami-0b39fbcb9d379b83b",
+        "us-east-1"      => "ami-0ac7415dd546fb485",
+        "us-east-2"      => "ami-0762583c8189d4204",
+        "us-west-1"      => "ami-0a46e50ca5d942c61",
+        "us-west-2"      => "ami-0ae546d2dd33d2039",
+        "eu-west-1"      => "ami-06c1d5fe67809f5dd",
+        "eu-west-2"      => "ami-07e394e4df20de8d2",
+        "eu-west-3"      => "ami-0151da05859253073",
+        "eu-central-1"      => "ami-06525d74e250ee032",
+        "ap-northeast-1"      => "ami-02378d43835d39ff4",
+        "ap-northeast-2"      => "ami-06509d7f0f8f8931f",
+        "ap-southeast-1"      => "ami-009122d67aa62493d",
+        "ap-southeast-2"      => "ami-0dd1294c5a7395c06",
+        "ca-central-1"      => "ami-079445a18d11ec016",
+        "ap-south-1"      => "ami-030493a647e0ba449",
+        "sa-east-1"      => "ami-03cae68c49eefd3ed",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -6,21 +6,21 @@ module Barcelona
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       AMI_IDS = {
-        "us-east-1"      => "ami-0fe472d8a85bc7b0e",
-        "us-east-2"      => "ami-0ea1d45dcdd47edf6",
-        "us-west-1"      => "ami-0fc161d91b03576d0",
-        "us-west-2"      => "ami-0849a313b038afda0",
-        "eu-west-1"      => "ami-08c149f9b2ace933d",
-        "eu-west-2"      => "ami-02a1ade676420a021",
-        "eu-west-3"      => "ami-065764f88497fd546",
-        "eu-central-1"      => "ami-04a2b113b98bfa0e8",
-        "ap-northeast-1"      => "ami-0b8b7786ce75a2b4f",
-        "ap-northeast-2"      => "ami-0a1d2fce2d3ca6e35",
-        "ap-southeast-1"      => "ami-02c7d3513f9fdf3f6",
-        "ap-southeast-2"      => "ami-0043df2e553ad12b6",
-        "ca-central-1"      => "ami-01aca21057a013fd0",
-        "ap-south-1"      => "ami-093613b5938a7e47c",
-        "sa-east-1"      => "ami-03faa3bc786326505",
+        "us-east-1"      => "ami-065bb5126e4504910",
+        "us-east-2"      => "ami-03dd1011b2501fbfd",
+        "us-west-1"      => "ami-034f10b7ffb207ab9",
+        "us-west-2"      => "ami-00b44d3dbe1f81742",
+        "eu-west-1"      => "ami-0482b9ce45184e650",
+        "eu-west-2"      => "ami-099431a4182b79e0f",
+        "eu-west-3"      => "ami-0d019491f88bb6bfa",
+        "eu-central-1"      => "ami-01aa7cea8549a00f9",
+        "ap-northeast-1"      => "ami-0e2faefe48ba06395",
+        "ap-northeast-2"      => "ami-0e6496235b65306a3",
+        "ap-southeast-1"      => "ami-0409b67925493d8b8",
+        "ap-southeast-2"      => "ami-02ed9e6d22bd9a91b",
+        "ca-central-1"      => "ami-06b2d3866642ed0c9",
+        "ap-south-1"      => "ami-04de5880b95cc889b",
+        "sa-east-1"      => "ami-09165e1a0a1e5de44",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this guide:

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
And it also updates the AMI for the bastion image.

https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1

I had issues building the image with Kaiser and previously thought I had to complete [this PR](https://github.com/degica/barcelona/pull/757) before updating the AMIs. But we can proceed with this PR first, I added the platform flag for the docker commands to work. 