### PR TITLE
Use docker image with ruby 2.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Gemfile.lock $APP_HOME/
 RUN bundle config set without 'development test'
 RUN bundle install -j=32
 
-FROM --platform=linux/amd64 ruby:2.6.5-slim-buster
+FROM --platform=linux/amd64 ruby:2.7.7
 
 ENV APP_HOME=/app
 ENV PATH=$APP_HOME/bin:$PATH


### PR DESCRIPTION
The last [commit](https://github.com/degica/barcelona/commit/159d006b5afc11465cbfbe17bee9c9018e5cd069) was missing the final source docker image change to ruby:2.7.7. I think it happened due to a bad rebase I did not correct before it was merged. This broke the build on my box, and also the last [deploy](https://github.com/degica/barcelona/actions/runs/4259748043/jobs/7412257095) seems to have failed.

This change fixes the build on my box.

I have tested this with a local instance of barcelona, and it was able to deploy a stack and application to the staging AWS account. During testing, I discovered that barcelona can currently only create one district per region per account, as there is a resource name conflict for `NATInstance1LaunchTemplate`. I confirmed this is the same behavior as a previous [commit](https://github.com/degica/barcelona/commit/d9488a18ccffb3a2a482aea92428d796da09c132), and some production stacks have a resource named this way.

This version should be safe to deploy.