### PR TITLE
Update show_ecs_images script and AMIs

### DIFF
--- a/bin/show_ecs_images
+++ b/bin/show_ecs_images
@@ -20,7 +20,8 @@ regions=%w(
 )
 def show_image_id_for_amazon_linux2(regions)
   path = '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
-  STDERR.puts "getting image id of #{path}..."
+  image_info=`aws ssm get-parameters --names #{path} --region us-east-1 --output json --query 'Parameters[0]' | jq -r '"Version: " + (.Version|tostring) + ", LastModifiedDate: " +  .LastModifiedDate'`.chomp
+  STDERR.puts "getting image id of #{path} ( latest info is #{image_info} )... Use these for bastion_builder.rb"
 
   regions.each do |region|
     image_id=`aws ssm get-parameters --names #{path} --region #{region} --query 'Parameters[0].Value' --output text`.chomp
@@ -30,8 +31,8 @@ end
 
 def show_image_id_for_ecs_optimized(regions)
   path = '/aws/service/ecs/optimized-ami/amazon-linux-2/recommended'
-  image_name=`aws ssm get-parameters --names #{path} --region us-east-1 --query 'Parameters[0].Value' --output text | jq -r '.image_name'`
-  STDERR.puts "getting image id of #{path} ( latest version is #{image_name} )..."
+  image_info=`aws ssm get-parameters --names #{path} --region us-east-1 --output json --query 'Parameters[0]' | jq -r '"Version: " + (.Version|tostring) + ", LastModifiedDate: " +  .LastModifiedDate + ", image_name: " + (.Value | fromjson.image_name)'`.chomp
+  STDERR.puts "getting image id of #{path} ( latest info is #{image_info} )... Use these for autoscaling_builder.rb"
 
   regions.each do |region|
     image_id=`aws ssm get-parameters --names #{path} --region #{region} --query 'Parameters[0].Value' --output text | jq -r '.image_id'`.chomp

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -3,22 +3,23 @@ module Barcelona
     class AutoscalingBuilder < CloudFormation::Builder
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
+      # latest info is Version: 107, LastModifiedDate: 2023-03-09T05:45:52.704000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230301-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0ac7415dd546fb485",
-        "us-east-2"      => "ami-0762583c8189d4204",
-        "us-west-1"      => "ami-0a46e50ca5d942c61",
-        "us-west-2"      => "ami-0ae546d2dd33d2039",
-        "eu-west-1"      => "ami-06c1d5fe67809f5dd",
-        "eu-west-2"      => "ami-07e394e4df20de8d2",
-        "eu-west-3"      => "ami-0151da05859253073",
-        "eu-central-1"      => "ami-06525d74e250ee032",
-        "ap-northeast-1"      => "ami-02378d43835d39ff4",
-        "ap-northeast-2"      => "ami-06509d7f0f8f8931f",
-        "ap-southeast-1"      => "ami-009122d67aa62493d",
-        "ap-southeast-2"      => "ami-0dd1294c5a7395c06",
-        "ca-central-1"      => "ami-079445a18d11ec016",
-        "ap-south-1"      => "ami-030493a647e0ba449",
-        "sa-east-1"      => "ami-03cae68c49eefd3ed",
+        "us-east-1"      => "ami-0345b85b1018c3e68",
+        "us-east-2"      => "ami-03dc89379f8a305fc",
+        "us-west-1"      => "ami-017f8b160fd639206",
+        "us-west-2"      => "ami-05f991e317f30f87a",
+        "eu-west-1"      => "ami-013192ba56160898d",
+        "eu-west-2"      => "ami-07250c1adbe786654",
+        "eu-west-3"      => "ami-0e600d12462af50d8",
+        "eu-central-1"      => "ami-089a2199aac0b0147",
+        "ap-northeast-1"      => "ami-01703abf1e5cede54",
+        "ap-northeast-2"      => "ami-0e96230fc6327a5ec",
+        "ap-southeast-1"      => "ami-0809e9bb32d947d14",
+        "ap-southeast-2"      => "ami-03c459b1b4740a344",
+        "ca-central-1"      => "ami-08cc570994a129e6d",
+        "ap-south-1"      => "ami-0d16d497d6d61b8a0",
+        "sa-east-1"      => "ami-091427ee6712d1fd3",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,22 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
+      # latest info is Version: 80, LastModifiedDate: 2023-03-01T03:59:44.645000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-065bb5126e4504910",
-        "us-east-2"      => "ami-03dd1011b2501fbfd",
-        "us-west-1"      => "ami-034f10b7ffb207ab9",
-        "us-west-2"      => "ami-00b44d3dbe1f81742",
-        "eu-west-1"      => "ami-0482b9ce45184e650",
-        "eu-west-2"      => "ami-099431a4182b79e0f",
-        "eu-west-3"      => "ami-0d019491f88bb6bfa",
-        "eu-central-1"      => "ami-01aa7cea8549a00f9",
-        "ap-northeast-1"      => "ami-0e2faefe48ba06395",
-        "ap-northeast-2"      => "ami-0e6496235b65306a3",
-        "ap-southeast-1"      => "ami-0409b67925493d8b8",
-        "ap-southeast-2"      => "ami-02ed9e6d22bd9a91b",
-        "ca-central-1"      => "ami-06b2d3866642ed0c9",
-        "ap-south-1"      => "ami-04de5880b95cc889b",
-        "sa-east-1"      => "ami-09165e1a0a1e5de44",
+        "us-east-1"      => "ami-05b5badc2f7ddd88d",
+        "us-east-2"      => "ami-00d883a1ee0640758",
+        "us-west-1"      => "ami-09ef595b9b7b629e8",
+        "us-west-2"      => "ami-0f64dfdea96e44686",
+        "eu-west-1"      => "ami-0e8b5d4aece7e1ce8",
+        "eu-west-2"      => "ami-008f4281d2c5de558",
+        "eu-west-3"      => "ami-02ee946aadc75122f",
+        "eu-central-1"      => "ami-0d8f9265cd415c863",
+        "ap-northeast-1"      => "ami-09d8ed8255877048d",
+        "ap-northeast-2"      => "ami-08730d297b5bafa6c",
+        "ap-southeast-1"      => "ami-02e60e0930ecb38d5",
+        "ap-southeast-2"      => "ami-01f89446d185d9206",
+        "ca-central-1"      => "ami-097a09ed1c70b92c2",
+        "ap-south-1"      => "ami-0ae0c7f8b67be1ffe",
+        "sa-east-1"      => "ami-049da537cd7dc9f69",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this guide:

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
And it also updates the AMI for the bastion image.

https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1

Also updates the show_esc_images script to display more info about the latest images. Added the latest image info as comments into the respective files for future reference.