### PR TITLE
Update drain_instance.py for more than 100 instances and ThrottlingExceptions

### DIFF
--- a/drain_instance.py
+++ b/drain_instance.py
@@ -2,6 +2,7 @@ import boto3
 import json
 import os
 import time
+import random
 
 session = boto3.session.Session()
 ecs = session.client(service_name='ecs')
@@ -9,12 +10,12 @@ ecs = session.client(service_name='ecs')
 clusterName = os.environ["CLUSTER_NAME"]
 
 def ciFor(ec2Id):
-    listResp = ecs.list_container_instances(cluster=clusterName)
-    descResp = ecs.describe_container_instances(cluster=clusterName, containerInstances=listResp['containerInstanceArns'])
-
-    for ci in descResp['containerInstances']:
-        if ci['ec2InstanceId'] == ec2Id:
-            return ci['containerInstanceArn'], ci['status']
+    paginator = ecs.get_paginator('list_container_instances')
+    for page in paginator.paginate(cluster=clusterName):
+        descResp = ecs.describe_container_instances(cluster=clusterName, containerInstances=page['containerInstanceArns'])
+        for ci in descResp['containerInstances']:
+            if ci['ec2InstanceId'] == ec2Id:
+                return ci['containerInstanceArn'], ci['status']
 
     return None, None
 
@@ -28,16 +29,24 @@ def lambda_handler(event, context):
     if msg['LifecycleTransition'] != 'autoscaling:EC2_INSTANCE_TERMINATING':
         return
 
-    ciId, status = ciFor(ec2Id)
-    if ciId == None:
-        return
+    # wait for random time to avoid ThrottlingException of AWS API call
+    sec = random.uniform(0, 5)
+    time.sleep(sec)
 
-    if status != 'DRAINING':
-        ecs.update_container_instances_state(cluster=clusterName,containerInstances=[ciId],status='DRAINING')
+    try:
+        ciId, status = ciFor(ec2Id)
+        if ciId == None:
+            return
+        if status != 'DRAINING':
+            ecs.update_container_instances_state(cluster=clusterName,containerInstances=[ciId],status='DRAINING')
 
-    tasks = ecs.list_tasks(cluster=clusterName, containerInstance=ciId)['taskArns']
-    if len(tasks) > 0:
-        time.sleep(5)
+        tasks = ecs.list_tasks(cluster=clusterName, containerInstance=ciId)['taskArns']
+        if len(tasks) > 0:
+            time.sleep(5)
+            session.client('sns').publish(TopicArn=topicArn, Message=json.dumps(msg), Subject='Invoking lambda again')
+        else:
+            session.client('autoscaling').complete_lifecycle_action(LifecycleHookName=lifecycleHookName, AutoScalingGroupName=asgName, LifecycleActionResult='CONTINUE', InstanceId=ec2Id)
+    except ThrottlingException:
+        sec = random.uniform(3, 5)
+        time.sleep(sec)
         session.client('sns').publish(TopicArn=topicArn, Message=json.dumps(msg), Subject='Invoking lambda again')
-    else:
-        session.client('autoscaling').complete_lifecycle_action(LifecycleHookName=lifecycleHookName, AutoScalingGroupName=asgName, LifecycleActionResult='CONTINUE', InstanceId=ec2Id)


### PR DESCRIPTION
Fixes https://github.com/degica/barcelona/issues/762

This PR also add a random wait for reducing the chance of ThrottlingException.

I have tested it on staging district by scaling up to 150 and down to 10 sometimes. All the container instances are draind.