### PR TITLE
Change the STOPSIGNAL of reverse proxy

### DIFF
--- a/dockerfiles/reverse-proxy/Dockerfile
+++ b/dockerfiles/reverse-proxy/Dockerfile
@@ -11,3 +11,4 @@ COPY render_template.rb /render_template.rb
 COPY entrypoint /entrypoint
 
 ENTRYPOINT ["/entrypoint"]
+STOPSIGNAL SIGQUIT


### PR DESCRIPTION
This PR changes the signal used on `docker stop` from the default, SIGTERM, to SIGQUIT.

This change will make nginx do graceful shutdown on terminates.

http://nginx.org/en/docs/control.html

This change is taken from [a ticket of public nginx docker image](https://github.com/nginxinc/docker-nginx/issues/377). It seems not applied to the image we are using.
> The Dockerfiles in this project [use](https://github.com/nginxinc/docker-nginx/blob/master/stable/buster/Dockerfile#L101) STOPSIGNAL SIGTERM (which actually isn't necessary since this is the default).
> What this means in practice is that when Docker or Kubernetes decide to stop a container, nginx will die immediately, closing any connections straight away:
> It would be much healthier, and comply with the ethos of both Docker and Kubernetes if instead the nginx image made an effort to close all connections before shutting down. 