### PR TITLE
Update to gp3 block store

### DIFF
--- a/bin/show_ecs_images
+++ b/bin/show_ecs_images
@@ -19,6 +19,7 @@ regions=%w(
   sa-east-1
 )
 def show_image_id_for_amazon_linux2(regions)
+  # can use gp2 for gp3 block stores
   path = '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
   STDERR.puts "getting image id of #{path}..."
 

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -26,6 +26,10 @@ module Barcelona
         !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
       end
 
+      def instance_store_present?
+        !!(instance_type =~ /\A(m6.d)\..+\z/)
+      end
+
       def build_resources
         add_resource("AWS::AutoScaling::LaunchConfiguration",
                      "ContainerInstanceLaunchConfiguration") do |j|
@@ -38,6 +42,7 @@ module Barcelona
           j.MetadataOptions do |m|
             m.HttpTokens 'required'
           end
+
           j.BlockDeviceMappings [
             # Root volume
             # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2ami-storage-config.html
@@ -45,8 +50,10 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
-                "VolumeSize" => 100,
-                "VolumeType" => "gp2"
+                               "Iops" => 3000,
+                         "Throughput" => 125,
+                         "VolumeSize" => 100,
+                         "VolumeType" => "gp3"
               }
             }
           ]

--- a/lib/barcelona/network/rds_stack.rb
+++ b/lib/barcelona/network/rds_stack.rb
@@ -16,7 +16,7 @@ module Barcelona::Network
           ref("DBSecurityGroup")
         ]
         j.DBSubnetGroupName ref("DBSubnetGroup")
-        j.StorageType "gp2"
+        j.StorageType "gp3"
       end
 
       add_resource("AWS::EC2::SecurityGroup", "DBSecurityGroup") do |j|

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -212,8 +212,10 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
-                "VolumeSize" => 8,
-                "VolumeType" => "gp2"
+                               "Iops" => 3000,
+                         "Throughput" => 125,
+                         "VolumeSize" => 100,
+                         "VolumeType" => "gp3"
               }
             },
           ]

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -148,8 +148,14 @@ describe Barcelona::Network::NetworkStack do
           "EbsOptimized" => true,
           "BlockDeviceMappings" => [
             {
-              "DeviceName"=>"/dev/xvda",
-              "Ebs" => {"DeleteOnTermination"=>true, "VolumeSize"=>100, "VolumeType"=>"gp2"}
+              "DeviceName" => "/dev/xvda",
+              "Ebs" => {
+                "DeleteOnTermination" => true,
+                               "Iops" => 3000,
+                         "Throughput" => 125,
+                         "VolumeSize" => 100,
+                         "VolumeType" => "gp3"
+              }
             }
           ]
         }


### PR DESCRIPTION
Amazon's GP3 block stores are more customizable and use less money. We can update this for our own purposes.