### PR TITLE
Update AMI of container and bastion instances to Amazon Linux 2.0.20230321

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -3,23 +3,23 @@ module Barcelona
     class AutoscalingBuilder < CloudFormation::Builder
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
-      # latest info is Version: 107, LastModifiedDate: 2023-03-09T05:45:52.704000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230301-x86_64-ebs
+      # latest info is Version: 109, LastModifiedDate: 2023-03-29T00:30:12.103000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230321-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0345b85b1018c3e68",
-        "us-east-2"      => "ami-03dc89379f8a305fc",
-        "us-west-1"      => "ami-017f8b160fd639206",
-        "us-west-2"      => "ami-05f991e317f30f87a",
-        "eu-west-1"      => "ami-013192ba56160898d",
-        "eu-west-2"      => "ami-07250c1adbe786654",
-        "eu-west-3"      => "ami-0e600d12462af50d8",
-        "eu-central-1"      => "ami-089a2199aac0b0147",
-        "ap-northeast-1"      => "ami-01703abf1e5cede54",
-        "ap-northeast-2"      => "ami-0e96230fc6327a5ec",
-        "ap-southeast-1"      => "ami-0809e9bb32d947d14",
-        "ap-southeast-2"      => "ami-03c459b1b4740a344",
-        "ca-central-1"      => "ami-08cc570994a129e6d",
-        "ap-south-1"      => "ami-0d16d497d6d61b8a0",
-        "sa-east-1"      => "ami-091427ee6712d1fd3",
+        "us-east-1"      => "ami-0c76be34ffbfb0b14",
+        "us-east-2"      => "ami-076214eda80ae72ef",
+        "us-west-1"      => "ami-0d54a8e02fa6fbeec",
+        "us-west-2"      => "ami-0c6ee50d15e7364d4",
+        "eu-west-1"      => "ami-0ef8272297113026d",
+        "eu-west-2"      => "ami-08ca13e7fb2ec74db",
+        "eu-west-3"      => "ami-0361c8c21e6630839",
+        "eu-central-1"      => "ami-0161e00a80b3f7535",
+        "ap-northeast-1"      => "ami-02a0270a232f442b0",
+        "ap-northeast-2"      => "ami-06e1828e3449a66a5",
+        "ap-southeast-1"      => "ami-000e3c1953aef9f7d",
+        "ap-southeast-2"      => "ami-01d8443c7f6628efe",
+        "ca-central-1"      => "ami-0220149e79e484f34",
+        "ap-south-1"      => "ami-0352888a5fa748216",
+        "sa-east-1"      => "ami-0cd73f4ec7e0d4559",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 80, LastModifiedDate: 2023-03-01T03:59:44.645000+09:00
+      # latest info is Version: 82, LastModifiedDate: 2023-03-24T04:58:42.118000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-05b5badc2f7ddd88d",
-        "us-east-2"      => "ami-00d883a1ee0640758",
-        "us-west-1"      => "ami-09ef595b9b7b629e8",
-        "us-west-2"      => "ami-0f64dfdea96e44686",
-        "eu-west-1"      => "ami-0e8b5d4aece7e1ce8",
-        "eu-west-2"      => "ami-008f4281d2c5de558",
-        "eu-west-3"      => "ami-02ee946aadc75122f",
-        "eu-central-1"      => "ami-0d8f9265cd415c863",
-        "ap-northeast-1"      => "ami-09d8ed8255877048d",
-        "ap-northeast-2"      => "ami-08730d297b5bafa6c",
-        "ap-southeast-1"      => "ami-02e60e0930ecb38d5",
-        "ap-southeast-2"      => "ami-01f89446d185d9206",
-        "ca-central-1"      => "ami-097a09ed1c70b92c2",
-        "ap-south-1"      => "ami-0ae0c7f8b67be1ffe",
-        "sa-east-1"      => "ami-049da537cd7dc9f69",
+        "us-east-1"      => "ami-06d3b5e1ed9e1d982",
+        "us-east-2"      => "ami-097bdef77f0f80fa6",
+        "us-west-1"      => "ami-0be8c499bc9cd5ac6",
+        "us-west-2"      => "ami-001e91409ff66b7b0",
+        "eu-west-1"      => "ami-0990f25dae5f0ae14",
+        "eu-west-2"      => "ami-0af46197a872cda03",
+        "eu-west-3"      => "ami-01fde5e5b31e98551",
+        "eu-central-1"      => "ami-09b7450350496e62d",
+        "ap-northeast-1"      => "ami-0ec1b47781bc9d6d1",
+        "ap-northeast-2"      => "ami-0e282bbf414018019",
+        "ap-southeast-1"      => "ami-0968d8c309285bfbc",
+        "ap-southeast-2"      => "ami-0ba1c1fc8b9ec09b8",
+        "ca-central-1"      => "ami-0d1fdfcfaef4dae90",
+        "ap-south-1"      => "ami-012856638f0051bd5",
+        "sa-east-1"      => "ami-042409731c376b558",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this guide:

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

And it also updates the AMI for the bastion image.

https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
