### PR TITLE
Adding processing time fields to nginx logs

### DIFF
--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -68,6 +68,7 @@ def default_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request" $status $body_bytes_sent '
     '"$http_referer" "$http_user_agent"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
   LOG_FORMAT
 end
 
@@ -76,6 +77,7 @@ def no_query_params_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request_method $uri $server_protocol" $status $body_bytes_sent '
     '"$http_user_agent"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
   LOG_FORMAT
 end
 


### PR DESCRIPTION
### Purpose
This PR adds processing times to the Nginx log. This helps us debug request delays.

Context:
https://degica.slack.com/archives/CTG3QN2C9/p1681720334180109