### PR TITLE
Update AMI of container and bastion instances to Amazon Linux 2.0.20230428

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -3,23 +3,25 @@ module Barcelona
     class AutoscalingBuilder < CloudFormation::Builder
       # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
       # amzn2-ami-ecs-hvm-2.0
-      # latest info is Version: 109, LastModifiedDate: 2023-03-29T00:30:12.103000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230321-x86_64-ebs
+      # You can see the latest version stored in public SSM parameter store
+      # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
+      # latest info is Version: 112, LastModifiedDate: 2023-05-06T06:49:53.602000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230428-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0c76be34ffbfb0b14",
-        "us-east-2"      => "ami-076214eda80ae72ef",
-        "us-west-1"      => "ami-0d54a8e02fa6fbeec",
-        "us-west-2"      => "ami-0c6ee50d15e7364d4",
-        "eu-west-1"      => "ami-0ef8272297113026d",
-        "eu-west-2"      => "ami-08ca13e7fb2ec74db",
-        "eu-west-3"      => "ami-0361c8c21e6630839",
-        "eu-central-1"      => "ami-0161e00a80b3f7535",
-        "ap-northeast-1"      => "ami-02a0270a232f442b0",
-        "ap-northeast-2"      => "ami-06e1828e3449a66a5",
-        "ap-southeast-1"      => "ami-000e3c1953aef9f7d",
-        "ap-southeast-2"      => "ami-01d8443c7f6628efe",
-        "ca-central-1"      => "ami-0220149e79e484f34",
-        "ap-south-1"      => "ami-0352888a5fa748216",
-        "sa-east-1"      => "ami-0cd73f4ec7e0d4559",
+        "us-east-1"      => "ami-090310a05d8eae025",
+        "us-east-2"      => "ami-02fd619ee86a2a3d8",
+        "us-west-1"      => "ami-0de23ce0365cb8ac2",
+        "us-west-2"      => "ami-0f9d51af8f7bd2135",
+        "eu-west-1"      => "ami-01c6d3733d0803993",
+        "eu-west-2"      => "ami-08bf6d5e3a39b36ae",
+        "eu-west-3"      => "ami-0dc8a5b98034eb6ae",
+        "eu-central-1"      => "ami-09822cbc47b3c1ce2",
+        "ap-northeast-1"      => "ami-0031a745da0bb1445",
+        "ap-northeast-2"      => "ami-02902330f629f7d79",
+        "ap-southeast-1"      => "ami-0a1409bf94faa559f",
+        "ap-southeast-2"      => "ami-04de619f62ed50f60",
+        "ca-central-1"      => "ami-0844bfc4148241d58",
+        "ap-south-1"      => "ami-0728433edfacabeeb",
+        "sa-east-1"      => "ami-0de5edb525dcf403a",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 82, LastModifiedDate: 2023-03-24T04:58:42.118000+09:00
+      # latest info is Version: 85, LastModifiedDate: 2023-04-25T07:24:27.345000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-06d3b5e1ed9e1d982",
-        "us-east-2"      => "ami-097bdef77f0f80fa6",
-        "us-west-1"      => "ami-0be8c499bc9cd5ac6",
-        "us-west-2"      => "ami-001e91409ff66b7b0",
-        "eu-west-1"      => "ami-0990f25dae5f0ae14",
-        "eu-west-2"      => "ami-0af46197a872cda03",
-        "eu-west-3"      => "ami-01fde5e5b31e98551",
-        "eu-central-1"      => "ami-09b7450350496e62d",
-        "ap-northeast-1"      => "ami-0ec1b47781bc9d6d1",
-        "ap-northeast-2"      => "ami-0e282bbf414018019",
-        "ap-southeast-1"      => "ami-0968d8c309285bfbc",
-        "ap-southeast-2"      => "ami-0ba1c1fc8b9ec09b8",
-        "ca-central-1"      => "ami-0d1fdfcfaef4dae90",
-        "ap-south-1"      => "ami-012856638f0051bd5",
-        "sa-east-1"      => "ami-042409731c376b558",
+        "us-east-1"      => "ami-02d69c34f7a0bf36a",
+        "us-east-2"      => "ami-01e59c211bdf9da28",
+        "us-west-1"      => "ami-07d9c945c74a1dff3",
+        "us-west-2"      => "ami-069be11a330abe15b",
+        "eu-west-1"      => "ami-0b6f8b704bc8dffa7",
+        "eu-west-2"      => "ami-0e3dd4f4b84ef84f5",
+        "eu-west-3"      => "ami-0e41fc02dc8fca79b",
+        "eu-central-1"      => "ami-091dab6f23d05f648",
+        "ap-northeast-1"      => "ami-05c7416867898f878",
+        "ap-northeast-2"      => "ami-0f4e16a6f2ceab9ef",
+        "ap-southeast-1"      => "ami-04008951c9ded5b67",
+        "ap-southeast-2"      => "ami-036a1e4556520be0c",
+        "ca-central-1"      => "ami-04c11eee2ddb80ae1",
+        "ap-south-1"      => "ami-0011b0621d70eafd9",
+        "sa-east-1"      => "ami-079dd71bcddf9d92c",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this guide:

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
