### PR TITLE
Update bastion and container instance AMI to Amazon Linux 2 2.0.20230515.0

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 112, LastModifiedDate: 2023-05-06T06:49:53.602000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230428-x86_64-ebs
+      # latest info is Version: 114, LastModifiedDate: 2023-06-02T05:20:26.587000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230530-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-090310a05d8eae025",
-        "us-east-2"      => "ami-02fd619ee86a2a3d8",
-        "us-west-1"      => "ami-0de23ce0365cb8ac2",
-        "us-west-2"      => "ami-0f9d51af8f7bd2135",
-        "eu-west-1"      => "ami-01c6d3733d0803993",
-        "eu-west-2"      => "ami-08bf6d5e3a39b36ae",
-        "eu-west-3"      => "ami-0dc8a5b98034eb6ae",
-        "eu-central-1"      => "ami-09822cbc47b3c1ce2",
-        "ap-northeast-1"      => "ami-0031a745da0bb1445",
-        "ap-northeast-2"      => "ami-02902330f629f7d79",
-        "ap-southeast-1"      => "ami-0a1409bf94faa559f",
-        "ap-southeast-2"      => "ami-04de619f62ed50f60",
-        "ca-central-1"      => "ami-0844bfc4148241d58",
-        "ap-south-1"      => "ami-0728433edfacabeeb",
-        "sa-east-1"      => "ami-0de5edb525dcf403a",
+        "us-east-1"      => "ami-04d9730eb75fb5301",
+        "us-east-2"      => "ami-002837afd61619c4a",
+        "us-west-1"      => "ami-036c16fe6c06e602b",
+        "us-west-2"      => "ami-036f51d99e53d0c67",
+        "eu-west-1"      => "ami-07ee103aa418d4c1a",
+        "eu-west-2"      => "ami-05031bcb444e966c6",
+        "eu-west-3"      => "ami-0619a87524af4765e",
+        "eu-central-1"      => "ami-08d7cc30c35e1adbd",
+        "ap-northeast-1"      => "ami-0752b1d81232e2008",
+        "ap-northeast-2"      => "ami-0f85b3bc942f9b861",
+        "ap-southeast-1"      => "ami-0078cac10e3519047",
+        "ap-southeast-2"      => "ami-03a0a389761973845",
+        "ca-central-1"      => "ami-0549f525f3c1dc87f",
+        "ap-south-1"      => "ami-08d8d17a037350913",
+        "sa-east-1"      => "ami-01d764ec22ffcb131",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 85, LastModifiedDate: 2023-04-25T07:24:27.345000+09:00
+      # latest info is Version: 88, LastModifiedDate: 2023-06-08T02:46:56.346000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-02d69c34f7a0bf36a",
-        "us-east-2"      => "ami-01e59c211bdf9da28",
-        "us-west-1"      => "ami-07d9c945c74a1dff3",
-        "us-west-2"      => "ami-069be11a330abe15b",
-        "eu-west-1"      => "ami-0b6f8b704bc8dffa7",
-        "eu-west-2"      => "ami-0e3dd4f4b84ef84f5",
-        "eu-west-3"      => "ami-0e41fc02dc8fca79b",
-        "eu-central-1"      => "ami-091dab6f23d05f648",
-        "ap-northeast-1"      => "ami-05c7416867898f878",
-        "ap-northeast-2"      => "ami-0f4e16a6f2ceab9ef",
-        "ap-southeast-1"      => "ami-04008951c9ded5b67",
-        "ap-southeast-2"      => "ami-036a1e4556520be0c",
-        "ca-central-1"      => "ami-04c11eee2ddb80ae1",
-        "ap-south-1"      => "ami-0011b0621d70eafd9",
-        "sa-east-1"      => "ami-079dd71bcddf9d92c",
+        "us-east-1"      => "ami-0c503d55a14d7a5f0",
+        "us-east-2"      => "ami-0dcbd2aa4a07a555b",
+        "us-west-1"      => "ami-0341ed0c1a5b70a87",
+        "us-west-2"      => "ami-0033f83482a4826f7",
+        "eu-west-1"      => "ami-0893e0c8fedb87927",
+        "eu-west-2"      => "ami-0d41efbc59109083c",
+        "eu-west-3"      => "ami-0fca2c9a397d947c4",
+        "eu-central-1"      => "ami-0b666c2ce15c8b118",
+        "ap-northeast-1"      => "ami-0e4d52202ff18bfea",
+        "ap-northeast-2"      => "ami-0b9e07b9baa424b6d",
+        "ap-southeast-1"      => "ami-0facd4d2e6f6f9e82",
+        "ap-southeast-2"      => "ami-073050df4f7d7f92c",
+        "ca-central-1"      => "ami-07e12bf3989c30960",
+        "ap-south-1"      => "ami-022d3078cc11f0e12",
+        "sa-east-1"      => "ami-00ce474e4c650fc40",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230524.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
