### PR TITLE
Amazon Linux 2 2.0.20230612.0

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 114, LastModifiedDate: 2023-06-02T05:20:26.587000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230530-x86_64-ebs
+      # latest info is Version: 115, LastModifiedDate: 2023-06-14T00:04:46.565000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230606-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-04d9730eb75fb5301",
-        "us-east-2"      => "ami-002837afd61619c4a",
-        "us-west-1"      => "ami-036c16fe6c06e602b",
-        "us-west-2"      => "ami-036f51d99e53d0c67",
-        "eu-west-1"      => "ami-07ee103aa418d4c1a",
-        "eu-west-2"      => "ami-05031bcb444e966c6",
-        "eu-west-3"      => "ami-0619a87524af4765e",
-        "eu-central-1"      => "ami-08d7cc30c35e1adbd",
-        "ap-northeast-1"      => "ami-0752b1d81232e2008",
-        "ap-northeast-2"      => "ami-0f85b3bc942f9b861",
-        "ap-southeast-1"      => "ami-0078cac10e3519047",
-        "ap-southeast-2"      => "ami-03a0a389761973845",
-        "ca-central-1"      => "ami-0549f525f3c1dc87f",
-        "ap-south-1"      => "ami-08d8d17a037350913",
-        "sa-east-1"      => "ami-01d764ec22ffcb131",
+        "us-east-1"      => "ami-0bf5ac026c9b5eb88",
+        "us-east-2"      => "ami-0840e4520d7b31497",
+        "us-west-1"      => "ami-0b442c02c1d3d2a18",
+        "us-west-2"      => "ami-0bde6c5470d17d540",
+        "eu-west-1"      => "ami-0637e5fd8f888abf4",
+        "eu-west-2"      => "ami-0206dc2da4b3b0a01",
+        "eu-west-3"      => "ami-0c2a9175f394c6105",
+        "eu-central-1"      => "ami-07480655a02fc53ae",
+        "ap-northeast-1"      => "ami-0f386dc4885ec169f",
+        "ap-northeast-2"      => "ami-0063312c13bc1e1ad",
+        "ap-southeast-1"      => "ami-0167d4afc8591fe51",
+        "ap-southeast-2"      => "ami-0c1b561b88a479085",
+        "ca-central-1"      => "ami-005cf0ce5ca6d42d4",
+        "ap-south-1"      => "ami-0c8892ce5874c1780",
+        "sa-east-1"      => "ami-066162c92c1822390",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 88, LastModifiedDate: 2023-06-08T02:46:56.346000+09:00
+      # latest info is Version: 89, LastModifiedDate: 2023-06-16T03:56:41.330000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-0c503d55a14d7a5f0",
-        "us-east-2"      => "ami-0dcbd2aa4a07a555b",
-        "us-west-1"      => "ami-0341ed0c1a5b70a87",
-        "us-west-2"      => "ami-0033f83482a4826f7",
-        "eu-west-1"      => "ami-0893e0c8fedb87927",
-        "eu-west-2"      => "ami-0d41efbc59109083c",
-        "eu-west-3"      => "ami-0fca2c9a397d947c4",
-        "eu-central-1"      => "ami-0b666c2ce15c8b118",
-        "ap-northeast-1"      => "ami-0e4d52202ff18bfea",
-        "ap-northeast-2"      => "ami-0b9e07b9baa424b6d",
-        "ap-southeast-1"      => "ami-0facd4d2e6f6f9e82",
-        "ap-southeast-2"      => "ami-073050df4f7d7f92c",
-        "ca-central-1"      => "ami-07e12bf3989c30960",
-        "ap-south-1"      => "ami-022d3078cc11f0e12",
-        "sa-east-1"      => "ami-00ce474e4c650fc40",
+        "us-east-1"      => "ami-0f1a6835595fb9246",
+        "us-east-2"      => "ami-0030e9fc5c777545a",
+        "us-west-1"      => "ami-01f4ebf3ee94d4842",
+        "us-west-2"      => "ami-03eb5bfc849fa01ae",
+        "eu-west-1"      => "ami-0d499daa694cb80e3",
+        "eu-west-2"      => "ami-0f4701bce4ab921c5",
+        "eu-west-3"      => "ami-03057096d91787da5",
+        "eu-central-1"      => "ami-0aecab792d09b6d55",
+        "ap-northeast-1"      => "ami-0224c3ca00a6ee32f",
+        "ap-northeast-2"      => "ami-02428dc32a3b6596f",
+        "ap-southeast-1"      => "ami-082b66fcd5080279b",
+        "ap-southeast-2"      => "ami-0ec96d3b207891374",
+        "ca-central-1"      => "ami-0a12b9155c0027f62",
+        "ap-south-1"      => "ami-0f6f58b29c9f73258",
+        "sa-east-1"      => "ami-0f59136b75bca26be",
       }
 
       def build_resources


### PR DESCRIPTION
This PR will update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230615.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
