### PR TITLE
Instance type M6 and Volume gp3, AMI update to Amazon Linux 2 2.0.20230628.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,4 +384,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/barcelona/network/auto_scaling_group.rb
+++ b/lib/barcelona/network/auto_scaling_group.rb
@@ -5,6 +5,9 @@ module Barcelona
         "AWS::AutoScaling::AutoScalingGroup"
       end
 
+      # Avoid API rate limiting for autoscaling updates
+      AUTOSCALING_MAX_BATCH_SIZE = 20
+
       def define_resource(json)
         super
         json.Properties do |j|
@@ -41,7 +44,7 @@ module Barcelona
 
         json.UpdatePolicy do |j|
           j.AutoScalingRollingUpdate do |j|
-            j.MaxBatchSize(desired_capacity > 0 ? desired_capacity : 1)
+            j.MaxBatchSize(desired_capacity > 0 ? AUTOSCALING_MAX_BATCH_SIZE : 1)
             j.MinInstancesInService desired_capacity
           end
         end

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 115, LastModifiedDate: 2023-06-14T00:04:46.565000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230606-x86_64-ebs
+      # latest info is Version: 118, LastModifiedDate: 2023-07-11T02:43:58.706000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230705-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0bf5ac026c9b5eb88",
-        "us-east-2"      => "ami-0840e4520d7b31497",
-        "us-west-1"      => "ami-0b442c02c1d3d2a18",
-        "us-west-2"      => "ami-0bde6c5470d17d540",
-        "eu-west-1"      => "ami-0637e5fd8f888abf4",
-        "eu-west-2"      => "ami-0206dc2da4b3b0a01",
-        "eu-west-3"      => "ami-0c2a9175f394c6105",
-        "eu-central-1"      => "ami-07480655a02fc53ae",
-        "ap-northeast-1"      => "ami-0f386dc4885ec169f",
-        "ap-northeast-2"      => "ami-0063312c13bc1e1ad",
-        "ap-southeast-1"      => "ami-0167d4afc8591fe51",
-        "ap-southeast-2"      => "ami-0c1b561b88a479085",
-        "ca-central-1"      => "ami-005cf0ce5ca6d42d4",
-        "ap-south-1"      => "ami-0c8892ce5874c1780",
-        "sa-east-1"      => "ami-066162c92c1822390",
+        "us-east-1"      => "ami-0507dff4275d8dd6d",
+        "us-east-2"      => "ami-0a2f86088203932e1",
+        "us-west-1"      => "ami-04a74838790dc77bf",
+        "us-west-2"      => "ami-07395cc0a598ee2eb",
+        "eu-west-1"      => "ami-023f1074e24ccf964",
+        "eu-west-2"      => "ami-079f34f67618526ea",
+        "eu-west-3"      => "ami-06ee90103b4c1602c",
+        "eu-central-1"      => "ami-0895a12593a7b3a0b",
+        "ap-northeast-1"      => "ami-0e432635473484865",
+        "ap-northeast-2"      => "ami-01bba9f96447a3f1e",
+        "ap-southeast-1"      => "ami-0d2ffabfbd38ccd28",
+        "ap-southeast-2"      => "ami-037bc2c139c7ae160",
+        "ca-central-1"      => "ami-0519bf5ddc298485d",
+        "ap-south-1"      => "ami-025fa2a3e27b6e58a",
+        "sa-east-1"      => "ami-0f544759009d3c50b",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -26,7 +26,7 @@ module Barcelona
 
       def ebs_optimized_by_default?
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
-        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
+        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|m6()?|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
       end
 
       def build_resources
@@ -48,8 +48,10 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                "Iops" => 3000,
+                "Throughput" => 125,
                 "VolumeSize" => 100,
-                "VolumeType" => "gp2"
+                "VolumeType" => "gp3"
               }
             }
           ]

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 89, LastModifiedDate: 2023-06-16T03:56:41.330000+09:00
+      # latest info is Version: 90, LastModifiedDate: 2023-06-30T05:46:13.821000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-0f1a6835595fb9246",
-        "us-east-2"      => "ami-0030e9fc5c777545a",
-        "us-west-1"      => "ami-01f4ebf3ee94d4842",
-        "us-west-2"      => "ami-03eb5bfc849fa01ae",
-        "eu-west-1"      => "ami-0d499daa694cb80e3",
-        "eu-west-2"      => "ami-0f4701bce4ab921c5",
-        "eu-west-3"      => "ami-03057096d91787da5",
-        "eu-central-1"      => "ami-0aecab792d09b6d55",
-        "ap-northeast-1"      => "ami-0224c3ca00a6ee32f",
-        "ap-northeast-2"      => "ami-02428dc32a3b6596f",
-        "ap-southeast-1"      => "ami-082b66fcd5080279b",
-        "ap-southeast-2"      => "ami-0ec96d3b207891374",
-        "ca-central-1"      => "ami-0a12b9155c0027f62",
-        "ap-south-1"      => "ami-0f6f58b29c9f73258",
-        "sa-east-1"      => "ami-0f59136b75bca26be",
+        "us-east-1"      => "ami-0ee3dd41c47751fe6",
+        "us-east-2"      => "ami-0104b1a6d7c2e71e7",
+        "us-west-1"      => "ami-0f5bca4d7b49c9f49",
+        "us-west-2"      => "ami-04d0def24be0d27d6",
+        "eu-west-1"      => "ami-0f10a5fd495b3e5f8",
+        "eu-west-2"      => "ami-09102fbce920ce7cb",
+        "eu-west-3"      => "ami-0ba85efb9770c80fc",
+        "eu-central-1"      => "ami-07f388ca43c843c04",
+        "ap-northeast-1"      => "ami-0ebe0a87a50664c5a",
+        "ap-northeast-2"      => "ami-0314c6b4d666713d7",
+        "ap-southeast-1"      => "ami-0a92570e87e2a32a6",
+        "ap-southeast-2"      => "ami-02196cf3114f961f7",
+        "ca-central-1"      => "ami-0e2bb53eeda050a28",
+        "ap-south-1"      => "ami-0770726357cfe8240",
+        "sa-east-1"      => "ami-05394326de8feacd8",
       }
 
       def build_resources

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -107,6 +107,20 @@ module Barcelona
           j.MetadataOptions do |m|
             m.HttpTokens 'required'
           end
+          j.BlockDeviceMappings [
+            # Root volume
+            # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/al2ami-storage-config.html
+            {
+              "DeviceName" => "/dev/xvda",
+              "Ebs" => {
+                "DeleteOnTermination" => true,
+                "Iops" => 3000,
+                "Throughput" => 125,
+                "VolumeSize" => 100,
+                "VolumeType" => "gp3"
+              }
+            }
+          ]
         end
 
         add_resource(BastionAutoScaling, "BastionAutoScaling",

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -212,8 +212,10 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
-                "VolumeSize" => 8,
-                "VolumeType" => "gp2"
+                "Iops" => 3000,
+                "Throughput" => 125,
+                "VolumeSize" => 100,
+                "VolumeType" => "gp3"
               }
             },
           ]

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -148,8 +148,14 @@ describe Barcelona::Network::NetworkStack do
           "EbsOptimized" => true,
           "BlockDeviceMappings" => [
             {
-              "DeviceName"=>"/dev/xvda",
-              "Ebs" => {"DeleteOnTermination"=>true, "VolumeSize"=>100, "VolumeType"=>"gp2"}
+              "DeviceName" => "/dev/xvda",
+              "Ebs" => {
+                "DeleteOnTermination" => true,
+                               "Iops" => 3000,
+                         "Throughput" => 125,
+                         "VolumeSize" => 100,
+                         "VolumeType" => "gp3"
+              }
             }
           ]
         }
@@ -375,7 +381,19 @@ describe Barcelona::Network::NetworkStack do
           "AssociatePublicIpAddress" => true,
           "SecurityGroups" => [
             {"Ref" => "SecurityGroupBastion"}
-          ]
+          ],
+          "BlockDeviceMappings" => [
+            {
+              "DeviceName" =>"/dev/xvda", 
+              "Ebs" => {
+                "DeleteOnTermination" => true,
+                "Iops" => 3000,
+                "Throughput" => 125,
+                "VolumeSize" => 100,
+                "VolumeType" => "gp3"
+              }
+            }
+          ],
         }
       },
       "BastionAutoScaling" => {

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -131,7 +131,7 @@ describe Barcelona::Network::NetworkStack do
         },
         "UpdatePolicy" => {
           "AutoScalingRollingUpdate" => {
-            "MaxBatchSize" => 1,
+            "MaxBatchSize" => 20,
             "MinInstancesInService" => 1
           }
         }


### PR DESCRIPTION
## Changes
- Updates the volume type for the bastion and container instances to gp3, from gp2.
- Defines m6 type instances as EBS optimized, per https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html . This will allow us to update the instances to m6i 
- Sets the MaxBatchSize for AutoscalingRollingUpdate to 20. This should reduce `resource contention` or `API Rate Limit exceeded` type errors when applying Cloudformation changes.
- Also including the latest AMI update so our instances will remain compliant. Details at the section below

This has been tested on a local instance of Barcelona with the sre-sandbox AWS account.

### How to roll out

We can update the instance type and volume type at the same time. Both changes require a `bcn district apply `, and Cloudformation change set execution. These steps will allow you to only perform it once.

- Merge and confirm that this PR's changes has been deployed to Barcelona.
- `bcn api patch /districts/:district_name '{ "cluster_instance_type": "m6i.large"}'` # replace `:district_name`
- `bcn district apply :district_name`
- Review and execute the Cloudformation changeset that was produced.

## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230629.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1

