### PR TITLE
Fix regex for ebs optimized setting

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -26,7 +26,7 @@ module Barcelona
 
       def ebs_optimized_by_default?
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
-        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|m6()?|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
+        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|m6.+||p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
       end
 
       def build_resources

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -26,7 +26,7 @@ module Barcelona
 
       def ebs_optimized_by_default?
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
-        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|m6.+||p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
+        !!(instance_type =~ /\A(a1|c4|c5.?|d2|f1|g3.?|h1|i3|m4|m5.?|m6.+|p2|p3(dn)?|r4|r5.?|t3|u-.*|x1.?|z1d)\..*\z/)
       end
 
       def build_resources

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -1070,4 +1070,21 @@ describe Barcelona::Network::NetworkStack do
       expect(generated["Resources"]["RouteNATForRouteTableTrusted2"]).to be_present
     end
   end
+
+  it "m6i.large instance type is ebs optimized" do
+    district.nat_type = nil
+    district.cluster_instance_type = "m6i.large"
+    stack = described_class.new(district)
+    generated = JSON.load(stack.target!)
+    expect(generated["Resources"]["ContainerInstanceLaunchConfiguration"]["Properties"]["EbsOptimized"]).to eq true
+  end
+
+  it "m1.large instance type is not ebs optimized by default" do
+    district.nat_type = nil
+    district.cluster_instance_type = "m1.large"
+    stack = described_class.new(district)
+    generated = JSON.load(stack.target!)
+    expect(generated["Resources"]["ContainerInstanceLaunchConfiguration"]["Properties"]["EbsOptimized"]).to eq false
+  end
+
 end


### PR DESCRIPTION
Fix for https://github.com/degica/barcelona/pull/789

https://github.com/degica/barcelona/pull/789 has been deployed, but not applied to any districts yet. We will deploy this fix and then proceed with updating the districts.

It seems that all newer instance types support this, we just want to make sure this flag is enabled for m6 types in the Cloudformation when updating.
This should match any m6 instance type defined at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-optimized.html#ebs-optimization-support