### PR TITLE
Fix ECSService sometimes failing to create

### DIFF
--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -4,7 +4,11 @@ module Backend::Ecs::V2
       def build_resources
         deps = []
         if use_alb?
-          deps = ['LBListenerRuleHTTP', 'LBListenerRuleHTTPS']
+          deps = ['LBListenerRuleHTTP']
+
+          if listener&.endpoint&.https_listener_id&.present?
+            deps << 'LBListenerRuleHTTPS'
+          end
         end
 
         add_resource("AWS::ECS::Service", "ECSService", { depends_on: deps }) do |j|          j.Cluster district.name

--- a/app/models/backend/ecs/v2/service_stack.rb
+++ b/app/models/backend/ecs/v2/service_stack.rb
@@ -2,8 +2,12 @@ module Backend::Ecs::V2
   class ServiceStack < CloudFormation::Stack
     class Builder < CloudFormation::Builder
       def build_resources
-        add_resource("AWS::ECS::Service", "ECSService") do |j|
-          j.Cluster district.name
+        deps = []
+        if use_alb?
+          deps = ['LBListenerRuleHTTP', 'LBListenerRuleHTTPS']
+        end
+
+        add_resource("AWS::ECS::Service", "ECSService", { depends_on: deps }) do |j|          j.Cluster district.name
           j.TaskDefinition options[:task_definition]
           j.DesiredCount options[:desired_count]
           if use_tcp_load_balancer?


### PR DESCRIPTION
ECSService sometimes fails to create when a reviewapp is being deployed. This creates a lot of headaches because barcelona does not return an error when the deploy is requested and it takes inspecting cloudformation to check what is happening.

This is primarily caused by https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#aws-resource-ecs-service--examples (in the Associate an Application Load Balancer with a service section). In CF the parallel resource creation creates a race condition for the preparation of the Listener

However in our stack, the listener already exists. The difference here is that the Listener rules have not been created yet, and that causes the issue.

The fix here is to force the ECSService to depend on the creation of listener rules.