### PR TITLE
Encrypt EBS, AMI update to Amazon Linux 2 2.0.20230822.0 

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 118, LastModifiedDate: 2023-07-11T02:43:58.706000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230705-x86_64-ebs
+      # latest info is Version: 121, LastModifiedDate: 2023-08-17T00:07:16.575000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230809-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0507dff4275d8dd6d",
-        "us-east-2"      => "ami-0a2f86088203932e1",
-        "us-west-1"      => "ami-04a74838790dc77bf",
-        "us-west-2"      => "ami-07395cc0a598ee2eb",
-        "eu-west-1"      => "ami-023f1074e24ccf964",
-        "eu-west-2"      => "ami-079f34f67618526ea",
-        "eu-west-3"      => "ami-06ee90103b4c1602c",
-        "eu-central-1"      => "ami-0895a12593a7b3a0b",
-        "ap-northeast-1"      => "ami-0e432635473484865",
-        "ap-northeast-2"      => "ami-01bba9f96447a3f1e",
-        "ap-southeast-1"      => "ami-0d2ffabfbd38ccd28",
-        "ap-southeast-2"      => "ami-037bc2c139c7ae160",
-        "ca-central-1"      => "ami-0519bf5ddc298485d",
-        "ap-south-1"      => "ami-025fa2a3e27b6e58a",
-        "sa-east-1"      => "ami-0f544759009d3c50b",
+        "us-east-1"      => "ami-0e692fe1bae5ca24c",
+        "us-east-2"      => "ami-098accd64a8a385dc",
+        "us-west-1"      => "ami-08c160e4491d2a9a1",
+        "us-west-2"      => "ami-02a4b44230bc8650a",
+        "eu-west-1"      => "ami-0c5cd894db560d66c",
+        "eu-west-2"      => "ami-02860af96bd3e1696",
+        "eu-west-3"      => "ami-01d44421a18be3f4d",
+        "eu-central-1"      => "ami-0b5009e7f102539b1",
+        "ap-northeast-1"      => "ami-0ae451dcc36be7bb3",
+        "ap-northeast-2"      => "ami-016e409dfaa836cb4",
+        "ap-southeast-1"      => "ami-0c68f952153c18847",
+        "ap-southeast-2"      => "ami-00bcae5b31b05c62c",
+        "ca-central-1"      => "ami-00f7fbbe4ca0bb446",
+        "ap-south-1"      => "ami-0205f72f24e39213b",
+        "sa-east-1"      => "ami-0d306330cbbf3cda9",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -48,6 +48,7 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                "Encrypted" => true,
                 "Iops" => 3000,
                 "Throughput" => 125,
                 "VolumeSize" => 100,

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 90, LastModifiedDate: 2023-06-30T05:46:13.821000+09:00
+      # latest info is Version: 94, LastModifiedDate: 2023-08-25T08:17:22.587000+09:00 )... Use these for bastion_builder.rb
       AMI_IDS = {
-        "us-east-1"      => "ami-0ee3dd41c47751fe6",
-        "us-east-2"      => "ami-0104b1a6d7c2e71e7",
-        "us-west-1"      => "ami-0f5bca4d7b49c9f49",
-        "us-west-2"      => "ami-04d0def24be0d27d6",
-        "eu-west-1"      => "ami-0f10a5fd495b3e5f8",
-        "eu-west-2"      => "ami-09102fbce920ce7cb",
-        "eu-west-3"      => "ami-0ba85efb9770c80fc",
-        "eu-central-1"      => "ami-07f388ca43c843c04",
-        "ap-northeast-1"      => "ami-0ebe0a87a50664c5a",
-        "ap-northeast-2"      => "ami-0314c6b4d666713d7",
-        "ap-southeast-1"      => "ami-0a92570e87e2a32a6",
-        "ap-southeast-2"      => "ami-02196cf3114f961f7",
-        "ca-central-1"      => "ami-0e2bb53eeda050a28",
-        "ap-south-1"      => "ami-0770726357cfe8240",
-        "sa-east-1"      => "ami-05394326de8feacd8",
+        "us-east-1"      => "ami-0e1c5d8c23330dee3",
+        "us-east-2"      => "ami-071807f4c8241ac3f",
+        "us-west-1"      => "ami-0540080bd63fd242d",
+        "us-west-2"      => "ami-04288abc8d2000768",
+        "eu-west-1"      => "ami-019743dbff6bf9883",
+        "eu-west-2"      => "ami-04b5f63f1e04f469b",
+        "eu-west-3"      => "ami-05335d5404e3b67f1",
+        "eu-central-1"      => "ami-011f11b2ae563e78c",
+        "ap-northeast-1"      => "ami-0fb2e8f28f4a31399",
+        "ap-northeast-2"      => "ami-0500635a02d3f474b",
+        "ap-southeast-1"      => "ami-08df616b01c9d36e6",
+        "ap-southeast-2"      => "ami-056b433d09bdcadeb",
+        "ca-central-1"      => "ami-02f754ea50a61080d",
+        "ap-south-1"      => "ami-036fcf8080bce5f54",
+        "sa-east-1"      => "ami-0ee0b5e7f79d63929",
       }
 
       def build_resources

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -114,6 +114,7 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                "Encrypted" => true,
                 "Iops" => 3000,
                 "Throughput" => 125,
                 "VolumeSize" => 100,

--- a/lib/barcelona/plugins/pcidss_plugin.rb
+++ b/lib/barcelona/plugins/pcidss_plugin.rb
@@ -212,6 +212,7 @@ module Barcelona
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                "Encrypted" => true,
                 "Iops" => 3000,
                 "Throughput" => 125,
                 "VolumeSize" => 100,

--- a/spec/lib/barcelona/network/network_stack_spec.rb
+++ b/spec/lib/barcelona/network/network_stack_spec.rb
@@ -151,6 +151,7 @@ describe Barcelona::Network::NetworkStack do
               "DeviceName" => "/dev/xvda",
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                          "Encrypted" => true,
                                "Iops" => 3000,
                          "Throughput" => 125,
                          "VolumeSize" => 100,
@@ -387,6 +388,7 @@ describe Barcelona::Network::NetworkStack do
               "DeviceName" =>"/dev/xvda", 
               "Ebs" => {
                 "DeleteOnTermination" => true,
+                "Encrypted" => true,
                 "Iops" => 3000,
                 "Throughput" => 125,
                 "VolumeSize" => 100,


### PR DESCRIPTION
## Changes
- Changes the setting to encrypt EBS volumes
- Also including the latest AMI update so our instances will remain compliant. Details at the section below

This has been tested on a local instance of Barcelona with the sre-sandbox5 AWS account.

## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230825.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1

