### PR TITLE
Update debase version to install it successfully on mac

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'vault'
 gem 'tzinfo', '~> 1.2.10'
 
 group :development, :test do
-  gem 'debase'
+  gem 'debase', '~> 0.2.5.beta2'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'ruby-debug-ide'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,9 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
-    debase (0.2.4.1)
-      debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (3.2.0)
+    debase (0.2.5.beta2)
+      debase-ruby_core_source (>= 0.10.12)
+    debase-ruby_core_source (3.2.2)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -350,7 +350,7 @@ DEPENDENCIES
   aws-sdk-s3
   aws-sdk-sns
   aws-sdk-ssm
-  debase
+  debase (~> 0.2.5.beta2)
   delayed_job_active_record
   factory_bot_rails
   gibberish


### PR DESCRIPTION
## Context
I encountered [this issue](https://github.com/ruby-debug/debase/issues/76) when I execute `bundle install` for [the AMI update operation](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321). As it's mentioned [here](https://github.com/ruby-debug/debase/issues/76#issuecomment-758628884), updating to `0.2.5.beta2` version could solve the issue on my environment.