### PR TITLE
AMI update to Amazon Linux 2 2.0.20230906.0

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 121, LastModifiedDate: 2023-08-17T00:07:16.575000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230809-x86_64-ebs
+      # latest info is Version: 123, LastModifiedDate: 2023-09-19T00:06:07.212000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230912-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0e692fe1bae5ca24c",
-        "us-east-2"      => "ami-098accd64a8a385dc",
-        "us-west-1"      => "ami-08c160e4491d2a9a1",
-        "us-west-2"      => "ami-02a4b44230bc8650a",
-        "eu-west-1"      => "ami-0c5cd894db560d66c",
-        "eu-west-2"      => "ami-02860af96bd3e1696",
-        "eu-west-3"      => "ami-01d44421a18be3f4d",
-        "eu-central-1"      => "ami-0b5009e7f102539b1",
-        "ap-northeast-1"      => "ami-0ae451dcc36be7bb3",
-        "ap-northeast-2"      => "ami-016e409dfaa836cb4",
-        "ap-southeast-1"      => "ami-0c68f952153c18847",
-        "ap-southeast-2"      => "ami-00bcae5b31b05c62c",
-        "ca-central-1"      => "ami-00f7fbbe4ca0bb446",
-        "ap-south-1"      => "ami-0205f72f24e39213b",
-        "sa-east-1"      => "ami-0d306330cbbf3cda9",
+        "us-east-1"      => "ami-0fec9863172e50c93",
+        "us-east-2"      => "ami-05383c67c111ecf57",
+        "us-west-1"      => "ami-020e3784a4501250b",
+        "us-west-2"      => "ami-080b1e312f29aebbb",
+        "eu-west-1"      => "ami-0d6c27a1bb3f71e9e",
+        "eu-west-2"      => "ami-0614d874e5d653441",
+        "eu-west-3"      => "ami-073deb7e91cdf45d8",
+        "eu-central-1"      => "ami-031ef26e74b8f374c",
+        "ap-northeast-1"      => "ami-01d514398745616a7",
+        "ap-northeast-2"      => "ami-0d77b2fba3628df46",
+        "ap-southeast-1"      => "ami-062a3e3b74bb5b4c5",
+        "ap-southeast-2"      => "ami-0775ca431543b2151",
+        "ca-central-1"      => "ami-04c4755874f196c5b",
+        "ap-south-1"      => "ami-03e75332ffeeb512f",
+        "sa-east-1"      => "ami-0c7896e35be2c7c07",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 94, LastModifiedDate: 2023-08-25T08:17:22.587000+09:00 )... Use these for bastion_builder.rb
+      # latest info is Version: 96, LastModifiedDate: 2023-09-19T01:46:56.193000+09:00 )... Use these for bastion_builder.rb
       AMI_IDS = {
-        "us-east-1"      => "ami-0e1c5d8c23330dee3",
-        "us-east-2"      => "ami-071807f4c8241ac3f",
-        "us-west-1"      => "ami-0540080bd63fd242d",
-        "us-west-2"      => "ami-04288abc8d2000768",
-        "eu-west-1"      => "ami-019743dbff6bf9883",
-        "eu-west-2"      => "ami-04b5f63f1e04f469b",
-        "eu-west-3"      => "ami-05335d5404e3b67f1",
-        "eu-central-1"      => "ami-011f11b2ae563e78c",
-        "ap-northeast-1"      => "ami-0fb2e8f28f4a31399",
-        "ap-northeast-2"      => "ami-0500635a02d3f474b",
-        "ap-southeast-1"      => "ami-08df616b01c9d36e6",
-        "ap-southeast-2"      => "ami-056b433d09bdcadeb",
-        "ca-central-1"      => "ami-02f754ea50a61080d",
-        "ap-south-1"      => "ami-036fcf8080bce5f54",
-        "sa-east-1"      => "ami-0ee0b5e7f79d63929",
+        "us-east-1"      => "ami-098143f68772b34f5",
+        "us-east-2"      => "ami-0dbb0f9887f1fe98f",
+        "us-west-1"      => "ami-0f56d8f4fdaf39279",
+        "us-west-2"      => "ami-00755a52896316cee",
+        "eu-west-1"      => "ami-0aa6a4d042e0ccc31",
+        "eu-west-2"      => "ami-0fc7663ee27a52476",
+        "eu-west-3"      => "ami-06509bffd4252cf89",
+        "eu-central-1"      => "ami-0a2a6a10b645a609e",
+        "ap-northeast-1"      => "ami-0baf2b5b1e0cfaeab",
+        "ap-northeast-2"      => "ami-0ec77cfb1037681eb",
+        "ap-southeast-1"      => "ami-080367f396ea04ea7",
+        "ap-southeast-2"      => "ami-046a52b150aed081a",
+        "ca-central-1"      => "ami-0634933bd8c9f5e98",
+        "ap-south-1"      => "ami-0579bae099b504874",
+        "sa-east-1"      => "ami-018cded4e74aec9cd",
       }
 
       def build_resources


### PR DESCRIPTION
## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-for-komoju-district-6980c4e127774d9791d44d9ad51b0321):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20230911.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
