### PR TITLE
Enable container metadata for ECS

### DIFF
--- a/app/services/apply_district.rb
+++ b/app/services/apply_district.rb
@@ -85,7 +85,8 @@ class ApplyDistrict
       "ECS_RESERVED_MEMORY" => 256,
       "ECS_CONTAINER_STOP_TIMEOUT" => "5m",
       "ECS_ENABLE_TASK_IAM_ROLE" => "true",
-      "ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST" => "true"
+      "ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST" => "true",
+      "ECS_ENABLE_CONTAINER_METADATA" => "true"
     }
 
     if district.dockercfg.present?


### PR DESCRIPTION
## Context
We are setting up ddagent as daemon service on ECS. The hats containers need to know the EC2 host private IP address to communicate with the service-daemon ddagent, [ref](https://docs.datadoghq.com/containers/amazon_ecs/apm/?tab=ecscontainermetadatafile#:~:text=cat%20%24ECS_CONTAINER_METADATA_FILE%20%7C%20jq%20%2Dr%20.HostPrivateIPv4Address).
The container can get the IP address by `cat $ECS_CONTAINER_METADATA_FILE | jq -r .HostPrivateIPv4Address` as explained in the above document, but this environment variable is blank by default. We need to turn on the container metadata by defining `ECS_ENABLE_CONTAINER_METADATA=true` in ECS config, [ref](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-metadata.html#:~:text=ECS_ENABLE_CONTAINER_METADATA%3Dtrue).

## Steps after merging this PR
For staging:
1. `bcn district apply staging`
1. Go to CF page on console and apply changes
1. Use [Instance Refresh](https://docs.aws.amazon.com/autoscaling/ec2/userguide/start-instance-refresh.html) feature with 90% minimum healthy instance to replace existing servers.

For production:
1. Confirm the setting works well on staging
1. `bcn district apply komoju`
1. The same on staging later.

@davidsiaw I'd like you to review the post-merge steps as well 🙏 