### PR TITLE
AMI update to Amazon Linux 2 2.0.20231101.0

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 123, LastModifiedDate: 2023-09-19T00:06:07.212000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20230912-x86_64-ebs
+      # latest info is Version: 126, LastModifiedDate: 2023-11-09T05:06:38.507000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20231103-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0fec9863172e50c93",
-        "us-east-2"      => "ami-05383c67c111ecf57",
-        "us-west-1"      => "ami-020e3784a4501250b",
-        "us-west-2"      => "ami-080b1e312f29aebbb",
-        "eu-west-1"      => "ami-0d6c27a1bb3f71e9e",
-        "eu-west-2"      => "ami-0614d874e5d653441",
-        "eu-west-3"      => "ami-073deb7e91cdf45d8",
-        "eu-central-1"      => "ami-031ef26e74b8f374c",
-        "ap-northeast-1"      => "ami-01d514398745616a7",
-        "ap-northeast-2"      => "ami-0d77b2fba3628df46",
-        "ap-southeast-1"      => "ami-062a3e3b74bb5b4c5",
-        "ap-southeast-2"      => "ami-0775ca431543b2151",
-        "ca-central-1"      => "ami-04c4755874f196c5b",
-        "ap-south-1"      => "ami-03e75332ffeeb512f",
-        "sa-east-1"      => "ami-0c7896e35be2c7c07",
+        "us-east-1"      => "ami-0b74aeb97fba885ea",
+        "us-east-2"      => "ami-0f896121197c465b6",
+        "us-west-1"      => "ami-0c5504b68ec2d9a7f",
+        "us-west-2"      => "ami-0dde9c7cb86beac37",
+        "eu-west-1"      => "ami-0ff103cb56a347a33",
+        "eu-west-2"      => "ami-02ef2f8ea6a7806b2",
+        "eu-west-3"      => "ami-0bfabc4e921335ce1",
+        "eu-central-1"      => "ami-0aa4f7ed90c2cb592",
+        "ap-northeast-1"      => "ami-096e08f9d8a9f57b1",
+        "ap-northeast-2"      => "ami-012a265cd28ba3e08",
+        "ap-southeast-1"      => "ami-080cdc1184ac6b4fa",
+        "ap-southeast-2"      => "ami-06d8f2a68469b0d41",
+        "ca-central-1"      => "ami-036c354a96f50530c",
+        "ap-south-1"      => "ami-07d5af8060c8e639d",
+        "sa-east-1"      => "ami-0ae7b598f864571a3",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 96, LastModifiedDate: 2023-09-19T01:46:56.193000+09:00 )... Use these for bastion_builder.rb
+      # latest info is Version: 102, LastModifiedDate: 2023-11-18T14:09:53.487000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-098143f68772b34f5",
-        "us-east-2"      => "ami-0dbb0f9887f1fe98f",
-        "us-west-1"      => "ami-0f56d8f4fdaf39279",
-        "us-west-2"      => "ami-00755a52896316cee",
-        "eu-west-1"      => "ami-0aa6a4d042e0ccc31",
-        "eu-west-2"      => "ami-0fc7663ee27a52476",
-        "eu-west-3"      => "ami-06509bffd4252cf89",
-        "eu-central-1"      => "ami-0a2a6a10b645a609e",
-        "ap-northeast-1"      => "ami-0baf2b5b1e0cfaeab",
-        "ap-northeast-2"      => "ami-0ec77cfb1037681eb",
-        "ap-southeast-1"      => "ami-080367f396ea04ea7",
-        "ap-southeast-2"      => "ami-046a52b150aed081a",
-        "ca-central-1"      => "ami-0634933bd8c9f5e98",
-        "ap-south-1"      => "ami-0579bae099b504874",
-        "sa-east-1"      => "ami-018cded4e74aec9cd",
+        "us-east-1"      => "ami-0588935a949f9ff17",
+        "us-east-2"      => "ami-0e4bab9adfcf464b1",
+        "us-west-1"      => "ami-0839bf007aad25236",
+        "us-west-2"      => "ami-0319ef1a70c93d5c8",
+        "eu-west-1"      => "ami-07e85b797329c2bae",
+        "eu-west-2"      => "ami-055c1c5b310817d75",
+        "eu-west-3"      => "ami-0d60e01ba76286b82",
+        "eu-central-1"      => "ami-08be7699a81774dd5",
+        "ap-northeast-1"      => "ami-058d2a108b2600a4f",
+        "ap-northeast-2"      => "ami-066e8b8972bbd816b",
+        "ap-southeast-1"      => "ami-08b96001e0e7a2b81",
+        "ap-southeast-2"      => "ami-018858d4e27f62c2d",
+        "ca-central-1"      => "ami-0866b1e4094c11483",
+        "ap-south-1"      => "ami-06fff02c54a38e17b",
+        "sa-east-1"      => "ami-025a07aa284285222",
       }
 
       def build_resources


### PR DESCRIPTION
## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-using-Barcelona-78b6c47ab7a14b5184d7fcf1b54775b0):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20231103.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
