### PR TITLE
Datadog security

### DIFF
--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -93,8 +93,6 @@ module Barcelona
         user_data.add_file("/etc/datadog-agent/security-agent.yaml", "root:root", "000755", <<~YAML)
           runtime_security_config:
             enabled: true
-          runtime_security_config:
-            enabled: true
           compliance_config:
             enabled: true
             host_benchmarks:

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -27,7 +27,7 @@ module Barcelona
 
       def agent_command
         [
-          "DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=#{api_key} bash -c",
+          "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=#{api_key} bash -c",
           '"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)" &&',
           'usermod -a -G docker dd-agent &&',
           'usermod -a -G systemd-journal dd-agent &&',
@@ -53,6 +53,18 @@ module Barcelona
             container_collect_all: true
           process_config:
             enabled: 'true'
+          runtime_security_config:
+            enabled: true
+          compliance_config:
+            enabled: true
+          sbom:
+            enabled: true
+            container_image:
+              enabled: true
+            host:
+              enabled: true
+          container_image:
+            enabled: true
           tags:
             - barcelona:#{district.name}
             - barcelona-dd-agent

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -10,6 +10,19 @@ module Barcelona
         user_data
       end
 
+      def on_network_stack_template(_stack, template)
+        bastion_lc = template["BastionLaunchConfiguration"]
+        return template if bastion_lc.nil?
+
+        user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
+        add_files!(user_data)
+        user_data.run_commands += [
+          agent_command
+        ]
+        bastion_lc["Properties"]["UserData"] = user_data.build
+        template
+      end
+
       private
 
       def on_heritage_task_definition(_heritage, task_definition)

--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -72,6 +72,22 @@ module Barcelona
             - role:app
         DATADOG_YAML
 
+        user_data.add_file("/etc/datadog-agent/system-probe.yaml", "root:root", "000755", <<~YAML)
+          runtime_security_config:
+            enabled: true
+        YAML
+
+        user_data.add_file("/etc/datadog-agent/security-agent.yaml", "root:root", "000755", <<~YAML)
+          runtime_security_config:
+            enabled: true
+          runtime_security_config:
+            enabled: true
+          compliance_config:
+            enabled: true
+            host_benchmarks:
+              enabled: true
+        YAML
+
         user_data.add_file("/etc/datadog-agent/conf.d/docker.d/docker_daemon.yaml", "root:root", "000755", <<~YAML)
           init_config:
           instances:

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -51,6 +51,50 @@ module Barcelona
           expect(security_agent_config_hash['compliance_config']['enabled']).to eq(true)
           expect(security_agent_config_hash['compliance_config']['host_benchmarks']['enabled']).to eq(true)
         end
+
+        context "when hooked with network_stack_template trigger" do
+          before do
+            district.save!
+          end
+
+          let(:user_data) do
+            template = JSON.load(::Barcelona::Network::NetworkStack.new(district).target!)
+            user_data_base64 = template["Resources"]["BastionLaunchConfiguration"]["Properties"]["UserData"]
+            YAML.load(Base64.decode64(user_data_base64))
+          end
+
+          it "adds datadog agent instalation to bastion servers" do
+            expect(user_data["runcmd"].last).to eq "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" && usermod -a -G docker dd-agent && usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
+          end
+
+          it "installs agent config file to bastion servers" do
+            agent_config = user_data['write_files'].find do |f|
+              f['path'] == '/etc/datadog-agent/datadog.yaml'
+            end
+            agent_config_hash = YAML.load(agent_config['content'])
+            expect(agent_config_hash['api_key']).to eq(api_key)
+            expect(agent_config_hash['logs_enabled']).to eq(true)
+            expect(agent_config_hash['runtime_security_config']['enabled']).to eq(true)
+          end
+
+          it "installs system-probe config file to bastion servers" do
+            system_probe_config = user_data['write_files'].find do |f|
+              f['path'] == '/etc/datadog-agent/system-probe.yaml'
+            end
+            system_probe_config_hash = YAML.load(system_probe_config['content'])
+            expect(system_probe_config_hash['runtime_security_config']['enabled']).to eq(true)
+          end
+
+          it "installs security-agent config file to bastion servers" do
+            security_agent_config = user_data['write_files'].find do |f|
+              f['path'] == '/etc/datadog-agent/security-agent.yaml'
+            end
+            security_agent_config_hash = YAML.load(security_agent_config['content'])
+            expect(security_agent_config_hash['runtime_security_config']['enabled']).to eq(true)
+            expect(security_agent_config_hash['compliance_config']['enabled']).to eq(true)
+            expect(security_agent_config_hash['compliance_config']['host_benchmarks']['enabled']).to eq(true)
+          end
+        end
       end
     end
   end

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -33,6 +33,24 @@ module Barcelona
           expect(agent_config_hash['logs_enabled']).to eq(true)
           expect(agent_config_hash['runtime_security_config']['enabled']).to eq(true)
         end
+
+        it "installs system-probe config file" do
+          system_probe_config = user_data['write_files'].find do |f|
+            f['path'] == '/etc/datadog-agent/system-probe.yaml'
+          end
+          system_probe_config_hash = YAML.load(system_probe_config['content'])
+          expect(system_probe_config_hash['runtime_security_config']['enabled']).to eq(true)
+        end
+
+        it "installs security-agent config file" do
+          security_agent_config = user_data['write_files'].find do |f|
+            f['path'] == '/etc/datadog-agent/security-agent.yaml'
+          end
+          security_agent_config_hash = YAML.load(security_agent_config['content'])
+          expect(security_agent_config_hash['runtime_security_config']['enabled']).to eq(true)
+          expect(security_agent_config_hash['compliance_config']['enabled']).to eq(true)
+          expect(security_agent_config_hash['compliance_config']['host_benchmarks']['enabled']).to eq(true)
+        end
       end
     end
   end

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -4,21 +4,34 @@ module Barcelona
   module Plugins
     describe DatadogPlugin do
       context "without proxy plugin" do
+        let(:api_key) { 'abcdef'}
         let!(:district) do
           create :district, plugins_attributes: [
             {
               name: 'datadog',
               plugin_attributes: {
-                "api_key" => "abcdef"
+                "api_key" => api_key
               }
             }
           ]
         end
+        let (:user_data) do
+          ci = ContainerInstance.new(district)
+          YAML.load(Base64.decode64(ci.user_data.build))
+        end
 
         it "gets hooked with container_instance_user_data trigger" do
-          ci = ContainerInstance.new(district)
-          user_data = YAML.load(Base64.decode64(ci.user_data.build))
-          expect(user_data["runcmd"].last).to eq "DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" && usermod -a -G docker dd-agent && usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
+          expect(user_data["runcmd"].last).to eq "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" && usermod -a -G docker dd-agent && usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
+        end
+
+        it "installs agent config file" do
+          agent_config = user_data['write_files'].find do |f|
+            f['path'] == '/etc/datadog-agent/datadog.yaml'
+          end
+          agent_config_hash = YAML.load(agent_config['content'])
+          expect(agent_config_hash['api_key']).to eq(api_key)
+          expect(agent_config_hash['logs_enabled']).to eq(true)
+          expect(agent_config_hash['runtime_security_config']['enabled']).to eq(true)
         end
       end
     end


### PR DESCRIPTION
This PR adds command and files for enabling Datadog CSW feature to datadog plugin.

The config changes needed is described here.
- https://www.notion.so/Datadog-as-IDS-IPS-and-FIM-109f205717b34e798bf4a69aab58997b
- https://docs.datadoghq.com/security/cloud_security_management/setup/csm_cloud_workload_security/agent/linux/

### Background

Barcelona plugin hooks creating cloud-init config file and insert additional commands and files to it.
