### PR TITLE
Remove docker feature from datadog agent on bastion 

### DIFF
--- a/lib/barcelona/plugins/datadog_plugin.rb
+++ b/lib/barcelona/plugins/datadog_plugin.rb
@@ -21,7 +21,7 @@ module Barcelona
         user_data = InstanceUserData.load_or_initialize(bastion_lc["Properties"]["UserData"])
         add_files!(user_data)
         user_data.run_commands += [
-          agent_command
+          agent_command(has_docker: false)
         ]
         bastion_lc["Properties"]["UserData"] = user_data.build
         template
@@ -42,11 +42,11 @@ module Barcelona
         )
       end
 
-      def agent_command
+      def agent_command(has_docker: true)
         [
           "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=#{api_key} bash -c",
           '"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)" &&',
-          'usermod -a -G docker dd-agent &&',
+          has_docker ? 'usermod -a -G docker dd-agent &&' : '',
           'usermod -a -G systemd-journal dd-agent &&',
           'systemctl restart datadog-agent'
         ].flatten.compact.join(" ")

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -74,7 +74,9 @@ module Barcelona
             agent_config_hash = YAML.load(agent_config['content'])
             expect(agent_config_hash['api_key']).to eq(api_key)
             expect(agent_config_hash['logs_enabled']).to eq(true)
+            expect(agent_config_hash['logs_config']['container_collect_all']).not_to eq(true)
             expect(agent_config_hash['runtime_security_config']['enabled']).to eq(true)
+            expect(agent_config_hash['container_image']['enabled']).not_to eq(true)
           end
 
           it "installs system-probe config file to bastion servers" do

--- a/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
+++ b/spec/lib/barcelona/plugins/datadog_plugin_spec.rb
@@ -64,7 +64,7 @@ module Barcelona
           end
 
           it "adds datadog agent instalation to bastion servers" do
-            expect(user_data["runcmd"].last).to eq "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" && usermod -a -G docker dd-agent && usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
+            expect(user_data["runcmd"].last).to eq "DD_RUNTIME_SECURITY_CONFIG_ENABLED=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=abcdef bash -c \"$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)\" &&  usermod -a -G systemd-journal dd-agent && systemctl restart datadog-agent"
           end
 
           it "installs agent config file to bastion servers" do


### PR DESCRIPTION
continues from #805, #806.

The configuration of datadog agent includes setting it for docker. It fails on bastion servers because bastion doesn't have docker installed.

Installation of datadog agent must be different on servers without docker. This PR fixes it.
