### PR TITLE
Revert "AMI update to Amazon Linux 2 2.0.20240424"

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 143, LastModifiedDate: 2024-04-27T02:10:19.025000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20240424-x86_64-ebs
+      # latest info is Version: 126, LastModifiedDate: 2023-11-09T05:06:38.507000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20231103-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-057f57c2fcd14e5f4",
-        "us-east-2"      => "ami-075e30e2747888320",
-        "us-west-1"      => "ami-00df5b538536416dd",
-        "us-west-2"      => "ami-03620c38721803dfd",
-        "eu-west-1"      => "ami-019666ff08d14f28e",
-        "eu-west-2"      => "ami-01255d13f656c60b9",
-        "eu-west-3"      => "ami-079c9b5ffb3112457",
-        "eu-central-1"      => "ami-02c92d96d6bb63209",
-        "ap-northeast-1"      => "ami-08e6382ac1e3e8349",
-        "ap-northeast-2"      => "ami-03507a48be45b34e7",
-        "ap-southeast-1"      => "ami-01f02bd2c1c60828c",
-        "ap-southeast-2"      => "ami-0d704efd46c049b84",
-        "ca-central-1"      => "ami-06d4eb346540cc650",
-        "ap-south-1"      => "ami-0c40583127f1b33b0",
-        "sa-east-1"      => "ami-038dd9a635f3ee70b",
+        "us-east-1"      => "ami-0b74aeb97fba885ea",
+        "us-east-2"      => "ami-0f896121197c465b6",
+        "us-west-1"      => "ami-0c5504b68ec2d9a7f",
+        "us-west-2"      => "ami-0dde9c7cb86beac37",
+        "eu-west-1"      => "ami-0ff103cb56a347a33",
+        "eu-west-2"      => "ami-02ef2f8ea6a7806b2",
+        "eu-west-3"      => "ami-0bfabc4e921335ce1",
+        "eu-central-1"      => "ami-0aa4f7ed90c2cb592",
+        "ap-northeast-1"      => "ami-096e08f9d8a9f57b1",
+        "ap-northeast-2"      => "ami-012a265cd28ba3e08",
+        "ap-southeast-1"      => "ami-080cdc1184ac6b4fa",
+        "ap-southeast-2"      => "ami-06d8f2a68469b0d41",
+        "ca-central-1"      => "ami-036c354a96f50530c",
+        "ap-south-1"      => "ami-07d5af8060c8e639d",
+        "sa-east-1"      => "ami-0ae7b598f864571a3",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 114, LastModifiedDate: 2024-05-03T05:52:56.139000+09:00
+      # latest info is Version: 102, LastModifiedDate: 2023-11-18T14:09:53.487000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-045602374a1982480",
-        "us-east-2"      => "ami-0665e0e1f1362f164",
-        "us-west-1"      => "ami-077dc9391f73918da",
-        "us-west-2"      => "ami-06883a492f195064e",
-        "eu-west-1"      => "ami-02abe262e357982fe",
-        "eu-west-2"      => "ami-0d3718d9421324fb3",
-        "eu-west-3"      => "ami-0f824bd6298c56797",
-        "eu-central-1"      => "ami-044920fe9a918ee22",
-        "ap-northeast-1"      => "ami-0ce3d93513d1506e7",
-        "ap-northeast-2"      => "ami-0217b147346e48e84",
-        "ap-southeast-1"      => "ami-0b658343569f12708",
-        "ap-southeast-2"      => "ami-04ea1aa4bf2426024",
-        "ca-central-1"      => "ami-043047d3e14a9b434",
-        "ap-south-1"      => "ami-008b777609c202186",
-        "sa-east-1"      => "ami-02ffcda6a2a46008f",
+        "us-east-1"      => "ami-0588935a949f9ff17",
+        "us-east-2"      => "ami-0e4bab9adfcf464b1",
+        "us-west-1"      => "ami-0839bf007aad25236",
+        "us-west-2"      => "ami-0319ef1a70c93d5c8",
+        "eu-west-1"      => "ami-07e85b797329c2bae",
+        "eu-west-2"      => "ami-055c1c5b310817d75",
+        "eu-west-3"      => "ami-0d60e01ba76286b82",
+        "eu-central-1"      => "ami-08be7699a81774dd5",
+        "ap-northeast-1"      => "ami-058d2a108b2600a4f",
+        "ap-northeast-2"      => "ami-066e8b8972bbd816b",
+        "ap-southeast-1"      => "ami-08b96001e0e7a2b81",
+        "ap-southeast-2"      => "ami-018858d4e27f62c2d",
+        "ca-central-1"      => "ami-0866b1e4094c11483",
+        "ap-south-1"      => "ami-06fff02c54a38e17b",
+        "sa-east-1"      => "ami-025a07aa284285222",
       }
 
       def build_resources


### PR DESCRIPTION
Reverts degica/barcelona#809

## Context
I was about to update AMI to use Docker v25.0 related to [this ticket](https://app.asana.com/0/1206315055720505/1207252555665641/f), but the latest AMI doesn't support that Docker version yet. (AWS release a new version which supports v25 after May 16, 2024) So, I'd like to revert the change.

ref: https://github.com/degica/barcelona/pull/809#issuecomment-2097493303

## Note
I only updated the `ec-staging` and `staging` districts after merging https://github.com/degica/barcelona/pull/809 PR, so I'll update them again to align the AMI with the master branch.