### PR TITLE
Updated ECS & Bastion AMI to July 2024 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         apk add --no-cache python3 py3-pip
         find /usr/lib/ -type f -name 'EXTERNALLY-MANAGED' -delete
         pip3 install awscli
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: setup
       run: git submodule update --init
     - name: script
@@ -39,13 +39,13 @@ jobs:
 
   deploy:
     container:
-      image: degica/rails-buildpack:2.6.5-stretch
+      image: public.ecr.aws/degica/rails-buildpack:latest
       env:
         BARCELONA_ENDPOINT: https://barcelona.degica.com
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [build]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: deploy_setup
       if: github.ref == 'refs/heads/master'
       run: |-

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -7,21 +7,21 @@ module Barcelona
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
       # latest info is Version: 126, LastModifiedDate: 2023-11-09T05:06:38.507000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20231103-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0b74aeb97fba885ea",
-        "us-east-2"      => "ami-0f896121197c465b6",
-        "us-west-1"      => "ami-0c5504b68ec2d9a7f",
-        "us-west-2"      => "ami-0dde9c7cb86beac37",
-        "eu-west-1"      => "ami-0ff103cb56a347a33",
-        "eu-west-2"      => "ami-02ef2f8ea6a7806b2",
-        "eu-west-3"      => "ami-0bfabc4e921335ce1",
-        "eu-central-1"      => "ami-0aa4f7ed90c2cb592",
-        "ap-northeast-1"      => "ami-096e08f9d8a9f57b1",
-        "ap-northeast-2"      => "ami-012a265cd28ba3e08",
-        "ap-southeast-1"      => "ami-080cdc1184ac6b4fa",
-        "ap-southeast-2"      => "ami-06d8f2a68469b0d41",
-        "ca-central-1"      => "ami-036c354a96f50530c",
-        "ap-south-1"      => "ami-07d5af8060c8e639d",
-        "sa-east-1"      => "ami-0ae7b598f864571a3",
+        "us-east-1"      => "ami-0fac1e606981b292b",
+        "us-east-2"      => "ami-063496725830a8a8e",
+        "us-west-1"      => "ami-0000fe44649a08f57",
+        "us-west-2"      => "ami-0469e9041ea25600d",
+        "eu-west-1"      => "ami-02a28f8b317b61070",
+        "eu-west-2"      => "ami-0b07faf56462d5ae8",
+        "eu-west-3"      => "ami-031791ba176819256",
+        "eu-central-1"      => "ami-06d198da422b4d577",
+        "ap-northeast-1"      => "ami-07acd7f8d547a49e9",
+        "ap-northeast-2"      => "ami-03bd90cb269e7a1df",
+        "ap-southeast-1"      => "ami-030e545d619a1548a",
+        "ap-southeast-2"      => "ami-00e6a4a4d0cb8ca0f",
+        "ca-central-1"      => "ami-03df65cedd1751c66",
+        "ap-south-1"      => "ami-044c72a801982b446",
+        "sa-east-1"      => "ami-03b271468d5914879",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -7,21 +7,21 @@ module Barcelona
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       # latest info is Version: 102, LastModifiedDate: 2023-11-18T14:09:53.487000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-0588935a949f9ff17",
-        "us-east-2"      => "ami-0e4bab9adfcf464b1",
-        "us-west-1"      => "ami-0839bf007aad25236",
-        "us-west-2"      => "ami-0319ef1a70c93d5c8",
-        "eu-west-1"      => "ami-07e85b797329c2bae",
-        "eu-west-2"      => "ami-055c1c5b310817d75",
-        "eu-west-3"      => "ami-0d60e01ba76286b82",
-        "eu-central-1"      => "ami-08be7699a81774dd5",
-        "ap-northeast-1"      => "ami-058d2a108b2600a4f",
-        "ap-northeast-2"      => "ami-066e8b8972bbd816b",
-        "ap-southeast-1"      => "ami-08b96001e0e7a2b81",
-        "ap-southeast-2"      => "ami-018858d4e27f62c2d",
-        "ca-central-1"      => "ami-0866b1e4094c11483",
-        "ap-south-1"      => "ami-06fff02c54a38e17b",
-        "sa-east-1"      => "ami-025a07aa284285222",
+        "us-east-1"      => "ami-070b7c2988d4e2c89",
+        "us-east-2"      => "ami-0ee3e5d4a5112ce6a",
+        "us-west-1"      => "ami-081d1797e14cd5689",
+        "us-west-2"      => "ami-0211c3296405e1021",
+        "eu-west-1"      => "ami-08575e3ae35f313a6",
+        "eu-west-2"      => "ami-07325431fa2186a03",
+        "eu-west-3"      => "ami-028abbfd9ebaa1397",
+        "eu-central-1"      => "ami-084c4dda80be60621",
+        "ap-northeast-1"      => "ami-092957e65e64cc357",
+        "ap-northeast-2"      => "ami-0c8473b13e378f410",
+        "ap-southeast-1"      => "ami-0fe5e4fe8e0b4152c",
+        "ap-southeast-2"      => "ami-061e2848f084ca460",
+        "ca-central-1"      => "ami-0360d610188302fee",
+        "ap-south-1"      => "ami-03c3ac54a88879408",
+        "sa-east-1"      => "ami-0b62c1cd4293cf9af",
       }
 
       def build_resources


### PR DESCRIPTION
[ECS Release Notes](https://github.com/aws/amazon-ecs-ami/releases/tag/20240712) 

[Bastion Release Notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)

Major Change - Docker engine version upgraded to **v25.0.3**