### PR TITLE
Update ECS AMI to fix ECS agent bug

### DIFF
--- a/.github/workflows/build-reverse-proxy.yml
+++ b/.github/workflows/build-reverse-proxy.yml
@@ -1,7 +1,7 @@
 name: build-reverse-proxy
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: startup

--- a/.github/workflows/build-reverse-proxy.yml
+++ b/.github/workflows/build-reverse-proxy.yml
@@ -1,13 +1,13 @@
 name: build-reverse-proxy
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: startup
       run: |
         cd dockerfiles/reverse-proxy
-        docker-compose -f docker-compose.test.yml up --build -d
+        docker compose -f docker-compose.test.yml up --build -d
     - name: test
       run: |
         sleep 10

--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 126, LastModifiedDate: 2023-11-09T05:06:38.507000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20231103-x86_64-ebs
+      # latest info is Version: 160, LastModifiedDate: 2024-08-24T00:04:54.985000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20240821-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0fac1e606981b292b",
-        "us-east-2"      => "ami-063496725830a8a8e",
-        "us-west-1"      => "ami-0000fe44649a08f57",
-        "us-west-2"      => "ami-0469e9041ea25600d",
-        "eu-west-1"      => "ami-02a28f8b317b61070",
-        "eu-west-2"      => "ami-0b07faf56462d5ae8",
-        "eu-west-3"      => "ami-031791ba176819256",
-        "eu-central-1"      => "ami-06d198da422b4d577",
-        "ap-northeast-1"      => "ami-07acd7f8d547a49e9",
-        "ap-northeast-2"      => "ami-03bd90cb269e7a1df",
-        "ap-southeast-1"      => "ami-030e545d619a1548a",
-        "ap-southeast-2"      => "ami-00e6a4a4d0cb8ca0f",
-        "ca-central-1"      => "ami-03df65cedd1751c66",
-        "ap-south-1"      => "ami-044c72a801982b446",
-        "sa-east-1"      => "ami-03b271468d5914879",
+        "us-east-1"      => "ami-0a5f593ecaa0f722d",
+        "us-east-2"      => "ami-0ce790b55a703329e",
+        "us-west-1"      => "ami-06886ac35c1b2ce5b",
+        "us-west-2"      => "ami-0ca2af66da8e56876",
+        "eu-west-1"      => "ami-02e4aa707b997b03d",
+        "eu-west-2"      => "ami-05debd59f61b91073",
+        "eu-west-3"      => "ami-0c32f416bf4fcef22",
+        "eu-central-1"      => "ami-090e99a5576d2e247",
+        "ap-northeast-1"      => "ami-09acc689bdf119020",
+        "ap-northeast-2"      => "ami-0f3935da3561fe3b6",
+        "ap-southeast-1"      => "ami-01854a08f7ce76245",
+        "ap-southeast-2"      => "ami-0702b6b95f7216d59",
+        "ca-central-1"      => "ami-0321a34dec8344a1a",
+        "ap-south-1"      => "ami-0c7a993787e4d010d",
+        "sa-east-1"      => "ami-0f2771af3c4cbbbe5",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 102, LastModifiedDate: 2023-11-18T14:09:53.487000+09:00
+      # latest info is Version: 123, LastModifiedDate: 2024-08-21T03:48:03.779000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-070b7c2988d4e2c89",
-        "us-east-2"      => "ami-0ee3e5d4a5112ce6a",
-        "us-west-1"      => "ami-081d1797e14cd5689",
-        "us-west-2"      => "ami-0211c3296405e1021",
-        "eu-west-1"      => "ami-08575e3ae35f313a6",
-        "eu-west-2"      => "ami-07325431fa2186a03",
-        "eu-west-3"      => "ami-028abbfd9ebaa1397",
-        "eu-central-1"      => "ami-084c4dda80be60621",
-        "ap-northeast-1"      => "ami-092957e65e64cc357",
-        "ap-northeast-2"      => "ami-0c8473b13e378f410",
-        "ap-southeast-1"      => "ami-0fe5e4fe8e0b4152c",
-        "ap-southeast-2"      => "ami-061e2848f084ca460",
-        "ca-central-1"      => "ami-0360d610188302fee",
-        "ap-south-1"      => "ami-03c3ac54a88879408",
-        "sa-east-1"      => "ami-0b62c1cd4293cf9af",
+        "us-east-1"      => "ami-075d39ebbca89ed55",
+        "us-east-2"      => "ami-09e5a7cd9561f8ea9",
+        "us-west-1"      => "ami-0d34a8cd52a5c5dc7",
+        "us-west-2"      => "ami-08578967e04feedea",
+        "eu-west-1"      => "ami-01fe8a5feb270c44b",
+        "eu-west-2"      => "ami-0815423524a4fa683",
+        "eu-west-3"      => "ami-071600ac81869d08b",
+        "eu-central-1"      => "ami-0857949e0aef0e356",
+        "ap-northeast-1"      => "ami-07281c2a30e5bc1ab",
+        "ap-northeast-2"      => "ami-0dba641460bd4aa31",
+        "ap-southeast-1"      => "ami-07548161ae91256a2",
+        "ap-southeast-2"      => "ami-0ab9dc99bf651c06d",
+        "ca-central-1"      => "ami-06396c79efa907b53",
+        "ap-south-1"      => "ami-0c042aeb1107dbd8c",
+        "sa-east-1"      => "ami-0b4f2520bb50d26fe",
       }
 
       def build_resources


### PR DESCRIPTION
## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-using-Barcelona-78b6c47ab7a14b5184d7fcf1b54775b0):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-20231103.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1

## Context
The CPU instance of EC2 instance sometimes went up to 100% by a ECS agent bug.
We should fix this bug by updating the base AMI.

Slack: https://degica.slack.com/archives/C03SZBC0N/p1724400934236149?thread_ts=1724372022.330629&cid=C03SZBC0N