### PR TITLE
Replace dots in review app subdomains

### DIFF
--- a/app/models/review_app.rb
+++ b/app/models/review_app.rb
@@ -73,8 +73,8 @@ class ReviewApp < ApplicationRecord
     ]
   end
 
-  # replace underscores and downcase - not valid as subdomain
+  # replace dots & underscores and downcase - not valid as subdomain
   def sanitized_subject
-    subject.downcase.gsub('_', '-')
+    subject.downcase.gsub(/[._]/, '-')
   end
 end

--- a/spec/models/review_app_spec.rb
+++ b/spec/models/review_app_spec.rb
@@ -39,7 +39,7 @@ describe ReviewApp do
     context 'when an invalid subject is passed' do
       let(:review_app) {
         group.review_apps.new(
-          subject: "subject_With_Caps_And_Underscores",
+          subject: "subject_With_Caps_And.Underscores",
           image_name: "image",
           image_tag: "tag",
           retention: 12 * 3600,
@@ -57,7 +57,7 @@ describe ReviewApp do
         expect{review_app.save!}.to_not raise_error
       end
 
-      it "converts the underscores to hyphens" do
+      it "converts the dots and underscores to hyphens" do
         expect(review_app.to_param).to eq('subject-with-caps-and-underscores')
         expect(review_app.slug).to eq('review---subject-with-caps-and-underscores')
       end


### PR DESCRIPTION
While dots are valid, they don't work with our SSL certificate. I've already adapted the hats CI workflow to expect this change.