### PR TITLE
Reverted bastion host ami

### DIFF
--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -7,21 +7,21 @@ module Barcelona
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
       # latest info is Version: 123, LastModifiedDate: 2024-08-21T03:48:03.779000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-075d39ebbca89ed55",
-        "us-east-2"      => "ami-09e5a7cd9561f8ea9",
-        "us-west-1"      => "ami-0d34a8cd52a5c5dc7",
-        "us-west-2"      => "ami-08578967e04feedea",
-        "eu-west-1"      => "ami-01fe8a5feb270c44b",
-        "eu-west-2"      => "ami-0815423524a4fa683",
-        "eu-west-3"      => "ami-071600ac81869d08b",
-        "eu-central-1"      => "ami-0857949e0aef0e356",
-        "ap-northeast-1"      => "ami-07281c2a30e5bc1ab",
-        "ap-northeast-2"      => "ami-0dba641460bd4aa31",
-        "ap-southeast-1"      => "ami-07548161ae91256a2",
-        "ap-southeast-2"      => "ami-0ab9dc99bf651c06d",
-        "ca-central-1"      => "ami-06396c79efa907b53",
-        "ap-south-1"      => "ami-0c042aeb1107dbd8c",
-        "sa-east-1"      => "ami-0b4f2520bb50d26fe",
+        "us-east-1"      => "ami-0588935a949f9ff17",
+        "us-east-2"      => "ami-0e4bab9adfcf464b1",
+        "us-west-1"      => "ami-0839bf007aad25236",
+        "us-west-2"      => "ami-0319ef1a70c93d5c8",
+        "eu-west-1"      => "ami-07e85b797329c2bae",
+        "eu-west-2"      => "ami-055c1c5b310817d75",
+        "eu-west-3"      => "ami-0d60e01ba76286b82",
+        "eu-central-1"      => "ami-08be7699a81774dd5",
+        "ap-northeast-1"      => "ami-058d2a108b2600a4f",
+        "ap-northeast-2"      => "ami-066e8b8972bbd816b",
+        "ap-southeast-1"      => "ami-08b96001e0e7a2b81",
+        "ap-southeast-2"      => "ami-018858d4e27f62c2d",
+        "ca-central-1"      => "ami-0866b1e4094c11483",
+        "ap-south-1"      => "ami-06fff02c54a38e17b",
+        "sa-east-1"      => "ami-025a07aa284285222",
       }
 
       def build_resources


### PR DESCRIPTION
Original PR - https://github.com/degica/barcelona/pull/812

Related PR - https://github.com/degica/barcelona/pull/817

This PR will revert only the Bastion instance AMI due to ongoing ECS agent issues.

Slack Link - https://degica.slack.com/archives/CTG3QN2C9/p1726129388324169?thread_ts=1725935213.447989&cid=CTG3QN2C9