### PR TITLE
Increase max body size to handle POST requests larger than 10MB

### DIFF
--- a/dockerfiles/reverse-proxy/templates/nginx.conf.erb
+++ b/dockerfiles/reverse-proxy/templates/nginx.conf.erb
@@ -20,7 +20,7 @@ http {
   tcp_nodelay on;
 
   # allow large file upload
-  client_max_body_size 10m;
+  client_max_body_size 30m;
 
   gzip  on;
   gzip_static  on;


### PR DESCRIPTION
## Context
A payload in some POST requests could be higher than 10MB, especially when users upload images or files.
Ideally, I want to increase the value to 50MB, but at the same time, I don't want to increase the memory allocation for the Nginx container to minimize the impact. So, I feel 30MB is the maximum acceptable value for 128MB memory allocation.