### PR TITLE
AMI update to Amazon Linux 2 2.0.20250102

### DIFF
--- a/lib/barcelona/network/autoscaling_builder.rb
+++ b/lib/barcelona/network/autoscaling_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # amzn2-ami-ecs-hvm-2.0
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
-      # latest info is Version: 160, LastModifiedDate: 2024-08-24T00:04:54.985000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20240821-x86_64-ebs
+      # latest info is Version: 176, LastModifiedDate: 2025-01-04T01:06:07.871000+09:00, image_name: amzn2-ami-ecs-hvm-2.0.20250102-x86_64-ebs
       ECS_OPTIMIZED_AMI_IDS = {
-        "us-east-1"      => "ami-0b74aeb97fba885ea",
-        "us-east-2"      => "ami-0f896121197c465b6",
-        "us-west-1"      => "ami-0c5504b68ec2d9a7f",
-        "us-west-2"      => "ami-0dde9c7cb86beac37",
-        "eu-west-1"      => "ami-0ff103cb56a347a33",
-        "eu-west-2"      => "ami-02ef2f8ea6a7806b2",
-        "eu-west-3"      => "ami-0bfabc4e921335ce1",
-        "eu-central-1"      => "ami-0aa4f7ed90c2cb592",
-        "ap-northeast-1"      => "ami-096e08f9d8a9f57b1",
-        "ap-northeast-2"      => "ami-012a265cd28ba3e08",
-        "ap-southeast-1"      => "ami-080cdc1184ac6b4fa",
-        "ap-southeast-2"      => "ami-06d8f2a68469b0d41",
-        "ca-central-1"      => "ami-036c354a96f50530c",
-        "ap-south-1"      => "ami-07d5af8060c8e639d",
-        "sa-east-1"      => "ami-0ae7b598f864571a3",
+        "us-east-1"      => "ami-00510a0be518b7bcf",
+        "us-east-2"      => "ami-0e93f2758d93e5407",
+        "us-west-1"      => "ami-017b240646f3ae10b",
+        "us-west-2"      => "ami-0575ac0e31eace5d0",
+        "eu-west-1"      => "ami-03ee16d613a361821",
+        "eu-west-2"      => "ami-0cd5249d03ac9d116",
+        "eu-west-3"      => "ami-0a9c6826ae9257f49",
+        "eu-central-1"      => "ami-0c3372f4b0abb685e",
+        "ap-northeast-1"      => "ami-065fd01648ca74747",
+        "ap-northeast-2"      => "ami-070bb7dbe656a0889",
+        "ap-southeast-1"      => "ami-00b264d2db52dc3a0",
+        "ap-southeast-2"      => "ami-0f625b79e81434e3a",
+        "ca-central-1"      => "ami-0a2221d88e92dd00e",
+        "ap-south-1"      => "ami-03546d38de43204ad",
+        "sa-east-1"      => "ami-0a518e607c2ef7fa1",
       }
 
       def ebs_optimized_by_default?

--- a/lib/barcelona/network/bastion_builder.rb
+++ b/lib/barcelona/network/bastion_builder.rb
@@ -5,23 +5,23 @@ module Barcelona
       # Amazon Linux 2 AMI
       # You can see the latest version stored in public SSM parameter store
       # https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
-      # latest info is Version: 123, LastModifiedDate: 2024-08-21T03:48:03.779000+09:00
+      # latest info is Version: 134, LastModifiedDate: 2024-12-21T04:16:42.337000+09:00
       AMI_IDS = {
-        "us-east-1"      => "ami-0588935a949f9ff17",
-        "us-east-2"      => "ami-0e4bab9adfcf464b1",
-        "us-west-1"      => "ami-0839bf007aad25236",
-        "us-west-2"      => "ami-0319ef1a70c93d5c8",
-        "eu-west-1"      => "ami-07e85b797329c2bae",
-        "eu-west-2"      => "ami-055c1c5b310817d75",
-        "eu-west-3"      => "ami-0d60e01ba76286b82",
-        "eu-central-1"      => "ami-08be7699a81774dd5",
-        "ap-northeast-1"      => "ami-058d2a108b2600a4f",
-        "ap-northeast-2"      => "ami-066e8b8972bbd816b",
-        "ap-southeast-1"      => "ami-08b96001e0e7a2b81",
-        "ap-southeast-2"      => "ami-018858d4e27f62c2d",
-        "ca-central-1"      => "ami-0866b1e4094c11483",
-        "ap-south-1"      => "ami-06fff02c54a38e17b",
-        "sa-east-1"      => "ami-025a07aa284285222",
+        "us-east-1"      => "ami-0ac664bd64e1dcc6b",
+        "us-east-2"      => "ami-05175b461d18d94d9",
+        "us-west-1"      => "ami-0853d0de3297e47e0",
+        "us-west-2"      => "ami-06c7fbd87fa7b507c",
+        "eu-west-1"      => "ami-0fc56b47fc1f238ee",
+        "eu-west-2"      => "ami-0f9e888df95272f70",
+        "eu-west-3"      => "ami-0584a5ab8f4034679",
+        "eu-central-1"      => "ami-03b7db59d53c5e228",
+        "ap-northeast-1"      => "ami-0dbca050974482176",
+        "ap-northeast-2"      => "ami-07a2318163330ee84",
+        "ap-southeast-1"      => "ami-047d5a3391704b8b2",
+        "ap-southeast-2"      => "ami-0c372b59cfa8c3d65",
+        "ca-central-1"      => "ami-01a9d286de9a4d56e",
+        "ap-south-1"      => "ami-019cd93943ccead1a",
+        "sa-east-1"      => "ami-06b07a4baf3024a9f",
       }
 
       def build_resources


### PR DESCRIPTION
## AMI Update

This PR will also update the AMIs of the container instances as described in this [guide](https://www.notion.so/How-to-Update-AMI-using-Barcelona-78b6c47ab7a14b5184d7fcf1b54775b0):

[Release notes](https://docs.aws.amazon.com/AL2/latest/relnotes/relnotes-al2.html)

[Amazon ECS-optimized AMIs - Amazon Elastic Container Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)

ECS AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id/description?region=ap-northeast-1
https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/description?region=ap-northeast-1

And it also updates the AMI for the bastion image.

Bastion AMI SSM path: https://ap-northeast-1.console.aws.amazon.com/systems-manager/parameters/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2/description?region=ap-northeast-1
