### PR TITLE
[DOCKERFILES][REVERSE_PROXY] Log: $upstream_queue_time

### DIFF
--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -68,7 +68,7 @@ def default_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request" $status $body_bytes_sent '
     '"$http_referer" "$http_user_agent"'
-    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time" uqt="$upstream_queue_time"'
   LOG_FORMAT
 end
 
@@ -77,7 +77,7 @@ def no_query_params_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request_method $uri $server_protocol" $status $body_bytes_sent '
     '"$http_user_agent"'
-    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time" uqt="$upstream_queue_time"'
   LOG_FORMAT
 end
 


### PR DESCRIPTION
## Ticket
https://degica.atlassian.net/browse/SR-616

## Desc
Add `uqt = $upstream_queue_time` to nginx logs

Ref: https://nginx.org/en/docs/http/ngx_http_upstream_module.html#var_upstream_queue_time

## Current Logs
![image](https://github.com/user-attachments/assets/5a1a1b92-62bc-4a2d-a238-711da464a634)
![image](https://github.com/user-attachments/assets/3f5a4d07-dfef-424c-b94f-e175b67778b3)

> [!NOTE]
> these values are processed by DD Grok Parser
![image](https://github.com/user-attachments/assets/06053f9d-7ec6-48cb-927d-50c73af39c52)


