### PR TITLE
Revert "[DOCKERFILES][REVERSE_PROXY] Log: $upstream_queue_time"

### DIFF
--- a/dockerfiles/reverse-proxy/render_template.rb
+++ b/dockerfiles/reverse-proxy/render_template.rb
@@ -68,7 +68,7 @@ def default_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request" $status $body_bytes_sent '
     '"$http_referer" "$http_user_agent"'
-    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time" uqt="$upstream_queue_time"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
   LOG_FORMAT
 end
 
@@ -77,7 +77,7 @@ def no_query_params_log_format
     '$proxy_protocol_addr - [$time_local] '
     '"$request_method $uri $server_protocol" $status $body_bytes_sent '
     '"$http_user_agent"'
-    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time" uqt="$upstream_queue_time"'
+    'rt=$request_time uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"'
   LOG_FORMAT
 end
 


### PR DESCRIPTION
This reverts commit 7246164d3cd999ce846d6b4a273dd896e2122afe.

Failed CI: https://github.com/degica/barcelona/actions/runs/13104654021

somehow `$upstream_queue_time` variable is not available to use even though it's available [here in the docs](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#var_upstream_queue_time)

![Screenshot from 2025-02-03 09-32-59](https://github.com/user-attachments/assets/ac4d5085-c551-4410-87c9-74af9312366a)

I'm still figuring out why and how to fix this, but in the meantime I prefer to revert this first 
