### PR TITLE
Allocate more resources to scheduled jobs

### DIFF
--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -31,8 +31,8 @@ class HeritageTaskDefinition
   def self.schedule_definition(heritage)
     new(heritage: heritage,
         family_name: "#{heritage.name}-schedule",
-        cpu: 128,
-        memory: 512)
+        cpu: 512,
+        memory: 1512)
   end
 
   def to_task_definition(without_task_role: false, camelize: false)

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -349,8 +349,8 @@ describe HeritageTaskDefinition do
                               "ContainerDefinitions" => [
                                 {
                                   "Name" =>  "#{heritage.name}-schedule",
-                                  "Cpu" => 128,
-                                  "Memory" => 512,
+                                  "Cpu" => 512,
+                                  "Memory" => 1512,
                                   "Essential" => true,
                                   "Image" => heritage.image_path,
                                   "Environment" => [],


### PR DESCRIPTION
## Context
Some jobs got OOM due to a lack of allocated memory, 500 MB.

0.125 CPU allocation could cause CPU throttling.

## Changes
* 0.125 CPU => 0.5 CPU
* 0.5 GB Mem => 1.5 GB Mem