### PR TITLE
Add external_task_def to scheduled_tas

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -127,7 +127,8 @@ class HeritagesController < ApplicationController
       ],
       scheduled_tasks: [
         :schedule,
-        :command
+        :command,
+        :external_task_def
       ],
       environment: [
         :name,

--- a/app/models/heritage.rb
+++ b/app/models/heritage.rb
@@ -32,7 +32,7 @@ class Heritage < ActiveRecord::Base
                 "Id" => "barcelona-#{heritage.name}-schedule-event-#{i}",
                 "Input" => {
                   cluster: heritage.district.name,
-                  task_family: "#{heritage.name}-schedule",
+                  task_family: (s["external_task_def"] || "#{heritage.name}-schedule"),
                   command: run_command
                 }.to_json
               }


### PR DESCRIPTION
This PR adds `external_task_def` to the definition of scheduled tasks.
When you need a big memory in a task, you can register a task definition by Web Console or terraform and use it in barcelona.

```yaml
      - schedule: cron(0 16 * * ? *) # Everyday at 01:00 JST
        command: bin/invoke_with_checkin -u https://api.honeybadger.io/v1/check_in/oWI2MZ rake ssh_credential_j:get cron:deliver_jtrans_file
        external_task_def: deliver_jtrans_file:latest
```